### PR TITLE
Fix mouse listener to always send out change bounds actions (#22)

### DIFF
--- a/src/utils/smodel-util.ts
+++ b/src/utils/smodel-util.ts
@@ -16,6 +16,7 @@
 import {
     BoundsAware,
     isBoundsAware,
+    isMoveable,
     isSelectable,
     Selectable,
     SModelElement,
@@ -81,6 +82,10 @@ export function removeCssClasses(root: SModelElement, cssClasses: string[]) {
             root.cssClasses.splice(root.cssClasses.indexOf(cssClass), 1);
         }
     }
+}
+
+export function isNonRoutableSelectedMovableBoundsAware(element: SModelElement): element is SelectableBoundsAware {
+    return isNonRoutableSelectedBoundsAware(element) && isMoveable(element);
 }
 
 export function isNonRoutableSelectedBoundsAware(element: SModelElement): element is SelectableBoundsAware {


### PR DESCRIPTION
With this change, we don't rely on the `positionDelta` for sending out mouse `ChangeBoundsActions` but only check whether we started dragging via `lastDragPosition`.

Resolves #22 and also fixes #21 while we're at it.