### PR TITLE
Support popups for validation markers (#31)

### DIFF
--- a/src/features/hover/di.config.ts
+++ b/src/features/hover/di.config.ts
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from "inversify";
+import {
+    CenterCommand,
+    ClosePopupActionHandler,
+    configureActionHandler,
+    configureCommand,
+    FitToScreenCommand,
+    HoverFeedbackCommand,
+    HoverKeyListener,
+    HoverState,
+    MoveCommand,
+    PopupHoverMouseListener,
+    SetPopupModelCommand,
+    SetViewportCommand,
+    TYPES
+} from "sprotty";
+import { PopupPositionUpdater } from "sprotty/lib/features/hover/popup-position-updater";
+
+import { GlspHoverMouseListener } from "./hover";
+
+
+const glspHoverModule = new ContainerModule((bind, _unbind, isBound) => {
+    bind(TYPES.PopupVNodePostprocessor).to(PopupPositionUpdater).inSingletonScope();
+    bind(TYPES.MouseListener).to(GlspHoverMouseListener);
+    bind(TYPES.PopupMouseListener).to(PopupHoverMouseListener);
+    bind(TYPES.KeyListener).to(HoverKeyListener);
+    bind<HoverState>(TYPES.HoverState).toConstantValue({
+        mouseOverTimer: undefined,
+        mouseOutTimer: undefined,
+        popupOpen: false,
+        previousPopupElement: undefined
+    });
+    bind(ClosePopupActionHandler).toSelf().inSingletonScope();
+
+    const context = { bind, isBound };
+    configureCommand(context, HoverFeedbackCommand);
+    configureCommand(context, SetPopupModelCommand);
+    configureActionHandler(context, SetPopupModelCommand.KIND, ClosePopupActionHandler);
+    configureActionHandler(context, FitToScreenCommand.KIND, ClosePopupActionHandler);
+    configureActionHandler(context, CenterCommand.KIND, ClosePopupActionHandler);
+    configureActionHandler(context, SetViewportCommand.KIND, ClosePopupActionHandler);
+    configureActionHandler(context, MoveCommand.KIND, ClosePopupActionHandler);
+});
+
+export default glspHoverModule;

--- a/src/features/hover/hover.ts
+++ b/src/features/hover/hover.ts
@@ -1,0 +1,88 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from "inversify";
+import {
+    Action,
+    Bounds,
+    EMPTY_ROOT,
+    HoverMouseListener,
+    PreRenderedElementSchema,
+    RequestPopupModelAction,
+    SetPopupModelAction,
+    SIssueMarker,
+    SIssueSeverity,
+    SModelElement,
+    SModelRootSchema
+} from "sprotty";
+
+import { GIssueMarker } from "../validation/validate";
+
+@injectable()
+export class GlspHoverMouseListener extends HoverMouseListener {
+
+    protected startMouseOverTimer(target: SModelElement, event: MouseEvent): Promise<Action> {
+        this.stopMouseOverTimer();
+        return new Promise(resolve => {
+            this.state.mouseOverTimer = window.setTimeout(() => {
+                const popupBounds = this.computePopupBounds(target, { x: event.pageX, y: event.pageY });
+                if (target instanceof GIssueMarker) {
+                    resolve(new SetPopupModelAction(this.createPopupModel(target as GIssueMarker, popupBounds)));
+                } else {
+                    resolve(new RequestPopupModelAction(target.id, popupBounds));
+                }
+
+                this.state.popupOpen = true;
+                this.state.previousPopupElement = target;
+            }, this.options.popupOpenDelay);
+        });
+    }
+
+    protected createPopupModel(marker: GIssueMarker, bounds: Bounds): SModelRootSchema {
+        if (marker.issues !== undefined && marker.issues.length > 0) {
+            const message = marker.issues
+                .map(i => i.message)
+                .join("\n");
+            return {
+                type: 'html',
+                id: 'sprotty-popup',
+                children: [
+                    <PreRenderedElementSchema>{
+                        type: 'pre-rendered',
+                        id: 'popup-title',
+                        code: `<div class="${getSeverity(marker)}"><div class="sprotty-popup-title">${message}</div></div>`
+                    }
+                ],
+                canvasBounds: this.modifyBounds(bounds)
+            };
+        }
+        return { type: EMPTY_ROOT.type, id: EMPTY_ROOT.id };
+    }
+
+    protected modifyBounds(bounds: Bounds): Bounds {
+        return bounds;
+    }
+}
+
+export function getSeverity(marker: SIssueMarker): SIssueSeverity {
+    let currentSeverity: SIssueSeverity = 'info';
+    for (const severity of marker.issues.map(s => s.severity)) {
+        if (severity === 'error')
+            return severity;
+        if (severity === 'warning' && currentSeverity === 'info')
+            currentSeverity = severity;
+    }
+    return currentSeverity;
+}

--- a/src/features/validation/validate.ts
+++ b/src/features/validation/validate.ts
@@ -30,6 +30,7 @@ import {
 
 import { GLSP_TYPES } from "../../types";
 import { Marker, MarkerKind } from "../../utils/marker";
+import { addCssClasses, removeCssClasses } from "../../utils/smodel-util";
 import { getSeverity } from "../hover/hover";
 import { IFeedbackActionDispatcher, IFeedbackEmitter } from "../tool-feedback/feedback-action-dispatcher";
 import { FeedbackCommand } from "../tool-feedback/model";
@@ -172,21 +173,11 @@ export class ApplyMarkersCommand extends FeedbackCommand {
 }
 
 function addCSSClassToIssueParent(modelElement: SParentElement, issueMarker: SIssueMarker) {
-    if (modelElement.cssClasses === undefined) {
-        modelElement.cssClasses = [getSeverity(issueMarker)];
-    } else {
-        modelElement.cssClasses.push(getSeverity(issueMarker));
-    }
+    addCssClasses(modelElement, [getSeverity(issueMarker)]);
 }
 
 function removeCSSClassFromIssueParent(modelElement: SParentElement, issueMarker: SIssueMarker) {
-    if (modelElement.cssClasses !== undefined) {
-        const severity = getSeverity(issueMarker);
-        const index = modelElement.cssClasses.indexOf(severity, 0);
-        if (index > -1) {
-            modelElement.cssClasses.splice(index, 1);
-        }
-    }
+    removeCssClasses(modelElement, [getSeverity(issueMarker)]);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import glspServerCopyPasteModule from "./features/copy-paste/di.config";
 import glspEditLabelValidationModule from "./features/edit-label-validation/di.config";
 import executeModule from "./features/execute/di.config";
 import modelHintsModule from "./features/hints/di.config";
+import glspHoverModule from "./features/hover/di.config";
 import layoutCommandsModule from "./features/layout/di.config";
 import glspMouseToolModule from "./features/mouse-tool/di.config";
 import requestResponseModule from "./features/request-response/di.config";
@@ -48,6 +49,7 @@ export * from './features/execute/model';
 export * from './features/hints/request-type-hints-action';
 export * from './features/hints/type-hints';
 export * from './features/hints/model';
+export * from "./features/hover/hover";
 export * from './features/layout/layout-commands';
 export * from './features/mouse-tool/mouse-tool';
 export * from './features/operation/operation-actions';
@@ -84,7 +86,7 @@ export * from './model-source/websocket-diagram-server';
 export * from "./model-source/glsp-server-status";
 export {
     validationModule, saveModule, executeModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, glspCommandPaletteModule, requestResponseModule, //
-    glspContextMenuModule, glspServerCopyPasteModule, glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelValidationModule
+    glspContextMenuModule, glspServerCopyPasteModule, glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelValidationModule, glspHoverModule
 };
 
 


### PR DESCRIPTION
* introduce dedicated GIssueMarker which enabled the SDecoration default
features including hovering
* introduce GlspHoverMouseListener which is able to identify hovering
over GIssueMarkers and displays a popup without a server roundtrip
* introduce glspHoverModule which binds the GlspHoverMouseListener for
the MouseListener type and export it
* add additional css class on parent element when adding marker
* clear this again when marker is cleared

Examples:
https://github.com/eclipse-glsp/glsp-examples/pull/33 (+ server fix for examples https://github.com/eclipse-glsp/glsp-server/pull/43)