### PR TITLE
Support internal and external navigation and server-resolved navigations

### DIFF
--- a/src/base/actions/context-actions.ts
+++ b/src/base/actions/context-actions.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 import { Action, generateRequestId, LabeledAction, RequestAction, ResponseAction } from "sprotty";
 
+import { Args } from "../../base/args";
 import { EditorContext } from "../editor-context";
 
 export class RequestContextActions implements RequestAction<SetContextActions> {
@@ -31,7 +32,7 @@ export class SetContextActions implements ResponseAction {
     kind = SetContextActions.KIND;
     constructor(public readonly actions: LabeledAction[],
         public readonly responseId: string = '',
-        readonly args?: { [key: string]: string | number | boolean }) { }
+        readonly args?: Args) { }
 }
 
 export function isSetContextActionsAction(action: Action): action is SetContextActions {

--- a/src/base/actions/edit-validation-actions.ts
+++ b/src/base/actions/edit-validation-actions.ts
@@ -15,6 +15,8 @@
  ********************************************************************************/
 import { Action, generateRequestId, RequestAction, ResponseAction } from "sprotty";
 
+import { Args } from "../../base/args";
+
 export class RequestEditValidationAction implements RequestAction<SetEditValidationResultAction> {
     static readonly KIND = "requestEditValidation";
     kind = RequestEditValidationAction.KIND;
@@ -30,7 +32,7 @@ export class SetEditValidationResultAction implements ResponseAction {
     kind = SetEditValidationResultAction.KIND;
     constructor(public readonly status: ValidationStatus,
         public readonly responseId: string = '',
-        readonly args?: { [key: string]: string | number | boolean }) { }
+        readonly args?: Args) { }
 }
 
 export function isSetEditValidationResultAction(action: Action): action is SetEditValidationResultAction {

--- a/src/base/args.ts
+++ b/src/base/args.ts
@@ -1,0 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+export type Args = { [key: string]: string | number | boolean };

--- a/src/base/di.config.ts
+++ b/src/base/di.config.ts
@@ -25,10 +25,22 @@ import { DefaultModelInitializationConstraint, ModelInitializationConstraint } f
 import { FeedbackAwareUpdateModelCommand, SetModelActionHandler } from "./model/update-model-command";
 import { SelectionClearingMouseListener } from "./selection-clearing-mouse-listener";
 import { GLSPToolManager } from "./tool-manager/glsp-tool-manager";
+import { GLSP_TYPES } from "./types";
 
 const defaultGLSPModule = new ContainerModule((bind, _unbind, isBound, rebind) => {
     const context = { bind, _unbind, isBound, rebind };
     bind(EditorContextService).toSelf().inSingletonScope();
+    bind(GLSP_TYPES.IEditorContextServiceProvider).toProvider<EditorContextService>(ctx => {
+        return () => {
+            return new Promise<EditorContextService>((resolve, reject) => {
+                if (ctx.container.isBound(EditorContextService)) {
+                    resolve(ctx.container.get<EditorContextService>(EditorContextService));
+                } else {
+                    reject();
+                }
+            });
+        };
+    });
 
     // Model update initialization ------------------------------------
     configureCommand(context, FeedbackAwareUpdateModelCommand);

--- a/src/base/editor-context.ts
+++ b/src/base/editor-context.ts
@@ -16,6 +16,7 @@
 import { inject, injectable } from "inversify";
 import { ModelSource, MousePositionTracker, Point, TYPES } from "sprotty";
 
+import { Args } from "../base/args";
 import { isSourceUriAware } from "../base/source-uri-aware";
 import { SelectionService } from "../features/select/selection-service";
 import { GLSP_TYPES } from "./types";
@@ -24,7 +25,7 @@ export interface EditorContext {
     readonly selectedElementIds: string[];
     readonly sourceUri?: string;
     readonly lastMousePosition?: Point;
-    readonly args?: { [key: string]: string | number | boolean };
+    readonly args?: Args;
 }
 
 @injectable()
@@ -34,7 +35,7 @@ export class EditorContextService {
     @inject(MousePositionTracker) protected mousePositionTracker: MousePositionTracker;
     @inject(TYPES.ModelSourceProvider) protected modelSource: () => Promise<ModelSource>;
 
-    get(args?: { [key: string]: string | number | boolean }): EditorContext {
+    get(args?: Args): EditorContext {
         return {
             selectedElementIds: Array.from(this.selectionService.getSelectedElementIDs()),
             lastMousePosition: this.mousePositionTracker.lastPositionOnDiagram,
@@ -50,7 +51,7 @@ export class EditorContextService {
         return undefined;
     }
 
-    getWithSelection(selectedElementIds: string[], args?: { [key: string]: string | number | boolean }): EditorContext {
+    getWithSelection(selectedElementIds: string[], args?: Args): EditorContext {
         return {
             selectedElementIds,
             lastMousePosition: this.mousePositionTracker.lastPositionOnDiagram,
@@ -58,3 +59,6 @@ export class EditorContextService {
         };
     }
 }
+
+export type EditorContextServiceProvider = () => Promise<EditorContextService>;
+

--- a/src/base/operations/operation.ts
+++ b/src/base/operations/operation.ts
@@ -15,11 +15,13 @@
  ********************************************************************************/
 import { Action, ElementAndBounds, isAction, Point } from "sprotty";
 
+import { Args } from "../../base/args";
+
 export interface Operation extends Action { }
 
 export interface CreateOperation extends Operation {
     elementTypeId: string;
-    args?: { [key: string]: string | number | boolean };
+    args?: Args;
 }
 
 export function isCreateOperation(object?: any): object is CreateOperation {
@@ -33,7 +35,7 @@ export class CreateNodeOperation implements CreateOperation {
     constructor(public readonly elementTypeId: string,
         public location?: Point,
         public containerId?: string,
-        public args?: { [key: string]: string | number | boolean }) { }
+        public args?: Args) { }
 }
 
 export function isCreateNodeOperation(object?: any): object is CreateNodeOperation {
@@ -47,7 +49,7 @@ export class CreateEdgeOperation implements CreateOperation {
     constructor(public readonly elementTypeId: string,
         public sourceElementId?: string,
         public targetElementId?: string,
-        public args?: { [key: string]: string | number | boolean }) { }
+        public args?: Args) { }
 }
 
 export function isCreateConnectionOperation(object?: any): object is CreateEdgeOperation {
@@ -95,8 +97,7 @@ export interface ElementAndRoutingPoints {
 
 export abstract class TriggerElementCreationAction implements Action {
     abstract readonly kind: string;
-    constructor(public readonly elementTypeId: string,
-        readonly args?: { [key: string]: string | number | boolean }) { }
+    constructor(public readonly elementTypeId: string, readonly args?: Args) { }
 }
 
 export class TriggerNodeCreationAction extends TriggerElementCreationAction {

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -16,6 +16,7 @@
 export const GLSP_TYPES = {
     IAsyncClipboardService: Symbol.for("IAsyncClipboardService"),
     ICommandPaletteActionProviderRegistry: Symbol.for("ICommandPaletteActionProviderRegistry"),
+    IEditorContextServiceProvider: Symbol.for("IEditorContextProvider"),
     IFeedbackActionDispatcher: Symbol.for("IFeedbackActionDispatcher"),
     IToolFactory: Symbol.for("Factory<Tool>"),
     ITypeHintProvider: Symbol.for("ITypeHintProvider"),

--- a/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
+++ b/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
@@ -41,23 +41,13 @@ export class SelectionServiceAwareContextMenuMouseListener extends MouseListener
     mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         if (event.button === 2 && this.contextMenuService && this.menuProvider) {
             const mousePosition = { x: event.x, y: event.y };
-            let isTargetSelected = false;
             const selectableTarget = findParentByFeature(target, isSelectable);
             if (selectableTarget) {
-                isTargetSelected = selectableTarget.selected;
                 selectableTarget.selected = true;
                 this.selectionService.updateSelection(target.root, [selectableTarget.id], []);
             }
-            const restoreSelection = () => {
-                if (selectableTarget) {
-                    selectableTarget.selected = isTargetSelected;
-                    if (!isTargetSelected) {
-                        this.selectionService.updateSelection(target.root, [], [selectableTarget.id]);
-                    }
-                }
-            };
             Promise.all([this.contextMenuService(), this.menuProvider.getItems(target.root, mousePosition)])
-                .then(([menuService, menuItems]) => menuService.show(menuItems, mousePosition, restoreSelection));
+                .then(([menuService, menuItems]) => menuService.show(menuItems, mousePosition));
         }
         return [];
     }

--- a/src/features/navigation/di.config.ts
+++ b/src/features/navigation/di.config.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from "inversify";
+import { configureActionHandler } from "sprotty/lib";
+
+import {
+    NavigateAction,
+    NavigateToTargetAction,
+    NavigationActionHandler,
+    ProcessNavigationArgumentsAction
+} from "./navigation-action-handler";
+import { NavigationTargetResolver } from "./navigation-target-resolver";
+
+export const navigationModule = new ContainerModule((bind, _unbind, isBound) => {
+    bind(NavigationTargetResolver).toSelf().inSingletonScope();
+    bind(NavigationActionHandler).toSelf().inSingletonScope();
+    configureActionHandler({ bind, isBound }, NavigateAction.KIND, NavigationActionHandler);
+    configureActionHandler({ bind, isBound }, NavigateToTargetAction.KIND, NavigationActionHandler);
+    configureActionHandler({ bind, isBound }, ProcessNavigationArgumentsAction.KIND, NavigationActionHandler);
+});

--- a/src/features/navigation/external-navigate-to-target-handler.ts
+++ b/src/features/navigation/external-navigate-to-target-handler.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from "inversify";
+
+import { Args } from "../../base/args";
+
+@injectable()
+export abstract class ExternalNavigateToTargetHandler {
+    abstract navigateTo(uri: string, args?: Args): Promise<void>;
+}

--- a/src/features/navigation/navigation-action-handler.ts
+++ b/src/features/navigation/navigation-action-handler.ts
@@ -1,0 +1,247 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable, optional } from "inversify";
+import {
+    CenterAction,
+    generateRequestId,
+    ILogger,
+    RequestAction,
+    ResponseAction,
+    SelectAction,
+    SelectAllAction
+} from "sprotty";
+import { Action, IActionDispatcher, IActionHandler, ICommand, TYPES } from "sprotty/lib";
+
+import { Args } from "../../base/args";
+import { EditorContext, EditorContextServiceProvider } from "../../base/editor-context";
+import { GLSP_TYPES } from "../../base/types";
+import { GLSPServerStatusAction, ServerMessageAction } from "../../model-source/glsp-server-status";
+import { ExternalNavigateToTargetHandler } from "./external-navigate-to-target-handler";
+import { NavigationTarget, NavigationTargetResolver, SetResolvedNavigationTargetAction } from "./navigation-target-resolver";
+
+/**
+ * Action for triggering a navigation of a certain target type.
+ *
+ * Examples for target types could be `documentation`, `implementation`, etc.
+ * but this is up to the domain-specific diagram implementation to decide.
+ * Such an action will eventually trigger a `RequestNavigationTargetsAction`
+ * (see `NavigationActionHandler`) in order to request the navigation targets
+ * from the server.
+ *
+ * This action is typically triggered by a user action.
+ */
+export class NavigateAction implements Action {
+    static readonly KIND = 'navigate';
+    readonly kind = NavigateAction.KIND;
+    constructor(readonly targetTypeId: string, readonly args?: Args) { }
+}
+
+export function isNavigateAction(action: Action): action is NavigateAction {
+    return action !== undefined && (action.kind === NavigateAction.KIND)
+        && (<NavigateAction>action).targetTypeId !== undefined;
+}
+
+/** Action that is usually sent to the server to request navigation targets for a navigation type. */
+export class RequestNavigationTargetsAction implements RequestAction<SetNavigationTargetsAction> {
+    static readonly KIND = "requestNavigationTargets";
+    kind = RequestNavigationTargetsAction.KIND;
+    constructor(readonly targetTypeId: string, readonly editorContext: EditorContext,
+        readonly requestId: string = generateRequestId()) { }
+}
+
+/** Action that is usually sent from the server to the client as a repsonse to a `RequestNavigationTargetsAction`. */
+export class SetNavigationTargetsAction implements ResponseAction {
+    static readonly KIND = "setNavigationTargets";
+    kind = SetNavigationTargetsAction.KIND;
+    constructor(readonly targets: NavigationTarget[], readonly responseId: string = '', readonly args?: Args) { }
+}
+
+export function isSetNavigationTargetsAction(action: Action): action is SetNavigationTargetsAction {
+    return action !== undefined && (action.kind === SetNavigationTargetsAction.KIND)
+        && (<SetNavigationTargetsAction>action).targets !== undefined;
+}
+
+/** Action that triggers the navigation to a particular navigation target, such as element IDs, queries, etc.. */
+export class NavigateToTargetAction implements Action {
+    static readonly KIND = 'navigateToTarget';
+    readonly kind = NavigateToTargetAction.KIND;
+    constructor(readonly target: NavigationTarget) { }
+}
+
+export function isNavigateToTargetAction(action: Action): action is NavigateToTargetAction {
+    return action !== undefined && (action.kind === NavigateToTargetAction.KIND)
+        && (<NavigateToTargetAction>action).target !== undefined;
+}
+
+/** Action to trigger the processing of additional navigation arguments.
+ *
+ * The resolution of a `NavigationTarget` may entail additional arguments. In this case, this action is
+ * triggered allowing the client to react to those arguments. The default `NavigationActionHandler` will
+ * only process the arguments' keys `info`, `warning`, and `error` to present them to the user.
+ * Customizations, however, may add domain-specific arguments and register custom handler to also process
+ * other arguments and trigger some additional behavior (e.g. update other views, etc.).
+ */
+export class ProcessNavigationArgumentsAction implements Action {
+    static readonly KIND = 'processNavigationArguments';
+    readonly kind = ProcessNavigationArgumentsAction.KIND;
+    constructor(readonly args: Args) { }
+}
+
+export function isProcessNavigationArgumentsAction(action: Action): action is ProcessNavigationArgumentsAction {
+    return action !== undefined && (action.kind === ProcessNavigationArgumentsAction.KIND)
+        && (<ProcessNavigationArgumentsAction>action).args !== undefined;
+}
+
+/**
+ * Default handler for all actions that are related to the navigation.
+ *
+ * For a `NavigateAction` this handler triggers a `RequestNavigationTargetAction` to obtain the actual
+ * navigation targets for the navigation type that is specified in the `NavigateAction`.
+ * Once the navigation targets are available, it will trigger a `NavigateToTargetAction` to actually
+ * perform the navigation.
+ *
+ * In other scenarios, clients may also trigger the `NavigateToTargetAction` directly, e.g. when opening
+ * the diagram.
+ *
+ * Depending on the URI and arguments of the navigation target we may encounter three cases:
+ *   *(a)* the navigation target already specifies element IDs, in which case this action handler navigates
+ *         to the specified elements directly, by the selecting them and centering them in the viewport.
+ *   *(b)* the arguments of the navigation targets don't contain element IDs, but other arguments, the
+ *         navigation target needs to be resolved into actual elment IDs by the `NavigationTargetResolver`.
+ *         This can for instance be useful, if the navigation deals with queries or some other more complex
+ *         logic that can't be dealt with on the client.
+  *  *(c)* the target isn't resolved by the `NavigationTargetResolver`, e.g. because the `uri` doesn't match
+  *        the URI of the current diagram. In this case, the navigation request is forwarded to the
+  *        `ExternalNavigateToTargetHandler`, if it exists.
+ */
+@injectable()
+export class NavigationActionHandler implements IActionHandler {
+
+    readonly notificationTimeout = 5000;
+
+    @inject(TYPES.ILogger) protected logger: ILogger;
+    @inject(TYPES.IActionDispatcher) protected dispatcher: IActionDispatcher;
+    @inject(GLSP_TYPES.IEditorContextServiceProvider) protected editorContextService: EditorContextServiceProvider;
+    @inject(NavigationTargetResolver) protected resolver: NavigationTargetResolver;
+    @inject(ExternalNavigateToTargetHandler) @optional() protected externalHandler: ExternalNavigateToTargetHandler;
+
+    handle(action: Action): ICommand | Action | void {
+        if (isNavigateAction(action)) {
+            this.handleNavigateAction(action);
+        } else if (isNavigateToTargetAction(action)) {
+            this.handleNavigateToTarget(action);
+        } else if (isProcessNavigationArgumentsAction(action)) {
+            this.processNavigationArguments(action.args);
+        }
+    }
+
+    protected async handleNavigateAction(action: NavigateAction) {
+        try {
+            const editorContextService = await this.editorContextService();
+            const context = editorContextService.get(action.args);
+            const response = await this.dispatcher.request(new RequestNavigationTargetsAction(action.targetTypeId, context));
+            if (isSetNavigationTargetsAction(response) && response.targets && response.targets.length === 1) {
+                if (response.targets.length > 1) {
+                    this.logger.warn(this, 'Processing of multiple targets is not supported yet. ' +
+                        'Only the first is being processed.', response.targets);
+                }
+                return this.dispatcher.dispatch(new NavigateToTargetAction(response.targets[0]));
+            }
+            this.warnAboutFailedNavigation('No valid navigation target found');
+        } catch (reason) {
+            this.logger.error(this, 'Failed to obtain navigation target', reason, action);
+        }
+    }
+
+    protected async handleNavigateToTarget(action: NavigateToTargetAction) {
+        try {
+            const resolvedElements = await this.resolveElements(action);
+            if (this.containsElementIdsOrArguments(resolvedElements)) {
+                this.navigateTo(resolvedElements);
+                this.handleResolutionArguments(resolvedElements);
+                return;
+            } else if (this.externalHandler) {
+                this.navigateToExternal(action.target);
+                return;
+            }
+            this.warnAboutFailedNavigation('Could not resolve or navigate to target', action.target);
+        } catch (reason) {
+            this.logger.error(this, 'Failed to navigate', reason, action);
+        }
+    }
+
+    protected resolveElements(action: NavigateToTargetAction): Promise<SetResolvedNavigationTargetAction | undefined> {
+        return this.resolver.resolve(action.target);
+    }
+
+    protected containsElementIdsOrArguments(target: SetResolvedNavigationTargetAction | undefined): target is SetResolvedNavigationTargetAction {
+        return target !== undefined && (this.containsElementIds(target.elementIds) || this.containsArguments(target.args));
+    }
+
+    protected containsElementIds(elementIds: string[] | undefined): elementIds is string[] {
+        return elementIds !== undefined && elementIds.length > 0;
+    }
+
+    protected containsArguments(args: Args | undefined): args is Args {
+        return args !== undefined && args !== undefined && Object.keys(args).length > 0;
+    }
+
+    protected navigateTo(target: SetResolvedNavigationTargetAction) {
+        const elementIds = target.elementIds;
+        if (!this.containsElementIds(elementIds)) {
+            return;
+        }
+        this.dispatcher.dispatchAll([new SelectAllAction(false), new SelectAction(elementIds), new CenterAction(elementIds)]);
+    }
+
+    protected handleResolutionArguments(target: SetResolvedNavigationTargetAction) {
+        const args = target.args;
+        if (!this.containsArguments(args)) {
+            return;
+        }
+        this.dispatcher.dispatch(new ProcessNavigationArgumentsAction(args));
+    }
+
+    protected navigateToExternal(target: NavigationTarget): Promise<void> {
+        return this.externalHandler.navigateTo(target.uri, target.args);
+    }
+
+    protected processNavigationArguments(args: Args) {
+        if (args.info && args.info.toString().length > 0) {
+            this.notify('INFO', args.info.toString());
+        }
+        if (args.warning && args.warning.toString().length > 0) {
+            this.notify('WARNING', args.warning.toString());
+        }
+        if (args.error && args.error.toString().length > 0) {
+            this.notify('ERROR', args.error.toString());
+        }
+    }
+
+    protected warnAboutFailedNavigation(msg: string, target?: NavigationTarget) {
+        const message = `${msg}` + (target ? `: '${target.uri}' (arguments: ${JSON.stringify(target.args)})` : '');
+        this.logger.warn(this, msg, target);
+        this.notify('WARNING', message);
+    }
+
+    private notify(severity: string, message: string) {
+        const timeout = this.notificationTimeout;
+        this.dispatcher.dispatchAll([
+            <GLSPServerStatusAction>{ kind: GLSPServerStatusAction.KIND, severity, timeout, message },
+            <ServerMessageAction>{ kind: ServerMessageAction.KIND, severity, timeout, message }
+        ]);
+    }
+}

--- a/src/features/navigation/navigation-target-resolver.spec.ts
+++ b/src/features/navigation/navigation-target-resolver.spec.ts
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import "mocha";
+import "reflect-metadata";
+
+import { expect } from "chai";
+
+import { NavigationTarget } from "./navigation-target-resolver";
+
+describe('NavigationTarget', () => {
+
+    it('should be able to set and get element IDs', () => {
+        const navigationTarget: NavigationTarget = { uri: 'uri' };
+        NavigationTarget.setElementIds(navigationTarget, ['id1', 'id2']);
+        expect(NavigationTarget.getElementIds(navigationTarget)).to.be.eql(['id1', 'id2']);
+    });
+
+    it('should be able to set and get textual positions', () => {
+        const navigationTarget: NavigationTarget = { uri: 'uri' };
+        NavigationTarget.setTextPosition(navigationTarget, { line: 1, character: 2 });
+        expect(NavigationTarget.getTextPosition(navigationTarget)).to.be.eql({ line: 1, character: 2 });
+    });
+
+    it('should be able to set and get custom query arguments', () => {
+        const navigationTarget: NavigationTarget = { uri: 'uri' };
+        NavigationTarget.addArgument(navigationTarget, 'name', 'test');
+        expect(navigationTarget.args!.name).to.be.eql('test');
+    });
+
+    it('should specify whether it has arguments', () => {
+        let navigationTarget: NavigationTarget = { uri: 'uri' };
+        expect(NavigationTarget.hasArguments(navigationTarget)).to.be.false;
+        NavigationTarget.addArgument(navigationTarget, 'name', 'test');
+        expect(NavigationTarget.hasArguments(navigationTarget)).to.be.true;
+
+        navigationTarget = { uri: 'uri' };
+        expect(NavigationTarget.hasArguments(navigationTarget)).to.be.false;
+        NavigationTarget.setElementIds(navigationTarget, ['id1', 'id2']);
+        expect(NavigationTarget.hasArguments(navigationTarget)).to.be.true;
+
+        navigationTarget = { uri: 'uri' };
+        expect(NavigationTarget.hasArguments(navigationTarget)).to.be.false;
+        NavigationTarget.setTextPosition(navigationTarget, { line: 1, character: 2 });
+        expect(NavigationTarget.hasArguments(navigationTarget)).to.be.true;
+    });
+
+});

--- a/src/features/navigation/navigation-target-resolver.ts
+++ b/src/features/navigation/navigation-target-resolver.ts
@@ -1,0 +1,143 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable } from "inversify";
+import { Action, generateRequestId, IActionDispatcher, RequestAction, ResponseAction, TYPES } from "sprotty";
+
+import { Args } from "../../base/args";
+import { EditorContextServiceProvider } from "../../base/editor-context";
+import { GLSP_TYPES } from "../../base/types";
+
+export interface NavigationTarget {
+    uri: string;
+    label?: string;
+    args?: Args;
+}
+
+export namespace NavigationTarget {
+
+    export const ELEMENT_IDS = 'elementIds';
+    export const ELEMENT_IDS_SEPARATOR = '&';
+    export const TEXT_LINE = 'line';
+    export const TEXT_COLUMN = 'column';
+
+    export function hasArguments(target: NavigationTarget): boolean {
+        return target.args !== undefined && Object.keys(target.args).length > 0;
+    }
+
+    export function addArgument(target: NavigationTarget, key: string, value: string | number | boolean) {
+        if (target.args === undefined) {
+            target.args = {};
+        }
+        target.args[key] = value;
+    }
+
+    export function getElementIds(target: NavigationTarget): string[] {
+        if (target.args === undefined || target.args[NavigationTarget.ELEMENT_IDS] === undefined) {
+            return [];
+        }
+        const elementIdsValue = target.args[NavigationTarget.ELEMENT_IDS].toString();
+        return elementIdsValue.split(NavigationTarget.ELEMENT_IDS_SEPARATOR);
+    }
+
+    export function setElementIds(target: NavigationTarget, elementIds: string[]) {
+        if (target.args === undefined) {
+            target.args = {};
+        }
+        return target.args[NavigationTarget.ELEMENT_IDS] = elementIds.join(NavigationTarget.ELEMENT_IDS_SEPARATOR);
+    }
+
+    export function setTextPosition(target: NavigationTarget, position: TextPosition | undefined) {
+        if (position) {
+            if (target.args === undefined) {
+                target.args = {};
+            }
+            target.args[NavigationTarget.TEXT_LINE] = position.line;
+            target.args[NavigationTarget.TEXT_COLUMN] = position.character;
+        }
+    }
+
+    export function getTextPosition(target: NavigationTarget): TextPosition | undefined {
+        if (target.args === undefined
+            || target.args[NavigationTarget.TEXT_LINE] === undefined
+            || target.args[NavigationTarget.TEXT_COLUMN] === undefined) {
+            return undefined;
+        }
+        return {
+            line: Number(target.args[NavigationTarget.TEXT_LINE]),
+            character: Number(target.args[NavigationTarget.TEXT_COLUMN])
+        };
+    }
+}
+
+export interface TextPosition {
+    line: number;
+    character: number;
+}
+
+export class ResolveNavigationTargetAction implements RequestAction<SetResolvedNavigationTargetAction> {
+    static readonly KIND = 'resolveNavigationTarget';
+    kind = ResolveNavigationTargetAction.KIND;
+    constructor(readonly navigationTarget: NavigationTarget, public readonly requestId: string = generateRequestId()) { }
+}
+
+export class SetResolvedNavigationTargetAction implements ResponseAction {
+    static readonly KIND = 'setResolvedNavigationTarget';
+    kind = SetResolvedNavigationTargetAction.KIND;
+    constructor(readonly elementIds: string[] = [], readonly args?: Args, readonly responseId: string = '') { }
+}
+
+export function isSetResolvedNavigationTargets(action: Action): action is SetResolvedNavigationTargetAction {
+    return action !== undefined && (action.kind === SetResolvedNavigationTargetAction.KIND);
+}
+
+/**
+ * Resolves `NavigationTargets` to element ids.
+ *
+ * If the `NavigationTarget` doesn't have element ids itself, this resolver queries the server via a
+ * `ResolveNavigationTargetAction` for element ids.
+ */
+@injectable()
+export class NavigationTargetResolver {
+
+    @inject(GLSP_TYPES.IEditorContextServiceProvider) protected editorContextService: EditorContextServiceProvider;
+    @inject(TYPES.IActionDispatcher) protected dispatcher: IActionDispatcher;
+
+    async resolve(navigationTarget: NavigationTarget): Promise<SetResolvedNavigationTargetAction | undefined> {
+        const contextService = await this.editorContextService();
+        const sourceUri = await contextService.getSourceUri();
+        return this.resolveWithSourceUri(sourceUri, navigationTarget);
+    }
+
+    async resolveWithSourceUri(sourceUri: string | undefined, target: NavigationTarget): Promise<SetResolvedNavigationTargetAction | undefined> {
+        if (sourceUri && sourceUri !== target.uri && `file://${sourceUri}` !== target.uri) {
+            // different URI, so we can't resolve it locally
+            return undefined;
+        }
+        if (NavigationTarget.getElementIds(target).length > 0) {
+            return new SetResolvedNavigationTargetAction(NavigationTarget.getElementIds(target));
+        }
+        const response = await this.requestResolution(target);
+        if (isSetResolvedNavigationTargets(response)) {
+            return response;
+        }
+        return undefined;
+    }
+
+    protected requestResolution(target: NavigationTarget) {
+        return this.dispatcher.request(new ResolveNavigationTargetAction(target));
+    }
+}
+

--- a/src/features/validation/marker-navigator.ts
+++ b/src/features/validation/marker-navigator.ts
@@ -215,15 +215,15 @@ export class MarkerNavigatorContextMenuItemProvider implements IContextMenuItemP
         const hasMarkers = collectIssueMarkers(root).length > 0;
         return Promise.resolve([
             {
-                id: "navigate", label: "Navigate to", group: "navigate", actions: [],
+                id: "navigate", label: "Go to", group: "navigate", actions: [],
                 children: [
                     {
-                        id: "next-marker", label: "Navigate to next marker", group: "marker",
+                        id: "next-marker", label: "Next marker", group: "marker",
                         actions: [new NavigateToMarkerAction('next', selectedElementIds)],
                         isEnabled: () => hasMarkers
                     },
                     {
-                        id: "previous-marker", label: "Navigate to previous marker", group: "marker",
+                        id: "previous-marker", label: "Previous marker", group: "marker",
                         actions: [new NavigateToMarkerAction('previous', selectedElementIds)],
                         isEnabled: () => hasMarkers
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import modelHintsModule from "./features/hints/di.config";
 import glspHoverModule from "./features/hover/di.config";
 import layoutCommandsModule from "./features/layout/di.config";
 import glspMouseToolModule from "./features/mouse-tool/di.config";
+import { navigationModule } from "./features/navigation/di.config";
 import saveModule from "./features/save/di.config";
 import glspSelectModule from "./features/select/di.config";
 import toolFeedbackModule from "./features/tool-feedback/di.config";
@@ -32,6 +33,7 @@ import { markerNavigatorContextMenuModule, markerNavigatorModule, validationModu
 
 export * from 'sprotty';
 
+export * from './base/args';
 export * from './base/model/update-model-command';
 export * from './base/operations/operation';
 export * from './base/command-stack';
@@ -57,6 +59,9 @@ export * from './features/hints/model';
 export * from './features/hover/hover';
 export * from './features/layout/layout-commands';
 export * from './features/mouse-tool/mouse-tool';
+export * from './features/navigation/external-navigate-to-target-handler';
+export * from './features/navigation/navigation-action-handler';
+export * from './features/navigation/navigation-target-resolver';
 export * from './features/rank/model';
 export * from './features/reconnect/model';
 export * from './features/save/model';
@@ -92,5 +97,5 @@ export * from './model-source/glsp-server-status';
 export {
     validationModule, saveModule, executeCommandModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, glspCommandPaletteModule, //
     glspContextMenuModule, glspServerCopyPasteModule, copyPasteContextMenuModule, glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelValidationModule, //
-    glspHoverModule, toolsModule, markerNavigatorModule, markerNavigatorContextMenuModule,
+    glspHoverModule, toolsModule, navigationModule, markerNavigatorModule, markerNavigatorContextMenuModule,
 };

--- a/src/model-source/websocket-diagram-server.ts
+++ b/src/model-source/websocket-diagram-server.ts
@@ -38,6 +38,8 @@ import { ValidateLabelEditAction } from "../features/edit-label-validation/edit-
 import { RequestClipboardDataAction, PasteOperationAction, CutOperationAction } from "../features/copy-paste/copy-paste-actions";
 import { RequestEditValidationAction } from "../base/actions/edit-validation-actions";
 import { SourceUriAware } from "../base/source-uri-aware";
+import { RequestNavigationTargetsAction } from "../features/navigation/navigation-action-handler";
+import { ResolveNavigationTargetAction } from "../features/navigation/navigation-target-resolver";
 
 @injectable()
 export class GLSPWebsocketDiagramServer extends DiagramServer implements SourceUriAware {
@@ -113,6 +115,8 @@ export function registerDefaultGLSPServerActions(registry: ActionHandlerRegistry
     registry.register(PasteOperationAction.KIND, diagramServer);
     registry.register(CutOperationAction.KIND, diagramServer);
     registry.register(RequestEditValidationAction.KIND, diagramServer);
+    registry.register(RequestNavigationTargetsAction.KIND, diagramServer);
+    registry.register(ResolveNavigationTargetAction.KIND, diagramServer);
 
     // Register an empty handler for SwitchEditMode, to avoid runtime exceptions.
     // We don't want to support SwitchEditMode, but sprotty still sends some corresponding


### PR DESCRIPTION
This change introduces navigation handling featuring

  * server-based selection of navigation targets for a domain-specific navigation type id (e.g. definition, implementation, or next and previous) -- `RequestNavigationTargetsAction`
  * server-based resolution of queries to elements to which the diagram should navigate -- `ResolveNavigationTargetAction`
  * navigations to "external" resources handled by a dedicated external handler that can be bound by the outer application (Theia, Eclipse, etc.)
  * possibility to trigger additional behavior when the server resolved elements via arguments

The meaning of all involved actions are documented in src/features/navigation/navigation-action-handler.ts.

Besides this change improves a few minors on the way:

  * Fixes selection issue with context menu
  * Factors out an Arg type for arguments map

I'll put some videos into the issue linked below.

https://github.com/eclipse-glsp/glsp/issues/69