### PR TITLE
Use model source provider in editor context

### DIFF
--- a/src/base/editor-context.ts
+++ b/src/base/editor-context.ts
@@ -32,20 +32,20 @@ export class EditorContextService {
 
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
     @inject(MousePositionTracker) protected mousePositionTracker: MousePositionTracker;
-    @inject(TYPES.ModelSource) protected modelSource: ModelSource;
+    @inject(TYPES.ModelSourceProvider) protected modelSource: () => Promise<ModelSource>;
 
     get(args?: { [key: string]: string | number | boolean }): EditorContext {
         return {
             selectedElementIds: Array.from(this.selectionService.getSelectedElementIDs()),
-            sourceUri: this.getSourceUri(),
             lastMousePosition: this.mousePositionTracker.lastPositionOnDiagram,
             args
         };
     }
 
-    getSourceUri() {
-        if (isSourceUriAware(this.modelSource)) {
-            return this.modelSource.getSourceURI();
+    async getSourceUri() {
+        const modelSource = await this.modelSource();
+        if (isSourceUriAware(modelSource)) {
+            return modelSource.getSourceURI();
         }
         return undefined;
     }

--- a/src/features/validation/validate.ts
+++ b/src/features/validation/validate.ts
@@ -24,6 +24,7 @@ import {
     SIssue,
     SIssueMarker,
     SModelElement,
+    SModelRoot,
     SParentElement,
     TYPES
 } from "sprotty";
@@ -144,9 +145,10 @@ export class SetMarkersCommand extends Command {
         super();
     }
 
-    execute(context: CommandExecutionContext): CommandReturn {
+    async execute(context: CommandExecutionContext): Promise<SModelRoot> {
         const markers: Marker[] = this.action.markers;
-        if (this.externalMarkerManager) this.externalMarkerManager.setMarkers(markers, this.editorContextService.getSourceUri());
+        const uri = await this.editorContextService.getSourceUri();
+        if (this.externalMarkerManager) this.externalMarkerManager.setMarkers(markers, uri);
         const applyMarkersAction: ApplyMarkersAction = new ApplyMarkersAction(markers);
         this.validationFeedbackEmitter.registerValidationFeedbackAction(applyMarkersAction);
         return context.root;


### PR DESCRIPTION
This is to avoid an early dependency on the model source in case the editor context is used before the model source is bound.