### PR TITLE
#66, #72: Refactor code for easier customization

### DIFF
--- a/packages/client/src/base/actions/context-actions.ts
+++ b/packages/client/src/base/actions/context-actions.ts
@@ -20,19 +20,21 @@ import { EditorContext } from "../editor-context";
 
 export class RequestContextActions implements RequestAction<SetContextActions> {
     static readonly KIND = "requestContextActions";
-    kind = RequestContextActions.KIND;
     constructor(
         public readonly contextId: string,
         public readonly editorContext: EditorContext,
-        public readonly requestId: string = generateRequestId()) { }
+        public readonly requestId: string = generateRequestId(),
+        public readonly kind: string = RequestContextActions.KIND) { }
 }
 
 export class SetContextActions implements ResponseAction {
     static readonly KIND = "setContextActions";
-    kind = SetContextActions.KIND;
-    constructor(public readonly actions: LabeledAction[],
+    constructor(
+        public readonly actions: LabeledAction[],
         public readonly responseId: string = '',
-        readonly args?: Args) { }
+        public readonly args?: Args,
+        public readonly kind: string = SetContextActions.KIND) {
+    }
 }
 
 export function isSetContextActionsAction(action: Action): action is SetContextActions {

--- a/packages/client/src/base/actions/edit-mode-action.ts
+++ b/packages/client/src/base/actions/edit-mode-action.ts
@@ -13,15 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action } from "sprotty";
 import { injectable } from "inversify";
+import { Action } from "sprotty";
 
 @injectable()
 export class SetEditModeAction implements Action {
     static readonly KIND = "setEditMode";
-    kind = SetEditModeAction.KIND;
-
-    constructor(public readonly editMode: string = EditMode.EDITABLE) { }
+    constructor(public readonly editMode: string = EditMode.EDITABLE, public readonly kind: string = SetEditModeAction.KIND) { }
 }
 
 export function isSetEditModeAction(action: Action): action is SetEditModeAction {

--- a/packages/client/src/base/actions/edit-validation-actions.ts
+++ b/packages/client/src/base/actions/edit-validation-actions.ts
@@ -19,20 +19,21 @@ import { Args } from "../args";
 
 export class RequestEditValidationAction implements RequestAction<SetEditValidationResultAction> {
     static readonly KIND = "requestEditValidation";
-    kind = RequestEditValidationAction.KIND;
     constructor(
         public readonly contextId: string,
         public readonly modelElementId: string,
         public readonly text: string,
-        public readonly requestId: string = generateRequestId()) { }
+        public readonly requestId: string = generateRequestId(),
+        public readonly kind: string = RequestEditValidationAction.KIND) { }
 }
 
 export class SetEditValidationResultAction implements ResponseAction {
     static readonly KIND = "setEditValidationResult";
-    kind = SetEditValidationResultAction.KIND;
-    constructor(public readonly status: ValidationStatus,
+    constructor(
+        public readonly status: ValidationStatus,
         public readonly responseId: string = '',
-        readonly args?: Args) { }
+        public readonly args?: Args,
+        public readonly kind: string = SetEditValidationResultAction.KIND) { }
 }
 
 export function isSetEditValidationResultAction(action: Action): action is SetEditValidationResultAction {

--- a/packages/client/src/base/actions/protocol-actions.ts
+++ b/packages/client/src/base/actions/protocol-actions.ts
@@ -24,10 +24,7 @@ import { Action, ActionHandlerRegistry, IActionHandler, ModelSource, TYPES } fro
 @injectable()
 export class InitializeClientSessionAction implements Action {
     static readonly KIND = "initializeClientSession";
-    readonly kind = InitializeClientSessionAction.KIND;
-
-    constructor(public readonly clientId: string) { }
-
+    constructor(public readonly clientId: string, public readonly kind: string = InitializeClientSessionAction.KIND) { }
 }
 
 export function initializeClientSessionAction(action: Action): action is InitializeClientSessionAction {
@@ -41,9 +38,7 @@ export function initializeClientSessionAction(action: Action): action is Initial
 @injectable()
 export class DisposeClientSessionAction implements Action {
     static readonly KIND = "disposeClientSession";
-    readonly kind = DisposeClientSessionAction.KIND;
-
-    constructor(public readonly clientId: string) { }
+    constructor(public readonly clientId: string, public readonly kind: string = DisposeClientSessionAction.KIND) { }
 }
 
 export function isDisposeClientSessionAction(action: Action): action is DisposeClientSessionAction {

--- a/packages/client/src/base/auto-complete/auto-complete-widget.ts
+++ b/packages/client/src/base/auto-complete/auto-complete-widget.ts
@@ -51,9 +51,10 @@ export interface TextSubmitHandler {
 
 const configureAutocomplete: (settings: AutocompleteSettings<LabeledAction>) => AutocompleteResult = require('autocompleter');
 
-export class AutoCompleteWidget {
 
-    loadingIndicatorClasses = ['loading', 'fa', 'fa-spinner', 'fa-pulse', 'fa-3x', 'fa-fw'];
+
+export class AutoCompleteWidget {
+    public loadingIndicatorClasses = ['loading', 'fa', 'fa-spinner', 'fa-pulse', 'fa-3x', 'fa-fw'];
 
     protected containerElement: HTMLElement;
     protected inputElement: HTMLInputElement;
@@ -87,16 +88,21 @@ export class AutoCompleteWidget {
 
     initialize(containerElement: HTMLElement): void {
         this.containerElement = containerElement;
-        this.inputElement = document.createElement('input');
-        this.inputElement.style.position = 'absolute';
-        this.inputElement.spellcheck = false;
-        this.inputElement.autocapitalize = 'false';
-        this.inputElement.autocomplete = 'false';
-        this.inputElement.style.width = '100%';
-        this.inputElement.addEventListener('keydown', event => this.handleKeyDown(event));
-        this.inputElement.addEventListener('blur', () => window.setTimeout(() => this.notifyClose(), 200));
+        this.inputElement = this.createInputElement();
         this.containerElement.appendChild(this.inputElement);
         this.containerElement.style.position = 'absolute';
+    }
+
+    protected createInputElement(): HTMLInputElement {
+        const inputElement = document.createElement('input');
+        inputElement.style.position = 'absolute';
+        inputElement.spellcheck = false;
+        inputElement.autocapitalize = 'false';
+        inputElement.autocomplete = 'false';
+        inputElement.style.width = '100%';
+        inputElement.addEventListener('keydown', event => this.handleKeyDown(event));
+        inputElement.addEventListener('blur', () => window.setTimeout(() => this.notifyClose(), 200));
+        return inputElement;
     }
 
     protected handleKeyDown(event: KeyboardEvent) {
@@ -193,7 +199,7 @@ export class AutoCompleteWidget {
         return this.suggestionProvider.provideSuggestions(text);
     }
 
-    protected onLoaded(success: 'success' | 'error') {
+    protected onLoaded(_success: 'success' | 'error') {
         if (this.containerElement.contains(this.loadingIndicator)) {
             this.containerElement.removeChild(this.loadingIndicator);
         }

--- a/packages/client/src/base/auto-complete/auto-complete-widget.ts
+++ b/packages/client/src/base/auto-complete/auto-complete-widget.ts
@@ -54,7 +54,7 @@ const configureAutocomplete: (settings: AutocompleteSettings<LabeledAction>) => 
 
 
 export class AutoCompleteWidget {
-    public loadingIndicatorClasses = ['loading', 'fa', 'fa-spinner', 'fa-pulse', 'fa-3x', 'fa-fw'];
+    loadingIndicatorClasses = ['loading', 'fa', 'fa-spinner', 'fa-pulse', 'fa-3x', 'fa-fw'];
 
     protected containerElement: HTMLElement;
     protected inputElement: HTMLInputElement;

--- a/packages/client/src/base/auto-complete/validation-decorator.ts
+++ b/packages/client/src/base/auto-complete/validation-decorator.ts
@@ -32,13 +32,13 @@ export namespace IValidationDecorator {
 }
 
 export class ValidationDecorator implements IValidationDecorator {
-    public warningClasses = ['warning'];
-    public warningIconClasses = ['fa', 'fa-question-circle'];
-    public errorClasses = ['error'];
-    public errorIconClasses = ['fa', 'fa-exclamation-circle'];
+    warningClasses = ['warning'];
+    warningIconClasses = ['fa', 'fa-question-circle'];
+    errorClasses = ['error'];
+    errorIconClasses = ['fa', 'fa-exclamation-circle'];
 
-    public isValidated: boolean = false;
-    public hasValidationError: boolean = false;
+    isValidated: boolean = false;
+    hasValidationError: boolean = false;
 
     protected decorationDiv?: HTMLDivElement;
 

--- a/packages/client/src/base/auto-complete/validation-decorator.ts
+++ b/packages/client/src/base/auto-complete/validation-decorator.ts
@@ -24,7 +24,7 @@ export interface IValidationDecorator {
 
 export namespace IValidationDecorator {
     export const NO_DECORATION: IValidationDecorator = {
-        decorateValidationResult(status: ValidationStatus) { },
+        decorateValidationResult(_status: ValidationStatus) { },
         isValidatedOk(): boolean { return false; },
         invalidate() { },
         dispose() { }
@@ -32,14 +32,13 @@ export namespace IValidationDecorator {
 }
 
 export class ValidationDecorator implements IValidationDecorator {
+    public warningClasses = ['warning'];
+    public warningIconClasses = ['fa', 'fa-question-circle'];
+    public errorClasses = ['error'];
+    public errorIconClasses = ['fa', 'fa-exclamation-circle'];
 
-    warningClasses = ['warning'];
-    warningIconClasses = ['fa', 'fa-question-circle'];
-    errorClasses = ['error'];
-    errorIconClasses = ['fa', 'fa-exclamation-circle'];
-
-    isValidated: boolean = false;
-    hasValidationError: boolean = false;
+    public isValidated: boolean = false;
+    public hasValidationError: boolean = false;
 
     protected decorationDiv?: HTMLDivElement;
 

--- a/packages/client/src/base/editor-context.ts
+++ b/packages/client/src/base/editor-context.ts
@@ -32,13 +32,14 @@ export interface EditorContext {
 export interface EditModeListener {
     editModeChanged(newValue: string, oldvalue: string): void;
 }
+
 @injectable()
 export class EditorContextService implements IActionHandler {
 
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
     @inject(MousePositionTracker) protected mousePositionTracker: MousePositionTracker;
     @inject(TYPES.ModelSourceProvider) protected modelSource: () => Promise<ModelSource>;
-    editMode: string;
+    protected _editMode: string;
 
     constructor(@multiInject(GLSP_TYPES.IEditModeListener) @optional() protected editModeListeners: EditModeListener[] = []) { }
 
@@ -68,8 +69,8 @@ export class EditorContextService implements IActionHandler {
 
     handle(action: Action) {
         if (isSetEditModeAction(action)) {
-            const oldValue = this.editMode;
-            this.editMode = action.editMode;
+            const oldValue = this._editMode;
+            this._editMode = action.editMode;
             this.notifiyEditModeListeners(oldValue);
         }
     }
@@ -84,6 +85,10 @@ export class EditorContextService implements IActionHandler {
             return modelSource.getSourceURI();
         }
         return undefined;
+    }
+
+    get editMode(): string {
+        return this._editMode;
     }
 
     get modelRoot(): Readonly<SModelRoot> {

--- a/packages/client/src/base/operations/operation.ts
+++ b/packages/client/src/base/operations/operation.ts
@@ -17,6 +17,10 @@ import { Action, ElementAndBounds, isAction, Point } from "sprotty";
 
 import { Args } from "../args";
 
+/**
+ * Operations are actions that denote requests from the client to _modify_ the model. Model modifications are always performed by the server.
+ * After a successful modification, the server sends the updated model back to the client using the `UpdateModelAction`.
+ */
 export interface Operation extends Action { }
 
 export interface CreateOperation extends Operation {
@@ -30,12 +34,12 @@ export function isCreateOperation(object?: any): object is CreateOperation {
 
 export class CreateNodeOperation implements CreateOperation {
     static readonly KIND = "createNode";
-    readonly kind = CreateNodeOperation.KIND;
 
     constructor(public readonly elementTypeId: string,
         public location?: Point,
         public containerId?: string,
-        public args?: Args) { }
+        public args?: Args,
+        public readonly kind: string = CreateNodeOperation.KIND) { }
 }
 
 export function isCreateNodeOperation(object?: any): object is CreateNodeOperation {
@@ -44,12 +48,12 @@ export function isCreateNodeOperation(object?: any): object is CreateNodeOperati
 
 export class CreateEdgeOperation implements CreateOperation {
     static readonly KIND = "createEdge";
-    readonly kind = CreateEdgeOperation.KIND;
 
     constructor(public readonly elementTypeId: string,
         public sourceElementId?: string,
         public targetElementId?: string,
-        public args?: Args) { }
+        public args?: Args,
+        public readonly kind: string = CreateEdgeOperation.KIND) { }
 }
 
 export function isCreateConnectionOperation(object?: any): object is CreateEdgeOperation {
@@ -58,61 +62,63 @@ export function isCreateConnectionOperation(object?: any): object is CreateEdgeO
 
 export class DeleteElementOperation implements Operation {
     static readonly KIND = "deleteElement";
-    kind = DeleteElementOperation.KIND;
-    constructor(readonly elementIds: string[]) { }
+    constructor(readonly elementIds: string[], public readonly kind: string = DeleteElementOperation.KIND) { }
 }
 
 export class ChangeBoundsOperation implements Operation {
     static readonly KIND = "changeBounds";
-    readonly kind = ChangeBoundsOperation.KIND;
-    constructor(public newBounds: ElementAndBounds[]) { }
+    constructor(public newBounds: ElementAndBounds[], public readonly kind: string = ChangeBoundsOperation.KIND) { }
 }
 
 export class ChangeContainerOperation implements Operation {
     static readonly KIND = "changeContainer";
-    readonly kind = ChangeContainerOperation.KIND;
     constructor(public readonly elementId: string,
         public readonly targetContainerId: string,
-        public readonly location?: string) { }
+        public readonly location?: string,
+        public readonly kind: string = ChangeContainerOperation.KIND) { }
 }
 
 export class ReconnectEdgeOperation implements Operation {
     static readonly KIND = "reconnectEdge";
-    readonly kind = ReconnectEdgeOperation.KIND;
     constructor(public readonly connectionElementId: string,
         public readonly sourceElementId: string,
-        public readonly targetElementId: string) { }
+        public readonly targetElementId: string,
+        public readonly kind: string = ReconnectEdgeOperation.KIND) { }
 }
 
 export class ChangeRoutingPointsOperation implements Operation {
     static readonly KIND = "changeRoutingPoints";
-    readonly kind = ChangeRoutingPointsOperation.KIND;
-    constructor(public newRoutingPoints: ElementAndRoutingPoints[]) { }
+    constructor(public newRoutingPoints: ElementAndRoutingPoints[], public readonly kind: string = ChangeRoutingPointsOperation.KIND) { }
 }
+
 export class CompoundOperation implements Operation {
     static readonly KIND = "compound";
-    readonly kind = CompoundOperation.KIND;
-
-    constructor(public operationList: Operation[]) { }
+    constructor(public operationList: Operation[], public readonly kind: string = CompoundOperation.KIND) { }
 }
+
 export interface ElementAndRoutingPoints {
     elementId: string
     newRoutingPoints?: Point[];
 }
 
 export abstract class TriggerElementCreationAction implements Action {
-    abstract readonly kind: string;
-    constructor(public readonly elementTypeId: string, readonly args?: Args) { }
+    constructor(public readonly elementTypeId: string, readonly args?: Args, public readonly kind: string = 'unknown') { }
 }
 
 export class TriggerNodeCreationAction extends TriggerElementCreationAction {
     static readonly KIND = "triggerNodeCreation";
-    kind = TriggerNodeCreationAction.KIND;
+
+    constructor(public readonly elementTypeId: string, readonly args?: Args, public readonly kind = TriggerNodeCreationAction.KIND) {
+        super(elementTypeId, args, kind);
+    }
 }
 
 export class TriggerEdgeCreationAction extends TriggerElementCreationAction {
     static readonly KIND = "triggerEdgeCreation";
-    kind = TriggerEdgeCreationAction.KIND;
+
+    constructor(public readonly elementTypeId: string, readonly args?: Args, public readonly kind: string = TriggerEdgeCreationAction.KIND) {
+        super(elementTypeId, args, kind);
+    }
 }
 
 export function isTriggerElementTypeCreationAction(object?: any): object is TriggerElementCreationAction {

--- a/packages/client/src/base/selection-clearing-mouse-listener.ts
+++ b/packages/client/src/base/selection-clearing-mouse-listener.ts
@@ -30,7 +30,7 @@ import { MouseListener, SModelElement } from "sprotty";
  */
 @injectable()
 export class SelectionClearingMouseListener extends MouseListener {
-    mouseDown(target: SModelElement, event: MouseEvent) {
+    mouseDown(_target: SModelElement, event: MouseEvent) {
         const selection = document.getSelection();
         if (selection === null) {
             return [];

--- a/packages/client/src/base/tool-manager/glsp-tool-manager.ts
+++ b/packages/client/src/base/tool-manager/glsp-tool-manager.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable, multiInject, optional } from "inversify";
+import { inject, injectable, multiInject, optional, postConstruct } from "inversify";
 import { Tool, ToolManager } from "sprotty";
 
 import { distinctAdd } from "../../utils/array-utils";
@@ -25,17 +25,21 @@ export interface IGLSPToolManager extends ToolManager {
     /* Disables all actives tools and activates only default tool with non-edit function*/
     disableEditTools(): void;
 }
+
 @injectable()
 export class GLSPToolManager extends ToolManager implements IGLSPToolManager, EditModeListener {
     protected editorContext?: EditorContextService;
-    constructor(@multiInject(GLSP_TYPES.ITool) @optional() tools: Tool[],
-        @multiInject(GLSP_TYPES.IDefaultTool) @optional() defaultTools: Tool[],
-        @inject(GLSP_TYPES.IEditorContextServiceProvider) contextServiceProvider: EditorContextServiceProvider) {
-        super();
-        this.registerTools(...tools);
-        this.registerDefaultTools(...defaultTools);
+
+    @multiInject(GLSP_TYPES.ITool) @optional() public tools: Tool[];
+    @multiInject(GLSP_TYPES.IDefaultTool) @optional() public defaultTools: Tool[];
+    @inject(GLSP_TYPES.IEditorContextServiceProvider) public contextServiceProvider: EditorContextServiceProvider;
+
+    @postConstruct()
+    protected initialize(): void {
+        this.registerTools(...this.tools);
+        this.registerDefaultTools(...this.defaultTools);
         this.enableDefaultTools();
-        contextServiceProvider().then(editorContext => {
+        this.contextServiceProvider().then(editorContext => {
             editorContext.register(this);
             this.editorContext = editorContext;
         });

--- a/packages/client/src/base/tool-manager/glsp-tool-manager.ts
+++ b/packages/client/src/base/tool-manager/glsp-tool-manager.ts
@@ -30,9 +30,9 @@ export interface IGLSPToolManager extends ToolManager {
 export class GLSPToolManager extends ToolManager implements IGLSPToolManager, EditModeListener {
     protected editorContext?: EditorContextService;
 
-    @multiInject(GLSP_TYPES.ITool) @optional() public tools: Tool[];
-    @multiInject(GLSP_TYPES.IDefaultTool) @optional() public defaultTools: Tool[];
-    @inject(GLSP_TYPES.IEditorContextServiceProvider) public contextServiceProvider: EditorContextServiceProvider;
+    @multiInject(GLSP_TYPES.ITool) @optional() tools: Tool[];
+    @multiInject(GLSP_TYPES.IDefaultTool) @optional() defaultTools: Tool[];
+    @inject(GLSP_TYPES.IEditorContextServiceProvider) contextServiceProvider: EditorContextServiceProvider;
 
     @postConstruct()
     protected initialize(): void {

--- a/packages/client/src/features/change-bounds/model.ts
+++ b/packages/client/src/features/change-bounds/model.ts
@@ -49,13 +49,11 @@ export function isBoundsAwareMoveable(element: SModelElement): element is SModel
 
 export class SResizeHandle extends SChildElement implements Hoverable {
     static readonly TYPE = 'resize-handle';
-    type: string = SResizeHandle.TYPE;
-    hoverFeedback: boolean = false;
-    location?: ResizeHandleLocation;
 
-    constructor(location?: ResizeHandleLocation) {
+    constructor(public readonly location?: ResizeHandleLocation,
+        public readonly type: string = SResizeHandle.TYPE,
+        public readonly hoverFeedback: boolean = false) {
         super();
-        this.location = location;
     }
 
     hasFeature(feature: symbol): boolean {

--- a/packages/client/src/features/change-bounds/movement-restrictor.ts
+++ b/packages/client/src/features/change-bounds/movement-restrictor.ts
@@ -45,7 +45,7 @@ export function removeMovementRestrictionFeedback(element: SModelElement, moveme
 
 @injectable()
 export class NoOverlapMovmentRestrictor implements IMovementRestrictor {
-    public cssClasses = ["movement-not-allowed"];
+    cssClasses = ["movement-not-allowed"];
 
     validate(newLocation: Point, element: SModelElement): boolean {
         if (!isBoundsAwareMoveable(element)) {

--- a/packages/client/src/features/change-bounds/movement-restrictor.ts
+++ b/packages/client/src/features/change-bounds/movement-restrictor.ts
@@ -45,6 +45,8 @@ export function removeMovementRestrictionFeedback(element: SModelElement, moveme
 
 @injectable()
 export class NoOverlapMovmentRestrictor implements IMovementRestrictor {
+    public cssClasses = ["movement-not-allowed"];
+
     validate(newLocation: Point, element: SModelElement): boolean {
         if (!isBoundsAwareMoveable(element)) {
             return false;
@@ -62,8 +64,6 @@ export class NoOverlapMovmentRestrictor implements IMovementRestrictor {
         return !Array.from(element.root.index.all().filter(e => e.id !== ghostElement.id && e !== ghostElement.root && (e instanceof SNode))
             .map(e => e as SModelElement & BoundsAware)).some(e => areOverlapping(e, ghostElement));
     }
-
-    cssClasses = ["movement-not-allowed"];
 }
 
 export function areOverlapping(element1: SModelElement & BoundsAware, element2: SModelElement & BoundsAware) {

--- a/packages/client/src/features/command-palette/command-palette-tool.ts
+++ b/packages/client/src/features/command-palette/command-palette-tool.ts
@@ -31,9 +31,11 @@ export class CommandPaletteTool implements Tool {
     get id(): string {
         return CommandPaletteTool.ID;
     }
+
     enable(): void {
         this.keyTool.register(this.commandPaletteKeyListener);
     }
+
     disable(): void {
         this.keyTool.deregister(this.commandPaletteKeyListener);
     }

--- a/packages/client/src/features/command-palette/server-command-palette-provider.ts
+++ b/packages/client/src/features/command-palette/server-command-palette-provider.ts
@@ -31,7 +31,7 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
     @inject(EditorContextService) protected editorContext: EditorContextService;
 
-    getActions(root: Readonly<SModelElement>, text: string, lastMousePosition?: Point, index?: number): Promise<LabeledAction[]> {
+    getActions(_root: Readonly<SModelElement>, text: string, _lastMousePosition?: Point, index?: number): Promise<LabeledAction[]> {
         const requestAction = new RequestContextActions(ServerCommandPalette.CONTEXT_ID, this.editorContext.get({
             [ServerCommandPalette.TEXT]: text,
             [ServerCommandPalette.INDEX]: index ? index : 0

--- a/packages/client/src/features/context-menu/delete-element-context-menu.ts
+++ b/packages/client/src/features/context-menu/delete-element-context-menu.ts
@@ -16,7 +16,7 @@
 import { inject, injectable } from "inversify";
 import { IContextMenuItemProvider, MenuItem, Point, SModelRoot } from "sprotty";
 
-import { EditorContextServiceProvider } from "../../base/editor-context";
+import { EditorContextService, EditorContextServiceProvider } from "../../base/editor-context";
 import { DeleteElementOperation } from "../../base/operations/operation";
 import { GLSP_TYPES } from "../../base/types";
 
@@ -24,18 +24,19 @@ import { GLSP_TYPES } from "../../base/types";
 export class DeleteElementContextMenuItemProvider implements IContextMenuItemProvider {
     @inject(GLSP_TYPES.IEditorContextServiceProvider) editorContextServiceProvider: EditorContextServiceProvider;
 
-    async getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<MenuItem[]> {
+    async getItems(_root: Readonly<SModelRoot>, _lastMousePosition?: Point): Promise<MenuItem[]> {
         const editorContextService = await this.editorContextServiceProvider();
+        return [this.createDeleteMenuItem(editorContextService)];
+    }
 
-        return [
-            {
-                id: "delete",
-                label: "Delete",
-                sortString: "d",
-                group: "edit",
-                actions: [new DeleteElementOperation(editorContextService.selectedElements.map(e => e.id))],
-                isEnabled: () => !editorContextService.isReadonly && editorContextService.selectedElements.length > 0
-            }
-        ];
+    protected createDeleteMenuItem(editorContextService: EditorContextService): MenuItem {
+        return {
+            id: "delete",
+            label: "Delete",
+            sortString: "d",
+            group: "edit",
+            actions: [new DeleteElementOperation(editorContextService.selectedElements.map(e => e.id))],
+            isEnabled: () => !editorContextService.isReadonly && editorContextService.selectedElements.length > 0
+        };
     }
 }

--- a/packages/client/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
+++ b/packages/client/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
@@ -30,13 +30,9 @@ import { SelectionService } from "../select/selection-service";
 
 @injectable()
 export class SelectionServiceAwareContextMenuMouseListener extends MouseListener {
-
-    constructor(
-        @inject(TYPES.IContextMenuServiceProvider) @optional() protected readonly contextMenuService: IContextMenuServiceProvider,
-        @inject(TYPES.IContextMenuProviderRegistry) @optional() protected readonly menuProvider: ContextMenuProviderRegistry,
-        @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService) {
-        super();
-    }
+    @inject(TYPES.IContextMenuServiceProvider) @optional() protected readonly contextMenuService: IContextMenuServiceProvider;
+    @inject(TYPES.IContextMenuProviderRegistry) @optional() protected readonly menuProvider: ContextMenuProviderRegistry;
+    @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
 
     mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         if (event.button === 2 && this.contextMenuService && this.menuProvider) {

--- a/packages/client/src/features/copy-paste/copy-paste-actions.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-actions.ts
@@ -19,25 +19,28 @@ import { EditorContext } from "../../base/editor-context";
 
 export class CutOperationAction implements Action {
     static readonly KIND = "cut";
-    kind = CutOperationAction.KIND;
-    constructor(public readonly editorContext: EditorContext) { }
+
+    constructor(
+        public readonly editorContext: EditorContext,
+        public readonly kind: string = CutOperationAction.KIND) { }
 }
 
 export class PasteOperationAction implements Action {
     static readonly KIND = "paste";
-    kind = PasteOperationAction.KIND;
+
     constructor(
         public readonly clipboardData: ClipboardData,
-        public readonly editorContext: EditorContext) { }
+        public readonly editorContext: EditorContext,
+        public readonly kind: string = PasteOperationAction.KIND) { }
 }
 
 export class RequestClipboardDataAction implements RequestAction<SetClipboardDataAction> {
     static readonly KIND = "requestClipboardData";
-    kind = RequestClipboardDataAction.KIND;
 
     constructor(
         public readonly editorContext: EditorContext,
-        public readonly requestId: string = generateRequestId()) { }
+        public readonly requestId: string = generateRequestId(),
+        public readonly kind: string = RequestClipboardDataAction.KIND) { }
 
     static create(editorContext: EditorContext): RequestAction<SetClipboardDataAction> {
         return new RequestClipboardDataAction(editorContext);
@@ -48,8 +51,9 @@ export type ClipboardData = { [format: string]: string };
 
 export class SetClipboardDataAction implements ResponseAction {
     static readonly KIND = "setClipboardData";
-    kind = SetClipboardDataAction.KIND;
+
     constructor(
         public readonly clipboardData: ClipboardData,
-        public readonly responseId: string = '') { }
+        public readonly responseId: string = '',
+        public readonly kind: string = SetClipboardDataAction.KIND) { }
 }

--- a/packages/client/src/features/copy-paste/copy-paste-context-menu.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-context-menu.ts
@@ -80,18 +80,18 @@ export class CopyPasteContextMenuItemProvider implements IContextMenuItemProvide
         return Promise.resolve([
             this.createCopyMenuItem(hasSelectedElements),
             this.createCutMenuItem(hasSelectedElements),
-            this.ceratePasteMenuItem()
+            this.createPasteMenuItem()
         ]);
     }
 
-    private ceratePasteMenuItem(): MenuItem {
+    protected createPasteMenuItem(): MenuItem {
         return {
             id: "paste", label: "Paste", group: "copy-paste",
             actions: [new InvokePasteAction()], isEnabled: () => true
         };
     }
 
-    private createCutMenuItem(hasSelectedElements: boolean): MenuItem {
+    protected createCutMenuItem(hasSelectedElements: boolean): MenuItem {
         return {
             id: "cut", label: "Cut", group: "copy-paste",
             actions: [new InvokeCutAction()], isEnabled: () => hasSelectedElements

--- a/packages/client/src/features/copy-paste/copy-paste-context-menu.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-context-menu.ts
@@ -30,17 +30,17 @@ import { GLSPServerStatusAction, ServerMessageAction } from "../../model-source/
 
 export class InvokeCopyAction implements Action {
     static readonly KIND = "invoke-copy";
-    kind = InvokeCopyAction.KIND;
+    constructor(public readonly kind = InvokeCopyAction.KIND) { }
 }
 
 export class InvokePasteAction implements Action {
     static readonly KIND = "invoke-paste";
-    kind = InvokePasteAction.KIND;
+    constructor(public readonly kind = InvokePasteAction.KIND) { }
 }
 
 export class InvokeCutAction implements Action {
     static readonly KIND = "invoke-cut";
-    kind = InvokeCutAction.KIND;
+    constructor(public readonly kind = InvokeCutAction.KIND) { }
 }
 
 @injectable()
@@ -75,21 +75,33 @@ export class InvokeCopyPasteActionHandler implements IActionHandler {
 
 @injectable()
 export class CopyPasteContextMenuItemProvider implements IContextMenuItemProvider {
-    getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<MenuItem[]> {
+    getItems(root: Readonly<SModelRoot>, _lastMousePosition?: Point): Promise<MenuItem[]> {
         const hasSelectedElements = Array.from(root.index.all().filter(isSelected)).length > 0;
         return Promise.resolve([
-            {
-                id: "copy", label: "Copy", group: "copy-paste",
-                actions: [new InvokeCopyAction()], isEnabled: () => hasSelectedElements
-            },
-            {
-                id: "cut", label: "Cut", group: "copy-paste",
-                actions: [new InvokeCutAction()], isEnabled: () => hasSelectedElements
-            },
-            {
-                id: "paste", label: "Paste", group: "copy-paste",
-                actions: [new InvokePasteAction()], isEnabled: () => true
-            }
+            this.createCopyMenuItem(hasSelectedElements),
+            this.createCutMenuItem(hasSelectedElements),
+            this.ceratePasteMenuItem()
         ]);
+    }
+
+    private ceratePasteMenuItem(): MenuItem {
+        return {
+            id: "paste", label: "Paste", group: "copy-paste",
+            actions: [new InvokePasteAction()], isEnabled: () => true
+        };
+    }
+
+    private createCutMenuItem(hasSelectedElements: boolean): MenuItem {
+        return {
+            id: "cut", label: "Cut", group: "copy-paste",
+            actions: [new InvokeCutAction()], isEnabled: () => hasSelectedElements
+        };
+    }
+
+    protected createCopyMenuItem(hasSelectedElements: boolean): MenuItem {
+        return {
+            id: "copy", label: "Copy", group: "copy-paste",
+            actions: [new InvokeCopyAction()], isEnabled: () => hasSelectedElements
+        };
     }
 }

--- a/packages/client/src/features/copy-paste/copy-paste-handler.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-handler.ts
@@ -23,9 +23,9 @@ import { GLSP_TYPES } from "../../base/types";
 import { ClipboardData, CutOperationAction, PasteOperationAction, RequestClipboardDataAction } from "./copy-paste-actions";
 
 export interface ICopyPasteHandler {
-    handleCopy(e: ClipboardEvent): void;
-    handleCut(e: ClipboardEvent): void;
-    handlePaste(e: ClipboardEvent): void;
+    handleCopy(event: ClipboardEvent): void;
+    handleCut(event: ClipboardEvent): void;
+    handlePaste(event: ClipboardEvent): void;
 }
 
 export interface IAsyncClipboardService {
@@ -101,40 +101,40 @@ export class ServerCopyPasteHandler implements ICopyPasteHandler {
     @inject(GLSP_TYPES.IAsyncClipboardService) protected clipboadService: IAsyncClipboardService;
     @inject(EditorContextService) protected editorContext: EditorContextService;
 
-    handleCopy(e: ClipboardEvent) {
-        if (e.clipboardData && this.shouldCopy(e)) {
+    handleCopy(event: ClipboardEvent) {
+        if (event.clipboardData && this.shouldCopy(event)) {
             const clipboardId = uuid();
-            e.clipboardData.setData(CLIPBOARD_DATA_FORMAT, toClipboardId(clipboardId));
+            event.clipboardData.setData(CLIPBOARD_DATA_FORMAT, toClipboardId(clipboardId));
             this.actionDispatcher
                 .request(RequestClipboardDataAction.create(this.editorContext.get()))
                 .then(action => this.clipboadService.put(action.clipboardData, clipboardId));
-            e.preventDefault();
+            event.preventDefault();
         } else {
-            if (e.clipboardData) { e.clipboardData.clearData(); }
+            if (event.clipboardData) { event.clipboardData.clearData(); }
             this.clipboadService.clear();
         }
     }
 
-    handleCut(e: ClipboardEvent): void {
-        if (e.clipboardData && this.shouldCopy(e)) {
-            this.handleCopy(e);
+    handleCut(event: ClipboardEvent): void {
+        if (event.clipboardData && this.shouldCopy(event)) {
+            this.handleCopy(event);
             this.actionDispatcher.dispatch(new CutOperationAction(this.editorContext.get()));
-            e.preventDefault();
+            event.preventDefault();
         }
     }
 
-    handlePaste(e: ClipboardEvent): void {
-        if (e.clipboardData) {
-            const clipboardId = getClipboardIdFromDataTransfer(e.clipboardData);
+    handlePaste(event: ClipboardEvent): void {
+        if (event.clipboardData) {
+            const clipboardId = getClipboardIdFromDataTransfer(event.clipboardData);
             const clipboardData = this.clipboadService.get(clipboardId);
             if (clipboardData) {
                 this.actionDispatcher.dispatch(new PasteOperationAction(clipboardData, this.editorContext.get()));
             }
-            e.preventDefault();
+            event.preventDefault();
         }
     }
 
-    protected shouldCopy(e: ClipboardEvent) {
+    protected shouldCopy(_event: ClipboardEvent) {
         return this.editorContext.get().selectedElementIds.length > 0 && document.activeElement instanceof SVGElement
             && document.activeElement.parentElement && document.activeElement.parentElement.id === this.viewerOptions.baseDiv;
     }

--- a/packages/client/src/features/decoration/view.tsx
+++ b/packages/client/src/features/decoration/view.tsx
@@ -23,7 +23,7 @@ const JSX = { createElement: snabbdom.svg };
 @injectable()
 export class GlspIssueMarkerView extends IssueMarkerView {
 
-    render(marker: SIssueMarker, context: RenderingContext): VNode {
+    render(marker: SIssueMarker, _context: RenderingContext): VNode {
         const maxSeverity = super.getMaxSeverity(marker);
         const group = <g class-sprotty-issue={true} >
             <g>

--- a/packages/client/src/features/edit-label/edit-label-validator.ts
+++ b/packages/client/src/features/edit-label/edit-label-validator.ts
@@ -34,6 +34,7 @@ import {
 
 export namespace LabelEditValidation {
     export const CONTEXT_ID = 'label-edit';
+
     export function toEditLabelValidationResult(status: ValidationStatus): EditLabelValidationResult {
         const message = status.message;
         let severity = <Severity>'ok';

--- a/packages/client/src/features/execute/execute-command.ts
+++ b/packages/client/src/features/execute/execute-command.ts
@@ -19,12 +19,14 @@ import { isCommandExecutor } from "./model";
 
 export class ExecuteServerCommandAction implements Action {
     static readonly KIND = "executeServerCommand";
-    kind = ExecuteServerCommandAction.KIND;
-    constructor(public readonly commandId: String, public readonly options?: { [key: string]: string }) { }
+    constructor(
+        public readonly commandId: String,
+        public readonly options?: { [key: string]: string },
+        public readonly kind: string = ExecuteServerCommandAction.KIND) { }
 }
 
 export class ExecuteCommandMouseListener extends MouseListener {
-    doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+    doubleClick(target: SModelElement, _event: WheelEvent): (Action | Promise<Action>)[] {
         const result: Action[] = [];
         const commandExecutorTarget = findParentByFeature(target, isCommandExecutor);
         if (commandExecutorTarget) {

--- a/packages/client/src/features/hints/model.ts
+++ b/packages/client/src/features/hints/model.ts
@@ -16,6 +16,7 @@
 import { SModelElement, SModelElementSchema, SModelExtension } from "sprotty";
 
 export const containerFeature = Symbol("containable");
+
 export interface Containable extends SModelExtension {
     isContainableElement(input: SModelElement | SModelElementSchema | string): boolean
 }
@@ -25,6 +26,7 @@ export function isContainable(element: SModelElement): element is SModelElement 
 }
 
 export const reparentFeature = Symbol("reparentFeature");
+
 export interface Reparentable extends SModelExtension { }
 
 export function isReparentable(element: SModelElement): element is SModelElement & Reparentable {

--- a/packages/client/src/features/hints/request-type-hints-action.ts
+++ b/packages/client/src/features/hints/request-type-hints-action.ts
@@ -19,14 +19,15 @@ import { EdgeTypeHint, ShapeTypeHint } from "./type-hints";
 
 export class RequestTypeHintsAction implements Action {
     static readonly KIND = "requestTypeHints";
-    kind = RequestTypeHintsAction.KIND;
-    constructor(public readonly diagramType?: string) { }
+    constructor(public readonly diagramType?: string, public readonly kind: string = RequestTypeHintsAction.KIND) { }
 }
 
 export class SetTypeHintsAction implements Action {
     static readonly KIND = "setTypeHints";
-    kind = SetTypeHintsAction.KIND;
-    constructor(public readonly shapeHints: ShapeTypeHint[], public readonly edgeHints: EdgeTypeHint[]) { }
+    constructor(
+        public readonly shapeHints: ShapeTypeHint[],
+        public readonly edgeHints: EdgeTypeHint[],
+        public readonly kind: string = SetTypeHintsAction.KIND) { }
 }
 
 export function isSetTypeHintsAction(action: Action): action is SetTypeHintsAction {

--- a/packages/client/src/features/hints/type-hints.ts
+++ b/packages/client/src/features/hints/type-hints.ts
@@ -107,17 +107,17 @@ export class EdgeTypeHint extends TypeHint {
 @injectable()
 export class ApplyTypeHintsAction implements Action {
     readonly kind = ApplyTypeHintsCommand.KIND;
-    constructor() { }
 }
 
 @injectable()
 export class ApplyTypeHintsCommand extends FeedbackCommand {
 
-    static KIND = "applyTypeHints";
-    readonly priority = 10;
+    public static KIND = "applyTypeHints";
+    public readonly priority = 10;
 
-    constructor(@inject(TYPES.Action) protected action: ApplyTypeHintsAction,
-        @inject(GLSP_TYPES.ITypeHintProvider) protected typeHintProvider: ITypeHintProvider) {
+    @inject(GLSP_TYPES.ITypeHintProvider) protected typeHintProvider: ITypeHintProvider;
+
+    constructor(@inject(TYPES.Action) protected action: ApplyTypeHintsAction) {
         super();
     }
 
@@ -189,6 +189,7 @@ function addOrRemove(features: Set<symbol>, feature: symbol, add: boolean) {
         features.delete(feature);
     }
 }
+
 function isModifiableFetureSet(featureSet?: FeatureSet): featureSet is FeatureSet & Set<symbol> {
     return featureSet !== undefined && featureSet instanceof Set;
 }

--- a/packages/client/src/features/hover/hover.ts
+++ b/packages/client/src/features/hover/hover.ts
@@ -25,6 +25,7 @@ import {
     SIssueMarker,
     SIssueSeverity,
     SModelElement,
+    SModelElementSchema,
     SModelRootSchema
 } from "sprotty";
 
@@ -52,21 +53,27 @@ export class GlspHoverMouseListener extends HoverMouseListener {
 
     protected createPopupModel(marker: GIssueMarker, bounds: Bounds): SModelRootSchema {
         if (marker.issues !== undefined && marker.issues.length > 0) {
-            const message = '<ul>' + marker.issues.map(i => '<li>' + i.severity.toUpperCase() + ': ' + i.message + '</li>').join('') + '</ul>';
             return {
                 type: 'html',
                 id: 'sprotty-popup',
-                children: [
-                    <PreRenderedElementSchema>{
-                        type: 'pre-rendered',
-                        id: 'popup-title',
-                        code: `<div class="${getSeverity(marker)}"><div class="sprotty-popup-title">${message}</div></div>`
-                    }
-                ],
+                children: [this.createMarkerIssuePopup(marker)],
                 canvasBounds: this.modifyBounds(bounds)
             };
         }
         return { type: EMPTY_ROOT.type, id: EMPTY_ROOT.id };
+    }
+
+    protected createMarkerIssuePopup(marker: GIssueMarker): SModelElementSchema {
+        const message = this.createIssueMessage(marker);
+        return <PreRenderedElementSchema>{
+            type: 'pre-rendered',
+            id: 'popup-title',
+            code: `<div class="${getSeverity(marker)}"><div class="sprotty-popup-title">${message}</div></div>`
+        };
+    }
+
+    protected createIssueMessage(marker: GIssueMarker): string {
+        return '<ul>' + marker.issues.map(i => '<li>' + i.severity.toUpperCase() + ': ' + i.message + '</li>').join('') + '</ul>';
     }
 
     protected modifyBounds(bounds: Bounds): Bounds {

--- a/packages/client/src/features/layout/layout-commands.ts
+++ b/packages/client/src/features/layout/layout-commands.ts
@@ -70,8 +70,6 @@ export namespace Reduce {
 }
 
 export class ResizeElementsAction implements Action {
-    readonly kind = ResizeElementsCommand.KIND;
-
     constructor(
         /**
          * IDs of the elements that should be resized. If no IDs are given, the selected elements will be resized.
@@ -84,7 +82,8 @@ export class ResizeElementsAction implements Action {
         /**
          * Function to reduce the dimension to a target dimension value, see Reduce.* for potential functions.
          */
-        public readonly reductionFunction: (...values: number[]) => number) {
+        public readonly reductionFunction: (...values: number[]) => number,
+        public readonly kind: string = ResizeElementsCommand.KIND) {
     }
 }
 
@@ -113,8 +112,6 @@ export namespace Select {
 
 
 export class AlignElementsAction implements Action {
-    readonly kind = AlignElementsCommand.KIND;
-
     constructor(
         /**
          * IDs of the elements that should be aligned. If no IDs are given, the selected elements will be aligned.
@@ -127,7 +124,8 @@ export class AlignElementsAction implements Action {
         /**
          * Function to selected elements that are considered during alignment calculation, see Select.* for potential functions.
          */
-        public readonly selectionFunction: (elements: BoundsAwareModelElement[]) => BoundsAwareModelElement[] = Select.all) {
+        public readonly selectionFunction: (elements: BoundsAwareModelElement[]) => BoundsAwareModelElement[] = Select.all,
+        public readonly kind = AlignElementsCommand.KIND) {
     }
 }
 

--- a/packages/client/src/features/mouse-tool/mouse-tool.ts
+++ b/packages/client/src/features/mouse-tool/mouse-tool.ts
@@ -54,7 +54,7 @@ export class RankingMouseTool extends MouseTool implements IMouseTool {
             overwriteOn(vnode, 'mouseup', this.mouseUp.bind(this), element);
             overwriteOn(vnode, 'mousemove', this.mouseMove.bind(this), element);
             overwriteOn(vnode, 'wheel', this.wheel.bind(this), element);
-            overwriteOn(vnode, 'contextmenu', (target: SModelElement, event: any) => {
+            overwriteOn(vnode, 'contextmenu', (_target: SModelElement, event: any) => {
                 event.preventDefault();
             }, element);
             overwriteOn(vnode, 'dblclick', this.doubleClick.bind(this), element);

--- a/packages/client/src/features/reconnect/model.ts
+++ b/packages/client/src/features/reconnect/model.ts
@@ -25,6 +25,7 @@ import {
 } from "sprotty";
 
 export const reconnectFeature = Symbol("reconnectFeature");
+
 export interface Reconnectable extends SModelExtension {
 }
 

--- a/packages/client/src/features/save/save.ts
+++ b/packages/client/src/features/save/save.ts
@@ -18,12 +18,11 @@ import { matchesKeystroke } from "sprotty/lib/utils/keyboard";
 
 export class SaveModelAction implements Action {
     static readonly KIND = "saveModel";
-    readonly kind = SaveModelAction.KIND;
-    constructor() { }
+    constructor(public readonly kind: string = SaveModelAction.KIND) { }
 }
 
 export class SaveModelKeyboardListener extends KeyListener {
-    keyDown(element: SModelRoot, event: KeyboardEvent): Action[] {
+    keyDown(_element: SModelRoot, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'KeyS', 'ctrlCmd')) {
             return [new SaveModelAction()];
         }

--- a/packages/client/src/features/select/select-feedback-action.ts
+++ b/packages/client/src/features/select/select-feedback-action.ts
@@ -24,20 +24,18 @@ import {
 } from "sprotty";
 
 export class SelectFeedbackAction {
-    kind = SelectFeedbackCommand.KIND;
-
-    constructor(public readonly selectedElementsIDs: string[] = [],
-        public readonly deselectedElementsIDs: string[] = []) {
+    constructor(
+        public readonly selectedElementsIDs: string[] = [],
+        public readonly deselectedElementsIDs: string[] = [],
+        public readonly kind: string = SelectFeedbackCommand.KIND) {
     }
 }
 
 export class SelectAllFeedbackAction {
-    kind = SelectAllFeedbackCommand.KIND;
-
     /**
      * If `select` is true, all elements are selected, othewise they are deselected.
      */
-    constructor(public readonly select: boolean = true) {
+    constructor(public readonly select: boolean = true, public readonly kind: string = SelectFeedbackCommand.KIND) {
     }
 }
 

--- a/packages/client/src/features/tool-feedback/change-bounds-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/change-bounds-tool-feedback.ts
@@ -39,25 +39,18 @@ import { ChangeBoundsTool } from "../tools/change-bounds-tool";
 import { FeedbackCommand } from "./model";
 
 export class ShowChangeBoundsToolResizeFeedbackAction implements Action {
-    kind = ShowChangeBoundsToolResizeFeedbackCommand.KIND;
-    constructor(readonly elementId?: string) { }
+    constructor(readonly elementId?: string, public readonly kind: string = ShowChangeBoundsToolResizeFeedbackCommand.KIND) { }
 }
 
 export class HideChangeBoundsToolResizeFeedbackAction implements Action {
-    kind = HideChangeBoundsToolResizeFeedbackCommand.KIND;
-    constructor() { }
+    constructor(public readonly kind: string = HideChangeBoundsToolResizeFeedbackCommand.KIND) { }
 }
 
 @injectable()
 export class ShowChangeBoundsToolResizeFeedbackCommand extends FeedbackCommand {
     static readonly KIND = "showChangeBoundsToolResizeFeedback";
 
-    constructor(
-        @inject(TYPES.Action)
-        protected action: ShowChangeBoundsToolResizeFeedbackAction
-    ) {
-        super();
-    }
+    @inject(TYPES.Action) protected action: ShowChangeBoundsToolResizeFeedbackAction;
 
     execute(context: CommandExecutionContext): CommandReturn {
         const index = context.root.index;
@@ -80,12 +73,7 @@ export class ShowChangeBoundsToolResizeFeedbackCommand extends FeedbackCommand {
 export class HideChangeBoundsToolResizeFeedbackCommand extends FeedbackCommand {
     static readonly KIND = "hideChangeBoundsToolResizeFeedback";
 
-    constructor(
-        @inject(TYPES.Action)
-        protected action: HideChangeBoundsToolResizeFeedbackAction
-    ) {
-        super();
-    }
+    @inject(TYPES.Action) protected action: HideChangeBoundsToolResizeFeedbackAction;
 
     execute(context: CommandExecutionContext): CommandReturn {
         const index = context.root.index;
@@ -105,13 +93,14 @@ export class HideChangeBoundsToolResizeFeedbackCommand extends FeedbackCommand {
  * (see also `tools/MoveTool`).
  */
 export class FeedbackMoveMouseListener extends MouseListener {
-    hasDragged = false;
-    startDragPosition: Point | undefined;
-    elementId2startPos = new Map<string, Point>();
+    protected hasDragged = false;
+    protected startDragPosition: Point | undefined;
+    protected elementId2startPos = new Map<string, Point>();
 
     constructor(protected tool: ChangeBoundsTool) {
         super();
     }
+
     mouseDown(target: SModelElement, event: MouseEvent): Action[] {
         if (event.button === 0 && !(target instanceof SResizeHandle)) {
             const moveable = findParentByFeature(target, isMoveable);
@@ -208,6 +197,7 @@ export class FeedbackMoveMouseListener extends MouseListener {
         }
         return newPosition;
     }
+
     protected snap(position: Point, element: SModelElement, isSnap: boolean): Point {
         if (isSnap && this.tool.snapper) return this.tool.snapper.snap(position, element);
         else return position;
@@ -237,7 +227,7 @@ export class FeedbackMoveMouseListener extends MouseListener {
         return result;
     }
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, _element: SModelElement): VNode {
         return vnode;
     }
 }

--- a/packages/client/src/features/tool-feedback/creation-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/creation-tool-feedback.ts
@@ -43,8 +43,11 @@ import { getAbsolutePosition, toAbsolutePosition } from "../../utils/viewpoint-u
 import { FeedbackCommand } from "./model";
 
 export class DrawFeedbackEdgeAction implements Action {
-    kind = DrawFeedbackEdgeCommand.KIND;
-    constructor(readonly elementTypeId: string, readonly sourceId: string, readonly edgeSchema?: SEdgeSchema) { }
+    constructor(
+        public readonly elementTypeId: string,
+        public readonly sourceId: string,
+        public readonly edgeSchema?: SEdgeSchema,
+        public readonly kind: string = DrawFeedbackEdgeCommand.KIND) { }
 }
 
 @injectable()
@@ -63,8 +66,7 @@ export class DrawFeedbackEdgeCommand extends FeedbackCommand {
 }
 
 export class RemoveFeedbackEdgeAction implements Action {
-    kind = RemoveFeedbackEdgeCommand.KIND;
-    constructor() { }
+    constructor(public readonly kind: string = RemoveFeedbackEdgeCommand.KIND) { }
 }
 
 @injectable()
@@ -79,10 +81,10 @@ export class RemoveFeedbackEdgeCommand extends FeedbackCommand {
 
 export class FeedbackEdgeEnd extends SDanglingAnchor {
     static readonly TYPE = 'feedback-edge-end';
-    type = FeedbackEdgeEnd.TYPE;
     constructor(readonly sourceId: string,
         readonly elementTypeId: string,
-        public feedbackEdge: SRoutableElement | undefined = undefined) {
+        public feedbackEdge: SRoutableElement | undefined = undefined,
+        public readonly type: string = FeedbackEdgeEnd.TYPE) {
         super();
     }
 }
@@ -102,7 +104,7 @@ export class FeedbackEdgeEndMovingMouseListener extends MouseListener {
         const edge = edgeEnd.feedbackEdge;
         const position = getAbsolutePosition(edgeEnd, event);
         const endAtMousePosition = findChildrenAtPosition(target.root, position)
-            .find(e => isConnectable(e) && e.canConnect(edge, 'target'));
+            .find(element => isConnectable(element) && element.canConnect(edge, 'target'));
 
         if (endAtMousePosition instanceof SConnectableElement && edge.source && isBoundsAware(edge.source)) {
             const anchorComputer = this.anchorRegistry.get(PolylineEdgeRouter.KIND, endAtMousePosition.anchorKind);

--- a/packages/client/src/features/tool-feedback/css-feedback.ts
+++ b/packages/client/src/features/tool-feedback/css-feedback.ts
@@ -20,9 +20,13 @@ import { addCssClasses, removeCssClasses } from "../../utils/smodel-util";
 import { FeedbackCommand } from "./model";
 
 export class ModifyCSSFeedbackAction implements Action {
-    kind = ModifyCssFeedbackCommand.KIND;
-    readonly elementIds?: string[];
-    constructor(elements?: SModelElement[], readonly addClasses?: string[], readonly removeClasses?: string[]) {
+    public readonly elementIds?: string[];
+
+    constructor(
+        public readonly elements?: SModelElement[],
+        public readonly addClasses?: string[],
+        public readonly removeClasses?: string[],
+        public kind = ModifyCssFeedbackCommand.KIND) {
         if (elements) {
             this.elementIds = elements.map(elt => elt.id);
         }

--- a/packages/client/src/features/tool-feedback/css-feedback.ts
+++ b/packages/client/src/features/tool-feedback/css-feedback.ts
@@ -20,7 +20,7 @@ import { addCssClasses, removeCssClasses } from "../../utils/smodel-util";
 import { FeedbackCommand } from "./model";
 
 export class ModifyCSSFeedbackAction implements Action {
-    public readonly elementIds?: string[];
+    readonly elementIds?: string[];
 
     constructor(
         public readonly elements?: SModelElement[],

--- a/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
@@ -59,13 +59,11 @@ import { FeedbackCommand } from "./model";
  */
 
 export class ShowEdgeReconnectHandlesFeedbackAction implements Action {
-    kind = ShowEdgeReconnectHandlesFeedbackCommand.KIND;
-    constructor(readonly elementId?: string) { }
+    constructor(readonly elementId?: string, public readonly kind: string = ShowEdgeReconnectHandlesFeedbackCommand.KIND) { }
 }
 
 export class HideEdgeReconnectHandlesFeedbackAction implements Action {
-    kind = HideEdgeReconnectHandlesFeedbackCommand.KIND;
-    constructor() { }
+    constructor(public readonly kind: string = HideEdgeReconnectHandlesFeedbackCommand.KIND) { }
 }
 
 @injectable()
@@ -109,8 +107,13 @@ export class HideEdgeReconnectHandlesFeedbackCommand extends FeedbackCommand {
  */
 
 export class SwitchRoutingModeAction extends SwitchEditModeAction {
-    readonly kind = SwitchRoutingModeCommand.KIND;
+    constructor(public readonly elementsToActivate: string[] = [],
+        public readonly elementsToDeactivate: string[] = [],
+        public readonly kind: string = SwitchRoutingModeCommand.KIND) {
+        super(elementsToActivate, elementsToDeactivate);
+    }
 }
+
 @injectable()
 export class SwitchRoutingModeCommand extends SwitchEditModeCommand {
     static KIND = "switchRoutingMode";
@@ -122,10 +125,8 @@ export class SwitchRoutingModeCommand extends SwitchEditModeCommand {
  */
 
 export class DrawFeedbackEdgeSourceAction implements Action {
-    kind = DrawFeedbackEdgeSourceCommand.KIND;
-    constructor(readonly elementTypeId: string, readonly targetId: string) { }
+    constructor(readonly elementTypeId: string, readonly targetId: string, public readonly kind: string = DrawFeedbackEdgeSourceCommand.KIND) { }
 }
-
 
 @injectable()
 export class DrawFeedbackEdgeSourceCommand extends FeedbackCommand {
@@ -183,8 +184,8 @@ export class FeedbackEdgeSourceMovingMouseListener extends MouseListener {
 }
 
 export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
-    hasDragged = false;
-    lastDragPosition: Point | undefined;
+    protected hasDragged = false;
+    protected lastDragPosition: Point | undefined;
 
     constructor(protected edgeRouterRegistry?: EdgeRouterRegistry) {
         super();
@@ -258,13 +259,13 @@ export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
         return [];
     }
 
-    mouseUp(target: SModelElement, event: MouseEvent): Action[] {
+    mouseUp(_target: SModelElement, event: MouseEvent): Action[] {
         this.hasDragged = false;
         this.lastDragPosition = undefined;
         return [];
     }
 
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    decorate(vnode: VNode, _element: SModelElement): VNode {
         return vnode;
     }
 }

--- a/packages/client/src/features/tool-feedback/feedback-action-dispatcher.ts
+++ b/packages/client/src/features/tool-feedback/feedback-action-dispatcher.ts
@@ -61,10 +61,8 @@ export interface IFeedbackActionDispatcher {
 export class FeedbackActionDispatcher implements IFeedbackActionDispatcher {
     protected feedbackEmitters: Map<IFeedbackEmitter, Action[]> = new Map;
 
-    constructor(
-        @inject(TYPES.IActionDispatcherProvider) protected actionDispatcher: () => Promise<IActionDispatcher>,
-        @inject(TYPES.ILogger) protected logger: ILogger) {
-    }
+    @inject(TYPES.IActionDispatcherProvider) protected actionDispatcher: () => Promise<IActionDispatcher>;
+    @inject(TYPES.ILogger) protected logger: ILogger;
 
     registerFeedback(feedbackEmitter: IFeedbackEmitter, actions: Action[]): void {
         this.feedbackEmitters.set(feedbackEmitter, actions);

--- a/packages/client/src/features/tool-feedback/model.ts
+++ b/packages/client/src/features/tool-feedback/model.ts
@@ -20,6 +20,7 @@ export abstract class FeedbackCommand extends Command {
     readonly priority: number = 0;
 
     abstract execute(context: CommandExecutionContext): CommandReturn;
+
     undo(context: CommandExecutionContext): CommandReturn {
         return context.root;
     }

--- a/packages/client/src/features/tool-palette/palette-item.ts
+++ b/packages/client/src/features/tool-palette/palette-item.ts
@@ -31,7 +31,7 @@ export namespace PaletteItem {
     export function getTriggerAction(item?: PaletteItem): TriggerElementCreationAction | undefined {
         if (item) {
             const initiAction = item.actions.filter(a => isTriggerElementTypeCreationAction(a))
-                .map(a => a as TriggerElementCreationAction);
+                .map(action => action as TriggerElementCreationAction);
             return initiAction.length > 0 ? initiAction[0] : undefined;
         }
         return undefined;

--- a/packages/client/src/features/tools/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds-tool.ts
@@ -82,7 +82,6 @@ import { BaseGLSPTool } from "./base-glsp-tool";
 @injectable()
 export class ChangeBoundsTool extends BaseGLSPTool {
     static ID = "glsp.change-bounds-tool";
-    readonly id = ChangeBoundsTool.ID;
 
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
@@ -90,6 +89,10 @@ export class ChangeBoundsTool extends BaseGLSPTool {
     @inject(GLSP_TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
     protected feedbackMoveMouseListener: MouseListener;
     protected changeBoundsListener: MouseListener & SelectionListener;
+
+    get id(): string {
+        return ChangeBoundsTool.ID;
+    }
 
     enable() {
         // install feedback move mouse listener for client-side move updates

--- a/packages/client/src/features/tools/delete-tool.ts
+++ b/packages/client/src/features/tools/delete-tool.ts
@@ -41,7 +41,7 @@ import { IFeedbackActionDispatcher } from "../tool-feedback/feedback-action-disp
 export class DelKeyDeleteTool implements GLSPTool {
     static ID = "glsp.delete-keyboard";
 
-    public isEditTool = true;
+    isEditTool = true;
     protected deleteKeyListener: DeleteKeyListener = new DeleteKeyListener();
 
     @inject(KeyTool) protected readonly keytool: KeyTool;
@@ -80,7 +80,7 @@ export class DeleteKeyListener extends KeyListener {
 export class MouseDeleteTool implements GLSPTool {
     static ID = "glsp.delete-mouse";
 
-    public isEditTool = true;
+    isEditTool = true;
 
     protected deleteToolMouseListener: DeleteToolMouseListener = new DeleteToolMouseListener();
 

--- a/packages/client/src/features/tools/delete-tool.ts
+++ b/packages/client/src/features/tools/delete-tool.ts
@@ -40,12 +40,15 @@ import { IFeedbackActionDispatcher } from "../tool-feedback/feedback-action-disp
 @injectable()
 export class DelKeyDeleteTool implements GLSPTool {
     static ID = "glsp.delete-keyboard";
-    readonly id = DelKeyDeleteTool.ID;
 
-    isEditTool = true;
+    public isEditTool = true;
     protected deleteKeyListener: DeleteKeyListener = new DeleteKeyListener();
 
-    constructor(@inject(KeyTool) protected readonly keytool: KeyTool) { }
+    @inject(KeyTool) protected readonly keytool: KeyTool;
+
+    get id(): string {
+        return DelKeyDeleteTool.ID;
+    }
 
     enable() {
         this.keytool.register(this.deleteKeyListener);
@@ -75,14 +78,18 @@ export class DeleteKeyListener extends KeyListener {
  */
 @injectable()
 export class MouseDeleteTool implements GLSPTool {
-
     static ID = "glsp.delete-mouse";
-    readonly id = MouseDeleteTool.ID;
+
+    public isEditTool = true;
 
     protected deleteToolMouseListener: DeleteToolMouseListener = new DeleteToolMouseListener();
-    isEditTool = true;
-    constructor(@inject(GLSP_TYPES.MouseTool) protected mouseTool: IMouseTool,
-        @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected readonly feedbackDispatcher: IFeedbackActionDispatcher) { }
+
+    @inject(GLSP_TYPES.MouseTool) protected mouseTool: IMouseTool;
+    @inject(GLSP_TYPES.IFeedbackActionDispatcher) protected readonly feedbackDispatcher: IFeedbackActionDispatcher;
+
+    get id(): string {
+        return MouseDeleteTool.ID;
+    }
 
     enable() {
         this.mouseTool.register(this.deleteToolMouseListener);

--- a/packages/client/src/features/tools/edge-creation-tool.ts
+++ b/packages/client/src/features/tools/edge-creation-tool.ts
@@ -47,13 +47,16 @@ import { BaseGLSPTool } from "./base-glsp-tool";
 @injectable()
 export class EdgeCreationTool extends BaseGLSPTool implements IActionHandler {
     static ID = "tool_create_edge";
-    readonly id = EdgeCreationTool.ID;
 
     @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry;
 
     protected triggerAction: TriggerEdgeCreationAction;
     protected creationToolMouseListener: EdgeCreationToolMouseListener;
     protected feedbackEndMovingMouseListener: FeedbackEdgeEndMovingMouseListener;
+
+    get id(): string {
+        return EdgeCreationTool.ID;
+    }
 
     enable() {
         if (this.triggerAction === undefined) {
@@ -102,7 +105,7 @@ export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
         this.tool.dispatchFeedback([new RemoveFeedbackEdgeAction()]);
     }
 
-    nonDraggingMouseUp(element: SModelElement, event: MouseEvent): Action[] {
+    nonDraggingMouseUp(_element: SModelElement, event: MouseEvent): Action[] {
         const result: Action[] = [];
         if (event.button === 0) {
             if (!this.isSourceSelected()) {

--- a/packages/client/src/features/tools/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit-tool.ts
@@ -66,7 +66,10 @@ export class EdgeEditTool extends BaseGLSPTool {
     protected feedbackEdgeTargetMovingListener: FeedbackEdgeTargetMovingMouseListener;
     protected feedbackMovingListener: FeedbackEdgeRouteMovingMouseListener;
     protected edgeEditListener: EdgeEditListener;
-    readonly id = EdgeEditTool.ID;
+
+    get id(): string {
+        return EdgeEditTool.ID;
+    }
 
     enable(): void {
         this.edgeEditListener = new EdgeEditListener(this);

--- a/packages/client/src/features/tools/node-creation-tool.ts
+++ b/packages/client/src/features/tools/node-creation-tool.ts
@@ -41,12 +41,15 @@ import { BaseGLSPTool } from "./base-glsp-tool";
 @injectable()
 export class NodeCreationTool extends BaseGLSPTool implements IActionHandler {
     static ID = "tool_create_node";
-    readonly id = NodeCreationTool.ID;
 
     @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
 
     protected creationToolMouseListener: NodeCreationToolMouseListener;
     protected triggerAction: TriggerNodeCreationAction;
+
+    get id(): string {
+        return NodeCreationTool.ID;
+    }
 
     enable() {
         if (this.triggerAction === undefined) {

--- a/packages/client/src/features/undo-redo/model.ts
+++ b/packages/client/src/features/undo-redo/model.ts
@@ -17,10 +17,10 @@ import { Action } from "sprotty";
 
 export class GlspUndoAction implements Action {
     static readonly KIND = 'glspUndo';
-    readonly kind = GlspUndoAction.KIND;
+    constructor(public readonly kind = GlspUndoAction.KIND) { }
 }
 
 export class GlspRedoAction implements Action {
     static readonly KIND = 'glspRedo';
-    readonly kind = GlspRedoAction.KIND;
+    constructor(public readonly kind = GlspRedoAction.KIND) { }
 }

--- a/packages/client/src/features/validation/marker-navigator.ts
+++ b/packages/client/src/features/validation/marker-navigator.ts
@@ -45,14 +45,16 @@ import { SelectCommand, SelectionService } from "../select/selection-service";
 
 export class NavigateToMarkerAction implements Action {
     static readonly KIND = 'navigateToMarker';
-    readonly kind = NavigateToMarkerAction.KIND;
-    constructor(readonly direction: 'next' | 'previous' = 'next',
-        readonly selectedElementIds?: string[],
-        readonly severities: SIssueSeverity[] = MarkerNavigator.ALL_SEVERITIES) { }
+
+    constructor(
+        public readonly direction: 'next' | 'previous' = 'next',
+        public readonly selectedElementIds?: string[],
+        public readonly severities: SIssueSeverity[] = MarkerNavigator.ALL_SEVERITIES,
+        public kind = NavigateToMarkerAction.KIND) { }
 }
 
 export class SModelElementComparator {
-    compare(one: SModelElement, other: SModelElement): number {
+    compare(_one: SModelElement, _other: SModelElement): number {
         return 0;
     }
 }
@@ -209,6 +211,7 @@ export class NavigateToMarkerCommand extends Command {
 @injectable()
 export class MarkerNavigatorContextMenuItemProvider implements IContextMenuItemProvider {
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
+
     getItems(root: Readonly<SModelRoot>, lastMousePosition?: Point): Promise<MenuItem[]> {
         const selectedElementIds = Array.from(this.selectionService.getSelectedElementIDs());
         const hasMarkers = collectIssueMarkers(root).length > 0;
@@ -234,7 +237,7 @@ export class MarkerNavigatorContextMenuItemProvider implements IContextMenuItemP
 
 @injectable()
 export class MarkerNavigatorKeyListener extends KeyListener {
-    keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+    keyDown(_element: SModelElement, event: KeyboardEvent): Action[] {
         if (matchesKeystroke(event, 'Period', 'ctrl')) {
             return [new NavigateToMarkerAction('next')];
         } else if (matchesKeystroke(event, 'Comma', 'ctrl')) {

--- a/packages/client/src/features/validation/validate.ts
+++ b/packages/client/src/features/validation/validate.ts
@@ -77,8 +77,7 @@ export class ValidationFeedbackEmitter implements IFeedbackEmitter {
  * Action to set markers for a model
  */
 export class SetMarkersAction implements MarkersAction {
-    readonly kind = SetMarkersCommand.KIND;
-    constructor(public readonly markers: Marker[]) { }
+    constructor(public readonly markers: Marker[], public readonly kind = SetMarkersCommand.KIND) { }
 }
 
 export function isSetMarkersAction(action: Action): action is SetMarkersAction {
@@ -94,7 +93,7 @@ export function isSetMarkersAction(action: Action): action is SetMarkersAction {
 @injectable()
 export abstract class ExternalMarkerManager {
 
-    languageLabel: string;
+    public languageLabel: string;
 
     protected actionDispatcher?: IActionDispatcher;
 
@@ -150,11 +149,8 @@ export class SetMarkersCommand extends Command {
 * Action to retrieve markers for a model
 */
 export class RequestMarkersAction implements Action {
-
     static readonly KIND = 'requestMarkers';
-    readonly kind = RequestMarkersAction.KIND;
-
-    constructor(public readonly elementsIDs: string[] = []) { }
+    constructor(public readonly elementsIDs: string[] = [], public readonly kind = RequestMarkersAction.KIND) { }
 }
 
 /**
@@ -169,8 +165,7 @@ export interface MarkersAction extends Action {
  */
 @injectable()
 export class ApplyMarkersAction implements MarkersAction {
-    readonly kind = ApplyMarkersCommand.KIND;
-    constructor(public readonly markers: Marker[]) { }
+    constructor(public readonly markers: Marker[], public readonly kind = ApplyMarkersCommand.KIND) { }
 }
 
 /**
@@ -229,8 +224,7 @@ function removeCSSClassFromIssueParent(modelElement: SParentElement, issueMarker
  */
 @injectable()
 export class ClearMarkersAction implements MarkersAction {
-    readonly kind = ClearMarkersCommand.KIND;
-    constructor(public readonly markers: Marker[]) { }
+    constructor(public readonly markers: Marker[], public readonly kind = ClearMarkersCommand.KIND) { }
 }
 
 /**

--- a/packages/client/src/features/validation/validate.ts
+++ b/packages/client/src/features/validation/validate.ts
@@ -93,7 +93,7 @@ export function isSetMarkersAction(action: Action): action is SetMarkersAction {
 @injectable()
 export abstract class ExternalMarkerManager {
 
-    public languageLabel: string;
+    languageLabel: string;
 
     protected actionDispatcher?: IActionDispatcher;
 

--- a/packages/client/src/model-source/glsp-diagram-server.ts
+++ b/packages/client/src/model-source/glsp-diagram-server.ts
@@ -35,6 +35,7 @@ import { RequestTypeHintsAction } from "../features/hints/request-type-hints-act
 import { isServerMessageAction, ServerMessageAction } from "./glsp-server-status";
 
 const receivedFromServerProperty = '__receivedFromServer';
+
 @injectable()
 export class GLSPDiagramServer extends DiagramServer implements SourceUriAware {
     protected _sourceUri: string;
@@ -72,7 +73,6 @@ export class GLSPDiagramServer extends DiagramServer implements SourceUriAware {
         return super.handle(action);
     }
 
-
     handleLocally(action: Action): boolean {
         if (isServerMessageAction(action)) {
             return this.handleServerMessageAction(action);
@@ -82,12 +82,13 @@ export class GLSPDiagramServer extends DiagramServer implements SourceUriAware {
         }
         return super.handleLocally(action);
     }
+
     protected handleServerMessageAction(action: ServerMessageAction): boolean {
         this.logger.log('GLSPDiagramServer', `[${action.severity}] -${action.message}`);
         return false;
     }
 
-    protected handleComputedBounds(action: ComputedBoundsAction): boolean {
+    protected handleComputedBounds(_action: ComputedBoundsAction): boolean {
         return true;
     }
 

--- a/packages/protocol/src/glsp-client.ts
+++ b/packages/protocol/src/glsp-client.ts
@@ -23,6 +23,7 @@ export interface InitializeParameters<> {
     applicationId: string;
     options?: any
 }
+
 export class ApplicationIdProvider {
     private static _applicationId?: string;
     static get(): string {
@@ -32,6 +33,7 @@ export class ApplicationIdProvider {
         return ApplicationIdProvider._applicationId;
     }
 }
+
 export type ActionMessageHandler = (message: ActionMessage) => void;
 
 export enum ClientState {


### PR DESCRIPTION
- Use property injection over constructor injection
- Avoid readonly properties in classes that should be customizable

Fixes https://github.com/eclipse-glsp/glsp/issues/66
Fixes https://github.com/eclipse-glsp/glsp/issues/72

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>