### PR TITLE
Consider potential snapping in resize handles of change bounds tool

### DIFF
--- a/css/glsp-sprotty.css
+++ b/css/glsp-sprotty.css
@@ -60,6 +60,10 @@
     fill: #66a;
 }
 
+.sprotty-resize-handle.active {
+    fill: var(--theia-menu-selectionBackground);
+}
+
 .sprotty-resize-handle.mouseover {
     stroke: #112;
     stroke-width: 1;
@@ -87,4 +91,8 @@
 
 .edge-creation-select-target-mode, .edge-reconnect-select-target-mode {
     cursor: crosshair;
+}
+
+.resize-mode {
+    cursor: none;
 }

--- a/src/features/tool-feedback/css-feedback.ts
+++ b/src/features/tool-feedback/css-feedback.ts
@@ -62,7 +62,8 @@ export enum CursorCSS {
     EDGE_CREATION_TARGET = 'edge-creation-select-target-mode',
     EDGE_RECONNECT = 'edge-reconnect-select-target-mode',
     OPERATION_NOT_ALLOWED = 'edge-modification-not-allowed-mode',
-    ELEMENT_DELETION = "element-deletion-mode"
+    ELEMENT_DELETION = "element-deletion-mode",
+    RESIZE = "resize-mode"
 }
 
 export function cursorFeedbackAction(cursorCss?: CursorCSS): ModifyCSSFeedbackAction {
@@ -73,5 +74,10 @@ export function cursorFeedbackAction(cursorCss?: CursorCSS): ModifyCSSFeedbackAc
     return new ModifyCSSFeedbackAction(undefined, addCss, Object.values(CursorCSS));
 }
 
+export function applyCssClasses(element: SModelElement, ...classes: string[]) {
+    return new ModifyCSSFeedbackAction([element], classes, []);
+}
 
-
+export function deleteCssClasses(element: SModelElement, ...classes: string[]) {
+    return new ModifyCSSFeedbackAction([element], [], classes);
+}


### PR DESCRIPTION
- Fixes eclipse-glsp/glsp/issues/23
![resize-handle-snapping](https://user-images.githubusercontent.com/19170971/79838511-6aa7fc00-83b3-11ea-9d71-88669251be8d.gif)

Please note that with snapping the mouse and the handles do not necessarily align anymore. For example, a snapping to a grid of size 10 with rounding values normally leads to a snap of the resize handle on a move change > 5, therefore the handle moves 'faster' than the mouse which has only moved 5 pixel. 

EDIT: After the great suggestion from Tobi, I now hide the mouse cursor and resizing feels much smoother! It is a bit surprising when the mouse cursor reappears but that is not really a big issue. Additionally, I now also highlight the currently active 'dragging' cursor:

![resize-handle-snapping-nocursor](https://user-images.githubusercontent.com/19170971/79851677-ef037a80-83c5-11ea-8d96-fdb1ede596ea.gif)

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>