### PR TITLE
Layout command should respect minimum size and movement restrictor

### DIFF
--- a/src/features/change-bounds/movement-restrictor.ts
+++ b/src/features/change-bounds/movement-restrictor.ts
@@ -50,11 +50,14 @@ export class NoOverlapMovmentRestrictor implements IMovementRestrictor {
         if (!isBoundsAwareMoveable(element)) {
             return false;
         }
-        // Create ghost element at the newLocation;
-        const ghostElement = Object.create(element);
-
-        ghostElement.bounds.x = newLocation.x - element.bounds.width / 2;
-        ghostElement.bounds.y = newLocation.y - element.bounds.height / 2;
+        // Create ghost element at the newLocation
+        const ghostElement = Object.create(element) as SModelElement & BoundsAware;
+        ghostElement.bounds = {
+            x: newLocation.x,
+            y: newLocation.y,
+            width: element.bounds.width,
+            height: element.bounds.height
+        };
         ghostElement.type = "Ghost";
         ghostElement.id = element.id;
         return !Array.from(element.root.index.all().filter(e => e.id !== ghostElement.id && e !== ghostElement.root && (e instanceof SNode))

--- a/src/features/layout/layout-commands.spec.ts
+++ b/src/features/layout/layout-commands.spec.ts
@@ -27,11 +27,13 @@ import {
     defaultModule,
     ElementAndBounds,
     ElementMove,
+    FeatureSet,
     IActionDispatcher,
     MoveAction,
     MoveCommand,
     RequestAction,
     ResponseAction,
+    SChildElement,
     SetBoundsAction,
     SetBoundsCommand,
     SGraphFactory,
@@ -41,6 +43,7 @@ import {
 
 import { ChangeBoundsOperation } from "../../base/operations/operation";
 import { GLSP_TYPES } from "../../base/types";
+import { resizeFeature } from "../change-bounds/model";
 import { SelectionService } from "../select/selection-service";
 import { FeedbackActionDispatcher } from "../tool-feedback/feedback-action-dispatcher";
 import {
@@ -91,11 +94,21 @@ const node3 = {
     id: 'node3', type: 'node:circle',
     selected: true
 };
-const model = graphFactory.createRoot({
-    id: 'model1',
-    type: 'graph',
-    children: [node1, node2, node3]
-});
+const model = createModel();
+
+function createModel() {
+    const root = graphFactory.createRoot({
+        id: 'model1',
+        type: 'graph',
+        children: [node1, node2, node3]
+    });
+    root.children.forEach(child => applyFeature(child, resizeFeature));
+    return root;
+}
+
+function applyFeature(element: SChildElement, feature: symbol) {
+    (element.features as FeatureSet & Set<symbol>).add(feature);
+}
 
 const context: CommandExecutionContext = {
     root: model,

--- a/src/features/tools/change-bounds-tool.ts
+++ b/src/features/tools/change-bounds-tool.ts
@@ -26,7 +26,6 @@ import {
     isSelected,
     isViewport,
     KeyTool,
-    ModelLayoutOptions,
     MouseListener,
     Point,
     SConnectableElement,
@@ -44,6 +43,7 @@ import {
     ElementAndRoutingPoints
 } from "../../base/operations/operation";
 import { GLSP_TYPES } from "../../base/types";
+import { isValidMove, isValidSize } from "../../utils/layout-utils";
 import {
     forEachElement,
     isNonRoutableSelectedMovableBoundsAware,
@@ -65,6 +65,7 @@ import {
 } from "../tool-feedback/change-bounds-tool-feedback";
 import { IFeedbackActionDispatcher, IFeedbackEmitter } from "../tool-feedback/feedback-action-dispatcher";
 import { DragAwareMouseListener } from "./drag-aware-mouse-listener";
+
 
 /**
  * The change bounds tool has the license to move multiple elements or resize a single element by implementing the ChangeBounds operation.
@@ -377,38 +378,14 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements Sele
     }
 
     protected isValidBoundChange(element: SModelElement & BoundsAware, newPosition: Point, newSize: Dimension): boolean {
-        const valid = this.isValidSize(element, newSize);
-        if (this.tool.movementRestrictor) {
-            return valid && this.tool.movementRestrictor.validate(newPosition, element);
-        }
-        return valid;
+        return this.isValidSize(element, newSize) && this.isValidMove(element, newPosition);
     }
 
     protected isValidSize(element: SModelElement & BoundsAware, size: Dimension) {
-        return size.width >= this.minWidth(element) && size.height >= this.minHeight(element);
+        return isValidSize(element, size);
     }
 
-    protected minWidth(element: SModelElement & BoundsAware): number {
-        const layoutOptions = this.getLayoutOptions(element);
-        if (layoutOptions !== undefined && typeof layoutOptions.minWidth === 'number') {
-            return layoutOptions.minWidth;
-        }
-        return 1;
-    }
-
-    protected minHeight(element: SModelElement & BoundsAware): number {
-        const layoutOptions = this.getLayoutOptions(element);
-        if (layoutOptions !== undefined && typeof layoutOptions.minHeight === 'number') {
-            return layoutOptions.minHeight;
-        }
-        return 1;
-    }
-
-    protected getLayoutOptions(element: SModelElement): ModelLayoutOptions | undefined {
-        const layoutOptions = (element as any).layoutOptions;
-        if (layoutOptions !== undefined) {
-            return layoutOptions as ModelLayoutOptions;
-        }
-        return undefined;
+    protected isValidMove(element: SModelElement & BoundsAware, newPosition: Point) {
+        return isValidMove(element, newPosition, this.tool.movementRestrictor);
     }
 }

--- a/src/utils/layout-utils.ts
+++ b/src/utils/layout-utils.ts
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { BoundsAware, Dimension, ElementAndBounds, ElementMove, ModelLayoutOptions, Point, SModelElement } from "sprotty";
+
+import { IMovementRestrictor } from "../features/change-bounds/movement-restrictor";
+
+export function minWidth(element: SModelElement & BoundsAware): number {
+    const layoutOptions = getLayoutOptions(element);
+    if (layoutOptions !== undefined && typeof layoutOptions.minWidth === 'number') {
+        return layoutOptions.minWidth;
+    }
+    return 1;
+}
+
+export function minHeight(element: SModelElement & BoundsAware): number {
+    const layoutOptions = getLayoutOptions(element);
+    if (layoutOptions !== undefined && typeof layoutOptions.minHeight === 'number') {
+        return layoutOptions.minHeight;
+    }
+    return 1;
+}
+
+export function getLayoutOptions(element: SModelElement): ModelLayoutOptions | undefined {
+    const layoutOptions = (element as any).layoutOptions;
+    if (layoutOptions !== undefined) {
+        return layoutOptions as ModelLayoutOptions;
+    }
+    return undefined;
+}
+
+export function isValidSize(element: SModelElement & BoundsAware, size: Dimension) {
+    return size.width >= minWidth(element) && size.height >= minHeight(element);
+}
+
+export function isValidMove(element: SModelElement & BoundsAware, newPosition: Point, movementRestrictor?: IMovementRestrictor) {
+    if (movementRestrictor) {
+        return movementRestrictor.validate(newPosition, element);
+    }
+    return true;
+}
+
+export function toValidElementMove(element: SModelElement & BoundsAware, move: WriteableElementMove, movementRestrictor?: IMovementRestrictor) {
+    if (!isValidMove(element, move.toPosition, movementRestrictor)) {
+        return;
+    }
+    return move;
+}
+
+export function toValidElementAndBounds(element: SModelElement & BoundsAware, bounds: WriteableElementAndBounds, movementRestrictor?: IMovementRestrictor) {
+    if (!isValidMove(element, bounds.newPosition, movementRestrictor)) {
+        return;
+    }
+    const elementMinWidth = minWidth(element);
+    if (bounds.newSize.width < elementMinWidth) {
+        bounds.newSize.width = elementMinWidth;
+    }
+    const elementMinHeight = minHeight(element);
+    if (bounds.newSize.height < elementMinHeight) {
+        bounds.newSize.height = elementMinHeight;
+    }
+    return bounds;
+}
+
+export interface WriteablePoint extends Point {
+    x: number;
+    y: number;
+}
+
+export interface WriteableElementMove extends ElementMove {
+    fromPosition?: WriteablePoint;
+    toPosition: WriteablePoint;
+}
+
+export interface WriteableDimension extends Dimension {
+    width: number
+    height: number
+}
+
+export interface WriteableElementAndBounds extends ElementAndBounds {
+    newPosition: WriteablePoint;
+    newSize: WriteableDimension
+}

--- a/src/utils/smodel-util.ts
+++ b/src/utils/smodel-util.ts
@@ -100,6 +100,8 @@ export function isRoutingHandle(element: SModelElement | undefined): element is 
 
 export type SelectableBoundsAware = SModelElement & BoundsAware & Selectable;
 
+export type BoundsAwareModelElement = SModelElement & BoundsAware;
+
 export function toElementAndBounds(element: SModelElement & BoundsAware) {
     return {
         elementId: element.id,


### PR DESCRIPTION
- Extract layout interfaces and utility methods to separate file
- Use utility methods in change-bounds-tool but still allow overriding
- Consider minimum size and movement restrictor in resize/align commands

- Fixes eclipse-glsp/glsp/issues/43
- Fixes eclipse-glsp/glsp/issues/27

Requires https://github.com/eclipse-glsp/glsp-theia-integration/pull/25