### PR TITLE
Add readonly SModel access in editor context

### DIFF
--- a/src/base/editor-context.ts
+++ b/src/base/editor-context.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable } from "inversify";
-import { ModelSource, MousePositionTracker, Point, TYPES } from "sprotty";
+import { ModelSource, MousePositionTracker, Point, SModelElement, SModelRoot, TYPES } from "sprotty";
 
 import { Args } from "../base/args";
 import { isSourceUriAware } from "../base/source-uri-aware";
@@ -23,7 +23,6 @@ import { GLSP_TYPES } from "./types";
 
 export interface EditorContext {
     readonly selectedElementIds: string[];
-    readonly sourceUri?: string;
     readonly lastMousePosition?: Point;
     readonly args?: Args;
 }
@@ -43,6 +42,14 @@ export class EditorContextService {
         };
     }
 
+    getWithSelection(selectedElementIds: string[], args?: Args): EditorContext {
+        return {
+            selectedElementIds,
+            lastMousePosition: this.mousePositionTracker.lastPositionOnDiagram,
+            args
+        };
+    }
+
     async getSourceUri() {
         const modelSource = await this.modelSource();
         if (isSourceUriAware(modelSource)) {
@@ -51,12 +58,12 @@ export class EditorContextService {
         return undefined;
     }
 
-    getWithSelection(selectedElementIds: string[], args?: Args): EditorContext {
-        return {
-            selectedElementIds,
-            lastMousePosition: this.mousePositionTracker.lastPositionOnDiagram,
-            args
-        };
+    get modelRoot(): Readonly<SModelRoot> {
+        return this.selectionService.getModelRoot();
+    }
+
+    get selectedElements(): Readonly<SModelElement>[] {
+        return this.selectionService.getSelectedElements();
     }
 }
 

--- a/src/features/copy-paste/di.config.ts
+++ b/src/features/copy-paste/di.config.ts
@@ -31,6 +31,11 @@ export const glspServerCopyPasteModule = new ContainerModule((bind, _unbind, isB
     bind(GLSP_TYPES.IAsyncClipboardService).to(LocalClipboardService).inSingletonScope();
 });
 
+/**
+ * This module is not required if the diagram is deployed in Theia but only intended to be used
+ * in a standalone deployment of GLSP. If the GLSP diagram in Theia use the Theia-native
+ * `CopyPasteMenuContribution` in `glsp-theia-integration` instead.
+ */
 export const copyPasteContextMenuModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(GLSP_TYPES.IContextMenuProvider).to(CopyPasteContextMenuItemProvider).inSingletonScope();
     bind(InvokeCopyPasteActionHandler).toSelf().inSingletonScope();

--- a/src/features/layout/di.config.ts
+++ b/src/features/layout/di.config.ts
@@ -14,14 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ContainerModule } from "inversify";
-import { configureCommand, TYPES } from "sprotty";
+import { configureCommand } from "sprotty";
 
-import { AlignElementsCommand, LayoutKeyboardListener, ResizeElementsCommand } from "./layout-commands";
+import { AlignElementsCommand, ResizeElementsCommand } from "./layout-commands";
 
 const layoutCommandsModule = new ContainerModule((bind, _unbind, isBound) => {
     configureCommand({ bind, isBound }, ResizeElementsCommand);
     configureCommand({ bind, isBound }, AlignElementsCommand);
-    bind(TYPES.KeyListener).to(LayoutKeyboardListener);
 });
 
 export default layoutCommandsModule;

--- a/src/features/layout/layout-commands.ts
+++ b/src/features/layout/layout-commands.ts
@@ -22,13 +22,11 @@ import {
     ElementAndBounds,
     ElementMove,
     IActionDispatcher,
-    KeyListener,
     MoveAction,
     SetBoundsAction,
     SModelElement,
     TYPES
 } from "sprotty";
-import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
 
 import { ChangeBoundsOperation } from "../../base/operations/operation";
 import { GLSP_TYPES } from "../../base/types";
@@ -413,17 +411,5 @@ export class AlignElementsCommand extends LayoutElementsCommand {
     redo(context: CommandExecutionContext): CommandReturn {
         // we dispatch another action which can be redone, so no explicit implementation necessary
         return context.root;
-    }
-}
-
-export class LayoutKeyboardListener extends KeyListener {
-    keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
-        if (matchesKeystroke(event, 'KeyW', 'shift')) {
-            return [new ResizeElementsAction([], ResizeDimension.Width, Reduce.max)];
-        }
-        if (matchesKeystroke(event, 'KeyH', 'shift')) {
-            return [new ResizeElementsAction([], ResizeDimension.Height, Reduce.max)];
-        }
-        return [];
     }
 }

--- a/src/features/save/di.config.ts
+++ b/src/features/save/di.config.ts
@@ -18,6 +18,10 @@ import { TYPES } from "sprotty";
 
 import { SaveModelKeyboardListener } from "./save";
 
+/**
+ * This module is not required the diagram is deployed in Theia with the `GLSPDiagramWidget`
+ * but only intended to be used in a standalone deployment of GLSP.
+ */
 const saveModule = new ContainerModule(bind => {
     bind(TYPES.KeyListener).to(SaveModelKeyboardListener);
 

--- a/src/features/select/di.config.ts
+++ b/src/features/select/di.config.ts
@@ -14,13 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ContainerModule } from "inversify";
-import { configureCommand, SelectKeyboardListener, TYPES } from "sprotty";
+import { configureCommand, TYPES } from "sprotty";
 
 import { GLSP_TYPES } from "../../base/types";
 import { SelectAllCommand, SelectAllFeedbackCommand, SelectCommand, SelectFeedbackCommand } from "./action-definitions";
 import { RankedSelectMouseListener } from "./select-mouse-listener";
 import { SelectionService } from "./selection-service";
-
 
 const glspSelectModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(SelectionService).toSelf().inSingletonScope();
@@ -29,7 +28,6 @@ const glspSelectModule = new ContainerModule((bind, _unbind, isBound) => {
     configureCommand({ bind, isBound }, SelectAllCommand);
     configureCommand({ bind, isBound }, SelectFeedbackCommand);
     configureCommand({ bind, isBound }, SelectAllFeedbackCommand);
-    bind(TYPES.KeyListener).to(SelectKeyboardListener);
     bind(TYPES.MouseListener).to(RankedSelectMouseListener);
     bind(GLSP_TYPES.SModelRootListener).toService(SelectionService);
 });

--- a/src/features/select/selection-service.ts
+++ b/src/features/select/selection-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { inject, injectable, multiInject, optional } from "inversify";
-import { Action, ILogger, SModelRoot, TYPES } from "sprotty";
+import { Action, ILogger, isSelected, SModelElement, SModelRoot, TYPES } from "sprotty";
 
 import { SModelRootListener } from "../../base/model/update-model-command";
 import { GLSP_TYPES } from "../../base/types";
@@ -102,6 +102,14 @@ export class SelectionService implements SModelRootListener {
 
     notifyListeners(root: SModelRoot, selectedElementIDs: Set<string>) {
         this.selectionListeners.forEach(listener => listener.selectionChanged(root, Array.from(selectedElementIDs)));
+    }
+
+    getModelRoot(): Readonly<SModelRoot> {
+        return this.root;
+    }
+
+    getSelectedElements(): Readonly<SModelElement>[] {
+        return Array.from(this.root.index.all().filter(isSelected));
     }
 
     /**

--- a/src/features/validation/di.config.ts
+++ b/src/features/validation/di.config.ts
@@ -40,6 +40,11 @@ export const markerNavigatorModule = new ContainerModule((bind, _unbind, isBound
     configureCommand({ bind, isBound }, NavigateToMarkerCommand);
 });
 
+/**
+ * This module is not required if the diagram is deployed in Theia but only intended to be used
+ * in a standalone deployment of GLSP. If the GLSP diagram is in Theia use the Theia-native
+ * `registerMarkerNavigationCommands()` in `glsp-theia-integration` instead.
+ */
 export const markerNavigatorContextMenuModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(GLSP_TYPES.IContextMenuProvider).to(MarkerNavigatorContextMenuItemProvider).inSingletonScope();
     bind(TYPES.KeyListener).to(MarkerNavigatorKeyListener).inSingletonScope();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import glspSelectModule from "./features/select/di.config";
 import toolFeedbackModule from "./features/tool-feedback/di.config";
 import paletteModule from "./features/tool-palette/di.config";
 import toolsModule from "./features/tools/di.config";
-import { markerNavigatorContextMenuModule, markerNavigatorModule, validationModule } from "./features/validation/di.config";
+import { markerNavigatorModule, validationModule } from "./features/validation/di.config";
 
 export * from 'sprotty';
 
@@ -65,6 +65,7 @@ export * from './features/mouse-tool/mouse-tool';
 export * from './features/navigation/external-navigate-to-target-handler';
 export * from './features/navigation/navigation-action-handler';
 export * from './features/navigation/navigation-target-resolver';
+export * from './features/validation/marker-navigator';
 export * from './features/rank/model';
 export * from './features/reconnect/model';
 export * from './features/save/model';
@@ -100,5 +101,5 @@ export * from './model-source/glsp-server-status';
 export {
     validationModule, saveModule, executeCommandModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, glspCommandPaletteModule, //
     glspContextMenuModule, glspServerCopyPasteModule, copyPasteContextMenuModule, glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelValidationModule, //
-    glspHoverModule, toolsModule, navigationModule, markerNavigatorModule, markerNavigatorContextMenuModule, glspDecorationModule
+    glspHoverModule, toolsModule, navigationModule, markerNavigatorModule, glspDecorationModule
 };


### PR DESCRIPTION
This is required in preparation for providing a more convenient way of defining Theia-native command handlers on GLSP diagrams.

Also, this change makes context menu providers of GLSP moduels optional. We'll provide Theia-native context menus to be used if the GLSP diagram is deployed in Theia. Finally, this change also adds some missing exports.

https://github.com/eclipse-glsp/glsp/issues/79