### PR TITLE
Generalize input for ModifyCSSFeedbackAction

### DIFF
--- a/packages/client/src/features/tool-feedback/css-feedback.ts
+++ b/packages/client/src/features/tool-feedback/css-feedback.ts
@@ -16,6 +16,7 @@
 import { inject, injectable } from "inversify";
 import { Action, CommandExecutionContext, SModelElement, SModelRoot, TYPES } from "sprotty";
 
+import { isStringArray } from "../../utils/array-utils";
 import { addCssClasses, removeCssClasses } from "../../utils/smodel-util";
 import { FeedbackCommand } from "./model";
 
@@ -23,12 +24,12 @@ export class ModifyCSSFeedbackAction implements Action {
     readonly elementIds?: string[];
 
     constructor(
-        public readonly elements?: SModelElement[],
+        public readonly input?: string[] | SModelElement[],
         public readonly addClasses?: string[],
         public readonly removeClasses?: string[],
         public kind = ModifyCssFeedbackCommand.KIND) {
-        if (elements) {
-            this.elementIds = elements.map(elt => elt.id);
+        if (input) {
+            this.elementIds = isStringArray(input) ? input : input.map(element => element.id);
         }
     }
 }

--- a/packages/client/src/utils/array-utils.ts
+++ b/packages/client/src/utils/array-utils.ts
@@ -31,4 +31,25 @@ export function distinctAdd<T>(array: T[], value: T): boolean {
     return false;
 }
 
+interface Constructor<T> { new(...args: any[]): T }
+type PrimitiveType = 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined';
 
+export function isArrayOfType<T>(object: any, typeGuard: (elem: any) => elem is T, supportEmpty = false): object is T[] {
+    return isArrayMatching(object, element => typeGuard(element), supportEmpty);
+}
+
+export function isArrayOfClass<T>(object: any, className: Constructor<T>, supportEmpty = false): object is T[] {
+    return isArrayMatching(object, element => element instanceof className, supportEmpty);
+}
+
+export function isArrayOfPrimitive<T>(object: any, primitiveType: PrimitiveType, supportEmpty = false): object is T[] {
+    return isArrayMatching(object, element => typeof element === primitiveType, supportEmpty);
+}
+
+export function isStringArray(object: any, supportEmpty = false): object is string[] {
+    return isArrayOfPrimitive(object, 'string', supportEmpty);
+}
+
+export function isArrayMatching(object: any, predicate: (elem: any) => boolean, supportEmpty = false): boolean {
+    return Array.isArray(object) && object.every(predicate) && (supportEmpty || object.length > 0);
+}


### PR DESCRIPTION
Adapt `ModifyCSSFeedbackAction` to support both a string[] with the smodel ids or a SModelElement[] as input.