### PR TITLE
#98 Remove theia-related css keys from @eclipse-glsp/client

### DIFF
--- a/css/decoration.css
+++ b/css/decoration.css
@@ -1,11 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
 :root {
-    --glsp-error-foreground: var(--theia-editorError-foreground);
-    --glsp-warning-foreground: var(--theia-editorWarning-foreground);
-    --glsp-info-foreground: var(--theia-editorInfo-foreground);
+    --glsp-error-foreground: red;
+    --glsp-warning-foreground: yellow;
+    --glsp-info-foreground: lightblue;
 }
 
 .sprotty-issue-background {
-    fill: var(--theia-editor-background);
+    fill: none;
 }
 
 .sprotty-issue.sprotty-error {

--- a/css/glsp-sprotty.css
+++ b/css/glsp-sprotty.css
@@ -61,7 +61,7 @@
 }
 
 .sprotty-resize-handle.active {
-    fill: var(--theia-menu-selectionBackground);
+    fill: #0074e8;
 }
 
 .sprotty-resize-handle.mouseover {

--- a/css/tool-palette.css
+++ b/css/tool-palette.css
@@ -129,12 +129,9 @@
 }
 
 .search-input {
-    background: var(--theia-input-background);
-    color: var(--theia-input-foreground);
-    border: var(--theia-border-width) solid var(--theia-input-border);
-    font-family: var(--theia-ui-font-family);
-    font-size: var(--theia-ui-font-size1);
-    line-height: var(--theia-content-line-height);
+    background: #DFDFDF;
+    color: black;
+    border: v#BDDAEF;
     padding-left: 3px;
     width: 150px;
     margin-left: 5px;


### PR DESCRIPTION
The css stylesheets in @eclispe-glsp/client should be application/framework independent.
If needed, they can be overwritten by css files that are defined in the corresponding framework integration package (e.g. theia-integration)
Fixes https://github.com/eclipse-glsp/glsp/issues/98