### PR TITLE
Fix feedback edge snapping

### DIFF
--- a/src/features/tool-feedback/creation-tool-feedback.ts
+++ b/src/features/tool-feedback/creation-tool-feedback.ts
@@ -142,7 +142,7 @@ function drawFeedbackEdge(context: CommandExecutionContext, sourceId: string, el
     edgeEnd.position = toAbsolutePosition(source);
 
     const feedbackEdgeSchema = <SEdgeSchema>{
-        type: 'edge',
+        type: elementTypeId,
         id: feedbackEdgeId(root),
         sourceId: source.id,
         targetId: edgeEnd.id,


### PR DESCRIPTION
Replace static `edge` type of the feebackEdgeSchema with the correct `elementTypeId`. Otherwise the feedback edge snapping does only work if the target is  connectable to the type `edge`