### PR TITLE
Add IssueMarker background circle

### DIFF
--- a/css/decoration.css
+++ b/css/decoration.css
@@ -4,10 +4,8 @@
     --glsp-info-foreground: var(--theia-editorInfo-foreground);
 }
 
-.sprotty-issue-overlay {
-    fill: transparent;
-    width: var(--theia-icon-size);
-    height: var(--theia-icon-size);
+.sprotty-issue-background {
+    fill: var(--theia-editor-background);
 }
 
 .sprotty-issue.sprotty-error {

--- a/src/features/decoration/view.tsx
+++ b/src/features/decoration/view.tsx
@@ -27,12 +27,16 @@ export class GlspIssueMarkerView extends IssueMarkerView {
         const maxSeverity = super.getMaxSeverity(marker);
         const group = <g class-sprotty-issue={true} >
             <g>
-                <rect class-sprotty-issue-overlay={true} />
+                <circle class-sprotty-issue-background={true} r={this.radius} cx={this.radius} cy={this.radius} />
                 <path d={this.getGlspIssueMarkerPath(maxSeverity)} />
             </g>
         </g>;
         setClass(group, 'sprotty-' + maxSeverity, true);
         return group;
+    }
+
+    protected get radius(): number {
+        return 8; // var(--theia-icon-size)=16px => 16/2=8
     }
 
     protected getGlspIssueMarkerPath(severity: SIssueSeverity): string {


### PR DESCRIPTION
Remove rectangle overlay and replace with background circle which is filled with Theia editor background color to avoid that element details shine through

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>