### PR TITLE
#180: Provide default model and view registrations and add views

### DIFF
--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -20,15 +20,16 @@ import 'sprotty/css/edit-label.css';
 import {
     boundsModule,
     buttonModule,
+    configureDefaultModelElement,
     configureModelElement,
     ConsoleLogger,
     defaultGLSPModule,
     defaultModule,
+    DefaultTypes,
     DeleteElementContextMenuItemProvider,
     DiamondNodeView,
     edgeLayoutModule,
     editLabelFeature,
-    ExpandButtonView,
     expandModule,
     exportModule,
     fadeModule,
@@ -37,15 +38,12 @@ import {
     glspContextMenuModule,
     glspDecorationModule,
     glspEditLabelModule,
-    GLSPGraph,
     glspHoverModule,
     glspMouseToolModule,
     glspSelectModule,
     glspServerCopyPasteModule,
     glspViewportModule,
     GridSnapper,
-    HtmlRoot,
-    HtmlRootView,
     labelEditUiModule,
     layoutCommandsModule,
     LogLevel,
@@ -58,19 +56,13 @@ import {
     openModule,
     overrideViewerOptions,
     paletteModule,
-    PreRenderedElement,
-    PreRenderedView,
     RevealNamedElementActionProvider,
     routingModule,
-    SButton,
     SCompartment,
     SCompartmentView,
     SEdge,
-    SGraphView,
     SLabel,
     SLabelView,
-    SRoutingHandle,
-    SRoutingHandleView,
     toolFeedbackModule,
     toolsModule,
     TYPES,
@@ -91,19 +83,15 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
     bind(TYPES.IContextMenuItemProvider).to(DeleteElementContextMenuItemProvider);
     const context = { bind, unbind, isBound, rebind };
-    configureModelElement(context, 'graph', GLSPGraph, SGraphView);
+
+    configureDefaultModelElement(context);
     configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);
     configureModelElement(context, 'task:manual', TaskNode, TaskNodeView);
     configureModelElement(context, 'label:heading', SLabel, SLabelView, { enable: [editLabelFeature] });
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
     configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
     configureModelElement(context, 'label:icon', SLabel, SLabelView);
-    configureModelElement(context, 'html', HtmlRoot, HtmlRootView);
-    configureModelElement(context, 'pre-rendered', PreRenderedElement, PreRenderedView);
-    configureModelElement(context, 'button:expand', SButton, ExpandButtonView);
-    configureModelElement(context, 'routing-point', SRoutingHandle, SRoutingHandleView);
-    configureModelElement(context, 'volatile-routing-point', SRoutingHandle, SRoutingHandleView);
-    configureModelElement(context, 'edge', SEdge, WorkflowEdgeView);
+    configureModelElement(context, DefaultTypes.EDGE, SEdge, WorkflowEdgeView);
     configureModelElement(context, 'edge:weighted', WeightedEdge, WeightedEdgeView);
     configureModelElement(context, 'icon', Icon, IconView);
     configureModelElement(context, 'activityNode:merge', ActivityNode, DiamondNodeView);
@@ -115,7 +103,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
 export default function createContainer(widgetId: string): Container {
     const container = new Container();
 
-    container.load(validationModule, defaultModule, glspMouseToolModule, defaultGLSPModule, glspSelectModule, boundsModule, glspViewportModule, toolsModule,
+    container.load(defaultModule, defaultGLSPModule, glspMouseToolModule, validationModule, glspSelectModule, boundsModule, glspViewportModule, toolsModule,
         glspHoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule, labelEditUiModule, glspEditLabelModule,
         workflowDiagramModule, toolFeedbackModule, modelHintsModule, glspContextMenuModule, glspServerCopyPasteModule, modelSourceWatcherModule,
         glspCommandPaletteModule, paletteModule, routingModule, glspDecorationModule, edgeLayoutModule, zorderModule,

--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -20,7 +20,7 @@ import 'sprotty/css/edit-label.css';
 import {
     boundsModule,
     buttonModule,
-    configureDefaultModelElement,
+    configureDefaultModelElements,
     configureModelElement,
     ConsoleLogger,
     defaultGLSPModule,
@@ -84,7 +84,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     bind(TYPES.IContextMenuItemProvider).to(DeleteElementContextMenuItemProvider);
     const context = { bind, unbind, isBound, rebind };
 
-    configureDefaultModelElement(context);
+    configureDefaultModelElements(context);
     configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);
     configureModelElement(context, 'task:manual', TaskNode, TaskNodeView);
     configureModelElement(context, 'label:heading', SLabel, SLabelView, { enable: [editLabelFeature] });

--- a/examples/workflow-glsp/src/workflow-views.tsx
+++ b/examples/workflow-glsp/src/workflow-views.tsx
@@ -43,9 +43,9 @@ export class TaskNodeView extends RoundedCornerNodeView {
         const task = node as TaskNode;
         const rcr = this.getRoundedCornerRadius(task);
         const graph = <g>
-            <rect class-sprotty-node={true}
-                x={0} y={0} rx={rcr} ry={rcr}
+            <rect class-sprotty-node={true} class-selected={node.selected} class-mouseover={node.hoverFeedback}
                 {...this.additionalClasses(task, context)}
+                x={0} y={0} rx={rcr} ry={rcr}
                 width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
             {context.renderChildren(node)}
         </g>;
@@ -56,7 +56,7 @@ export class TaskNodeView extends RoundedCornerNodeView {
         return 5;
     }
 
-    protected additionalClasses(element: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): Classes {
+    protected additionalClasses(element: Readonly<SShapeElement & Hoverable & Selectable>, _context: RenderingContext): Classes {
         const node = element as TaskNode;
         return {
             'class-task': true,

--- a/examples/workflow-glsp/src/workflow-views.tsx
+++ b/examples/workflow-glsp/src/workflow-views.tsx
@@ -15,17 +15,21 @@
  ********************************************************************************/
 import {
     angleOfPoint,
+    GEdgeView,
+    Hoverable,
     IView,
     Point,
-    PolylineEdgeView,
     RectangularNodeView,
     RenderingContext,
+    RoundedCornerNodeView,
     SEdge,
+    Selectable,
     SShapeElement,
     toDegrees
 } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 import * as snabbdom from 'snabbdom-jsx';
+import { Classes } from 'snabbdom/modules/class';
 import { VNode } from 'snabbdom/vnode';
 
 import { ActivityNode, Icon, TaskNode, WeightedEdge } from './model';
@@ -34,23 +38,31 @@ import { ActivityNode, Icon, TaskNode, WeightedEdge } from './model';
 const JSX = { createElement: snabbdom.svg };
 
 @injectable()
-export class TaskNodeView extends RectangularNodeView {
-    render(node: TaskNode, context: RenderingContext): VNode {
-        const rcr = this.getRoundedCornerRadius(node);
+export class TaskNodeView extends RoundedCornerNodeView {
+    protected renderWithoutRadius(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode {
+        const task = node as TaskNode;
+        const rcr = this.getRoundedCornerRadius(task);
         const graph = <g>
-            <rect class-sprotty-node={true} class-task={true}
-                class-automated={node.taskType === 'automated'}
-                class-manual={node.taskType === 'manual'}
-                class-mouseover={node.hoverFeedback} class-selected={node.selected}
+            <rect class-sprotty-node={true}
                 x={0} y={0} rx={rcr} ry={rcr}
-                width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)}></rect>
+                {...this.additionalClasses(task, context)}
+                width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
             {context.renderChildren(node)}
         </g>;
         return graph;
     }
 
-    protected getRoundedCornerRadius(node: SShapeElement): number {
+    protected getRoundedCornerRadius(_node: TaskNode): number {
         return 5;
+    }
+
+    protected additionalClasses(element: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): Classes {
+        const node = element as TaskNode;
+        return {
+            'class-task': true,
+            'class-automated': node.taskType === 'automated',
+            'class-manual': node.taskType === 'manual'
+        };
     }
 }
 
@@ -67,36 +79,28 @@ export class ForkOrJoinNodeView extends RectangularNodeView {
 }
 
 @injectable()
-export class WorkflowEdgeView extends PolylineEdgeView {
+export class WorkflowEdgeView extends GEdgeView {
     protected renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
+        const additionals = super.renderAdditionals(edge, segments, context);
         const p1 = segments[segments.length - 2];
         const p2 = segments[segments.length - 1];
-        return [
-            <path class-sprotty-edge={true} class-arrow={true} d="M 1.5,0 L 10,-4 L 10,4 Z"
-                transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`} />
-        ];
+        const arrow = <path class-sprotty-edge={true} class-arrow={true} d='M 1.5,0 L 10,-4 L 10,4 Z'
+            transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`} />;
+        additionals.push(arrow);
+        return additionals;
     }
 }
 
 @injectable()
 export class WeightedEdgeView extends WorkflowEdgeView {
-    render(edge: Readonly<WeightedEdge>, context: RenderingContext): VNode {
-        const router = this.edgeRouterRegistry.get(edge.routerKind);
-        const route = router.route(edge);
-        if (route.length === 0) {
-            return this.renderDanglingEdge('Cannot compute route', edge, context);
-        }
-
-        return <g class-sprotty-edge={true}
-            class-weighted={true}
-            class-low={edge.probability === 'low'}
-            class-medium={edge.probability === 'medium'}
-            class-high={edge.probability === 'high'}
-            class-mouseover={edge.hoverFeedback}>
-            {this.renderLine(edge, route, context)}
-            {this.renderAdditionals(edge, route, context)}
-            {context.renderChildren(edge, { route })}
-        </g>;
+    protected addtionalClasses(edge: Readonly<SEdge>, _context: RenderingContext): Classes {
+        const wedge = edge as WeightedEdge;
+        return {
+            'class-no-probability': !wedge.probability,
+            'class-low': wedge.probability === 'low',
+            'class-medium': wedge.probability === 'medium',
+            'class-high': wedge.probability === 'high'
+        };
     }
 }
 

--- a/packages/client/src/base/di.config.ts
+++ b/packages/client/src/base/di.config.ts
@@ -26,10 +26,12 @@ import { GLSPCommandStack } from './command-stack';
 import { EditorContextService } from './editor-context';
 import { FocusTracker } from './focus-tracker';
 import { DefaultModelInitializationConstraint, ModelInitializationConstraint } from './model-initialization-constraint';
+import { GLSPModelRegistry } from './model/model-registry';
 import { FeedbackAwareUpdateModelCommand, SetModelActionHandler } from './model/update-model-command';
 import { SelectionClearingMouseListener } from './selection-clearing-mouse-listener';
 import { GLSPToolManager } from './tool-manager/glsp-tool-manager';
 import { GLSP_TYPES } from './types';
+import { GLSPViewRegistry } from './view/view-registry';
 
 const defaultGLSPModule = new ContainerModule((bind, _unbind, isBound, rebind) => {
     const context = { bind, _unbind, isBound, rebind };
@@ -64,6 +66,10 @@ const defaultGLSPModule = new ContainerModule((bind, _unbind, isBound, rebind) =
     rebind(TYPES.IActionDispatcher).toService(GLSPActionDispatcher);
 
     bind(ModelInitializationConstraint).to(DefaultModelInitializationConstraint).inSingletonScope();
+
+    // support re-registration of model elements and views
+    rebind(TYPES.SModelRegistry).to(GLSPModelRegistry).inSingletonScope();
+    rebind(TYPES.ViewRegistry).to(GLSPViewRegistry).inSingletonScope();
 });
 
 export default defaultGLSPModule;

--- a/packages/client/src/base/model/model-registry.ts
+++ b/packages/client/src/base/model/model-registry.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,16 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import '../../../css/decoration.css';
+import { injectable } from 'inversify';
+import { SModelElement, SModelRegistry } from 'sprotty';
 
-import { ContainerModule } from 'inversify';
-import { TYPES } from 'sprotty';
-
-import { GlspDecorationPlacer } from './decoration-placer';
-
-const glspDecorationModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(GlspDecorationPlacer).toSelf().inSingletonScope();
-    bind(TYPES.IVNodePostprocessor).toService(GlspDecorationPlacer);
-});
-
-export default glspDecorationModule;
+@injectable()
+export class GLSPModelRegistry extends SModelRegistry {
+    register(key: string, factory: (u: void) => SModelElement): void {
+        if (key === undefined) {
+            throw new Error('Key is undefined');
+        }
+        if (this.hasKey(key)) {
+            // do not throw error but log overwriting
+            console.log(`Factory for model element '${key}' will be overwritten.`);
+        }
+        this.elements.set(key, factory);
+    }
+}

--- a/packages/client/src/base/view/view-registry.ts
+++ b/packages/client/src/base/view/view-registry.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,16 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import '../../../css/decoration.css';
+import { injectable } from 'inversify';
+import { IView, ViewRegistry } from 'sprotty';
 
-import { ContainerModule } from 'inversify';
-import { TYPES } from 'sprotty';
-
-import { GlspDecorationPlacer } from './decoration-placer';
-
-const glspDecorationModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(GlspDecorationPlacer).toSelf().inSingletonScope();
-    bind(TYPES.IVNodePostprocessor).toService(GlspDecorationPlacer);
-});
-
-export default glspDecorationModule;
+@injectable()
+export class GLSPViewRegistry extends ViewRegistry {
+    register(key: string, instance: IView): void {
+        if (key === undefined) {
+            throw new Error('Key is undefined');
+        }
+        if (this.hasKey(key)) {
+            // do not throw error but log overwriting
+            console.log(`View instance for type '${key}' will be overwritten.`);
+        }
+        this.elements.set(key, instance);
+    }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -49,11 +49,13 @@ export * from './base/drag-aware-mouse-listener';
 export * from './base/editor-context';
 export * from './base/focus-tracker';
 export * from './base/model-initialization-constraint';
+export * from './base/model/model-registry';
 export * from './base/model/update-model-command';
 export * from './base/operations/operation';
 export * from './base/selection-clearing-mouse-listener';
 export * from './base/source-uri-aware';
 export * from './base/types';
+export * from './base/view/view-registry';
 export * from './features/change-bounds/model';
 export * from './features/change-bounds/movement-restrictor';
 export * from './features/change-bounds/snap';
@@ -61,7 +63,6 @@ export * from './features/command-palette/server-command-palette-provider';
 export * from './features/context-menu/delete-element-context-menu';
 export * from './features/copy-paste/copy-paste-handler';
 export * from './features/decoration/decoration-placer';
-export * from './features/decoration/view';
 export * from './features/edit-label/edit-label-tool';
 export * from './features/edit-label/edit-label-validator';
 export * from './features/hints/model';
@@ -100,10 +101,13 @@ export * from './features/viewport/glsp-scroll-mouse-listener';
 export * from './lib/model';
 export * from './model-source/glsp-server-status';
 export * from './model-source/glsp-diagram-server';
+export * from './utils/argument-utils';
 export * from './utils/array-utils';
 export * from './utils/marker';
 export * from './utils/smodel-util';
 export * from './utils/viewpoint-util';
+export * from './views';
+
 export {
     validationModule, saveModule, paletteModule, toolFeedbackModule, defaultGLSPModule, modelHintsModule, glspCommandPaletteModule,
     glspContextMenuModule, glspServerCopyPasteModule, copyPasteContextMenuModule, glspSelectModule, glspMouseToolModule, layoutCommandsModule, glspEditLabelModule,

--- a/packages/client/src/utils/argument-utils.ts
+++ b/packages/client/src/utils/argument-utils.ts
@@ -1,0 +1,127 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { SModelElement } from 'sprotty';
+
+import { hasArguments } from '../base/args';
+
+export namespace GArgument {
+    export function asNumber(argValue: (string | number | boolean)): number | undefined {
+        return typeof argValue === 'number' ? argValue : undefined;
+    }
+
+    export function asNumbers(argValues: (string | number | boolean)[]): (number | undefined)[] {
+        return argValues.map(asNumber);
+    }
+
+    export function asString(argValue: (string | number | boolean)): string | undefined {
+        return typeof argValue === 'string' ? argValue : undefined;
+    }
+
+    export function asStrings(argValues: (string | number | boolean)[]): (string | undefined)[] {
+        return argValues.map(asString);
+    }
+
+    export function asBoolean(argValue: (string | number | boolean)): boolean | undefined {
+        return typeof argValue === 'boolean' ? argValue : undefined;
+    }
+
+    export function asBooleans(argValues: (string | number | boolean)[]): (boolean | undefined)[] {
+        return argValues.map(asBoolean);
+    }
+
+    export function getArgument(element: SModelElement | undefined, key: string): string | number | boolean | undefined {
+        return hasArguments(element) ? element.args[key] : undefined;
+    }
+
+    export function getNumber(element: SModelElement | undefined, key: string): number | undefined {
+        return hasArguments(element) ? asNumber(element.args[key]) : undefined;
+    }
+
+    export function getString(element: SModelElement | undefined, key: string): string | undefined {
+        return hasArguments(element) ? asString(element.args[key]) : undefined;
+    }
+
+    export function getBoolean(element: SModelElement | undefined, key: string): boolean | undefined {
+        return hasArguments(element) ? asBoolean(element.args[key]) : undefined;
+    }
+
+    export function getArguments(element: SModelElement | undefined, ...keys: string[]): (number | boolean | string)[] | undefined {
+        if (!hasArguments(element)) {
+            return undefined;
+        }
+        const values = [];
+        for (const key of keys) {
+            const value = element.args[key];
+            if (value) {
+                values.push(value);
+            }
+        }
+        return values;
+    }
+
+    export function getNumbers(element: SModelElement | undefined, ...keys: string[]): (number | undefined)[] | undefined {
+        const values = getArguments(element, ...keys);
+        return values ? asNumbers(values) : undefined;
+    }
+
+    export function getStrings(element: SModelElement | undefined, ...keys: string[]): (string | undefined)[] | undefined {
+        const values = getArguments(element, ...keys);
+        return values ? asStrings(values) : undefined;
+    }
+
+    export function getBooleans(element: SModelElement | undefined, ...keys: string[]): (boolean | undefined)[] | undefined {
+        const values = getArguments(element, ...keys);
+        return values ? asBooleans(values) : undefined;
+    }
+
+    export function hasNValues<T>(values: (T | undefined)[], length: number): values is T[] {
+        return values.length === length && values.filter(e => e === undefined).length === 0;
+    }
+}
+
+export namespace EdgePadding {
+    const KEY = 'edgePadding';
+
+    export function from(element: SModelElement | undefined): number | undefined {
+        return GArgument.getNumber(element, KEY);
+    }
+}
+
+export class CornerRadius {
+    static NO_RADIUS = new CornerRadius(0);
+
+    static KEY_RADIUS_TOP_LEFT = 'radiusTopLeft';
+    static KEY_RADIUS_TOP_RIGHT = 'radiusTopRight';
+    static KEY_RADIUS_BOTTOM_RIGHT = 'radiusBottomRight';
+    static KEY_RADIUS_BOTTOM_LEFT = 'radiusBottomLeft';
+
+    constructor(
+        public readonly topLeft: number = 0,
+        public readonly topRight: number = topLeft,
+        public readonly bottomRight: number = topLeft,
+        public readonly bottomLeft: number = topRight) {
+    }
+
+    static from(element: SModelElement | undefined): CornerRadius | undefined {
+        const radius = GArgument.getNumbers(element, this.KEY_RADIUS_TOP_LEFT, this.KEY_RADIUS_TOP_RIGHT, this.KEY_RADIUS_BOTTOM_RIGHT, this.KEY_RADIUS_BOTTOM_LEFT);
+        if (radius === undefined || radius[0] === undefined) {
+            return undefined;
+        }
+        return GArgument.hasNValues(radius, 4)
+            ? new CornerRadius(radius[0], radius[1], radius[2], radius[3])
+            : new CornerRadius(radius[0]);
+    }
+}

--- a/packages/client/src/views/base-view-module.ts
+++ b/packages/client/src/views/base-view-module.ts
@@ -1,0 +1,98 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+import {
+    CircularNode,
+    CircularNodeView,
+    configureModelElement,
+    DiamondNode,
+    DiamondNodeView,
+    ExpandButtonView,
+    ForeignObjectElement,
+    ForeignObjectView,
+    HtmlRoot,
+    HtmlRootView,
+    PreRenderedElement,
+    PreRenderedView,
+    RectangularNode,
+    RectangularNodeView,
+    SButton,
+    SCompartment,
+    SCompartmentView,
+    SEdge,
+    SGraphView,
+    ShapedPreRenderedElement,
+    SIssueMarker,
+    SLabel,
+    SLabelView,
+    SNode,
+    SPort,
+    SRoutingHandle,
+    SRoutingHandleView,
+    SvgViewportView,
+    ViewportRootElement
+} from 'sprotty';
+
+import { GLSPGraph } from '../lib/model';
+import { DefaultTypes } from './default-types';
+import { GEdgeView } from './glsp-edge-view';
+import { GIssueMarkerView } from './issue-marker-view';
+import { RoundedCornerNodeView } from './rounded-corner-view';
+
+interface ContainerContext {
+    bind: interfaces.Bind;
+    isBound: interfaces.IsBound;
+}
+
+const baseViewModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    const context = { bind, unbind, isBound, rebind };
+    configureDefaultModelElement(context);
+});
+
+export function configureDefaultModelElement(context: ContainerContext): void {
+    // HTML elements
+    configureModelElement(context, DefaultTypes.HTML, HtmlRoot, HtmlRootView);
+
+    // generic elements
+    configureModelElement(context, DefaultTypes.FOREIGN_OBJECT, ForeignObjectElement, ForeignObjectView);
+    configureModelElement(context, DefaultTypes.PRE_RENDERED, PreRenderedElement, PreRenderedView);
+    configureModelElement(context, DefaultTypes.SHAPE_PRE_RENDERED, ShapedPreRenderedElement, PreRenderedView);
+
+    // SVG elements
+    configureModelElement(context, DefaultTypes.SVG, ViewportRootElement, SvgViewportView);
+
+    // graph elements
+    configureModelElement(context, DefaultTypes.GRAPH, GLSPGraph, SGraphView);
+    configureModelElement(context, DefaultTypes.NODE, SNode, RoundedCornerNodeView);
+    configureModelElement(context, DefaultTypes.COMPARTMENT, SCompartment, SCompartmentView);
+    configureModelElement(context, DefaultTypes.COMPARTMENT_HEADER, SCompartment, SCompartmentView);
+    configureModelElement(context, DefaultTypes.EDGE, SEdge, GEdgeView);
+    configureModelElement(context, DefaultTypes.PORT, SPort, RectangularNodeView);
+    configureModelElement(context, DefaultTypes.ROUTING_POINT, SRoutingHandle, SRoutingHandleView);
+    configureModelElement(context, DefaultTypes.VOLATILE_ROUTING_POINT, SRoutingHandle, SRoutingHandleView);
+    configureModelElement(context, DefaultTypes.LABEL, SLabel, SLabelView);
+
+    // UI elements
+    configureModelElement(context, DefaultTypes.BUTTON_EXPAND, SButton, ExpandButtonView);
+    configureModelElement(context, DefaultTypes.ISSUE_MARKER, SIssueMarker, GIssueMarkerView);
+
+    // shapes
+    configureModelElement(context, DefaultTypes.NODE_CIRCLE, CircularNode, CircularNodeView);
+    configureModelElement(context, DefaultTypes.NODE_DIAMOND, DiamondNode, DiamondNodeView);
+    configureModelElement(context, DefaultTypes.NODE_RECTANGLE, RectangularNode, RectangularNodeView);
+}
+
+export default baseViewModule;

--- a/packages/client/src/views/base-view-module.ts
+++ b/packages/client/src/views/base-view-module.ts
@@ -59,10 +59,10 @@ interface ContainerContext {
 
 const baseViewModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
-    configureDefaultModelElement(context);
+    configureDefaultModelElements(context);
 });
 
-export function configureDefaultModelElement(context: ContainerContext): void {
+export function configureDefaultModelElements(context: ContainerContext): void {
     // HTML elements
     configureModelElement(context, DefaultTypes.HTML, HtmlRoot, HtmlRootView);
 

--- a/packages/client/src/views/default-types.ts
+++ b/packages/client/src/views/default-types.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export namespace DefaultTypes {
+    // HTML elements
+    export const HTML = 'html';
+
+    // generic types
+    export const FOREIGN_OBJECT = 'foreign-object';
+    export const PRE_RENDERED = 'pre-rendered';
+    export const SHAPE_PRE_RENDERED = 'shape-pre-rendered';
+
+    // SVG elements
+    export const SVG = 'svg';
+
+    // graph types
+    export const GRAPH = 'graph';
+    export const NODE = 'node';
+    export const COMPARTMENT = 'comp';
+    export const COMPARTMENT_HEADER = 'comp:header';
+    export const EDGE = 'edge';
+    export const PORT = 'port';
+    export const ROUTING_POINT = 'routing-point';
+    export const VOLATILE_ROUTING_POINT = `volatile-${ROUTING_POINT}`;
+    export const LABEL = 'label';
+
+    // UI elements
+    export const BUTTON_EXPAND = 'button:expand';
+    export const ISSUE_MARKER = 'marker';
+
+    // shapes
+    export const NODE_CIRCLE = 'node:circle';
+    export const NODE_RECTANGLE = 'node:rectangle';
+    export const NODE_DIAMOND = 'node:diamond';
+}

--- a/packages/client/src/views/glsp-edge-view.tsx
+++ b/packages/client/src/views/glsp-edge-view.tsx
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from 'inversify';
+import * as snabbdom from 'snabbdom-jsx';
+import { Classes } from 'snabbdom/modules/class';
+import { VNode } from 'snabbdom/vnode';
+import { Point, PolylineEdgeView, RenderingContext, SEdge } from 'sprotty';
+
+import { EdgePadding } from '../utils/argument-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const JSX = { createElement: snabbdom.svg };
+
+@injectable()
+export class GEdgeView extends PolylineEdgeView {
+    render(edge: Readonly<SEdge>, context: RenderingContext): VNode {
+        const router = this.edgeRouterRegistry.get(edge.routerKind);
+        const route = router.route(edge);
+        if (route.length === 0) {
+            return this.renderDanglingEdge('Cannot compute route', edge, context);
+        }
+
+        return <g class-sprotty-edge={true} class-mouseover={edge.hoverFeedback} {...this.addtionalClasses(edge, context)}>
+            {this.renderLine(edge, route, context)}
+            {this.renderAdditionals(edge, route, context)}
+            {context.renderChildren(edge, { route })}
+        </g>;
+    }
+
+    protected addtionalClasses(_edge: Readonly<SEdge>, _context: RenderingContext): Classes {
+        return {};
+    }
+
+    protected renderLine(_edge: SEdge, segments: Point[], _context: RenderingContext): VNode {
+        return <path d={this.createPathForSegments(segments)} />;
+    }
+
+    protected renderAdditionals(edge: SEdge, segments: Point[], _context: RenderingContext): VNode[] {
+        // for additional padding we draw another transparent path with larger stroke width
+        const edgePadding = EdgePadding.from(edge);
+        return edgePadding ? [this.renderMouseHandle(segments, edgePadding)] : [];
+    }
+
+    protected renderMouseHandle(segments: Point[], padding: number): VNode {
+        return <path class-mouse-handle d={this.createPathForSegments(segments)}
+            style-stroke-width={padding * 2} style-stroke="transparent" style-stroke-dasharray="none" style-stroke-dashoffset="0" />;
+    }
+
+    protected createPathForSegments(segments: Point[]): string {
+        const firstPoint = segments[0];
+        let path = `M ${firstPoint.x},${firstPoint.y}`;
+        for (let i = 1; i < segments.length; i++) {
+            const p = segments[i];
+            path += ` L ${p.x},${p.y}`;
+        }
+        return path;
+    }
+
+}

--- a/packages/client/src/views/index.ts
+++ b/packages/client/src/views/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,16 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import '../../../css/decoration.css';
-
-import { ContainerModule } from 'inversify';
-import { TYPES } from 'sprotty';
-
-import { GlspDecorationPlacer } from './decoration-placer';
-
-const glspDecorationModule = new ContainerModule((bind, _unbind, isBound) => {
-    bind(GlspDecorationPlacer).toSelf().inSingletonScope();
-    bind(TYPES.IVNodePostprocessor).toService(GlspDecorationPlacer);
-});
-
-export default glspDecorationModule;
+export * from './base-view-module';
+export * from './default-types';
+export * from './glsp-edge-view';
+export * from './issue-marker-view';
+export * from './rounded-corner';
+export * from './rounded-corner-view';

--- a/packages/client/src/views/issue-marker-view.tsx
+++ b/packages/client/src/views/issue-marker-view.tsx
@@ -23,7 +23,7 @@ import { IssueMarkerView, RenderingContext, setClass, SIssueMarker, SIssueSeveri
 const JSX = { createElement: snabbdom.svg };
 
 @injectable()
-export class GlspIssueMarkerView extends IssueMarkerView {
+export class GIssueMarkerView extends IssueMarkerView {
 
     render(marker: SIssueMarker, _context: RenderingContext): VNode {
         const maxSeverity = super.getMaxSeverity(marker);

--- a/packages/client/src/views/rounded-corner-view.tsx
+++ b/packages/client/src/views/rounded-corner-view.tsx
@@ -1,0 +1,90 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from 'inversify';
+import * as snabbdom from 'snabbdom-jsx';
+import { Classes } from 'snabbdom/modules/class';
+import { VNode } from 'snabbdom/vnode';
+import { Hoverable, RectangularNodeView, RenderingContext, Selectable, SNode, SPort, SShapeElement } from 'sprotty/lib';
+
+import { CornerRadius } from '../utils/argument-utils';
+import { RoundedCornerWrapper } from './rounded-corner';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const JSX = { createElement: snabbdom.svg };
+
+@injectable()
+export class RoundedCornerNodeView extends RectangularNodeView {
+    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
+        const cornerRadius = CornerRadius.from(node);
+        if (!cornerRadius) {
+            return this.renderWithoutRadius(node, context);
+        }
+
+        const wrapper = new RoundedCornerWrapper(node, cornerRadius);
+        return <g class-node={true} >
+            <defs>
+                <clipPath id={toClipPathId(node)}>
+                    <path d={this.renderPath(wrapper, context, this.getClipPathInsets() || 0)}></path>
+                </clipPath>
+            </defs>
+            {this.renderPathNode(wrapper, context)}
+            {context.renderChildren(node)}
+        </g>;
+    }
+
+    protected renderWithoutRadius(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode | undefined {
+        return super.render(node, context);
+    }
+
+    protected getClipPathInsets(): number | undefined {
+        return 2;
+    }
+
+    protected renderPathNode(wrapper: Readonly<RoundedCornerWrapper>, context: RenderingContext): VNode {
+        return <path d={this.renderPath(wrapper, context, 0)}
+            class-sprotty-node={wrapper.element instanceof SNode}
+            class-sprotty-port={wrapper.element instanceof SPort}
+            class-mouseover={wrapper.element.hoverFeedback}
+            class-selected={wrapper.element.selected}
+            {...this.additionalClasses(wrapper.element, context)} />;
+    }
+
+    protected additionalClasses(_node: Readonly<SShapeElement & Hoverable & Selectable>, _context: RenderingContext): Classes {
+        return {};
+    }
+
+    protected renderPath(wrapper: Readonly<RoundedCornerWrapper>, _context: RenderingContext, inset: number): string {
+        // Calcualte length of straight line segments
+        const topLineLength = Math.max(0, wrapper.size.width - wrapper.cornerRadius.topLeft - wrapper.cornerRadius.topRight);
+        const rightLineLength = Math.max(0, wrapper.size.height - wrapper.cornerRadius.topRight - wrapper.cornerRadius.bottomRight);
+        const bottomLineLength = Math.max(0, wrapper.size.width - wrapper.cornerRadius.bottomLeft - wrapper.cornerRadius.bottomRight);
+
+        const path = `M${0 + inset},${0 + wrapper.topLeftCorner.radiusY}` +
+            `q${0},${-(wrapper.topLeftCorner.radiusY - inset)} ${wrapper.topLeftCorner.radiusX - inset},${-(wrapper.topLeftCorner.radiusY - inset)}` +
+            `h${topLineLength}` +
+            `q${wrapper.topRightCorner.radiusX - inset},0 ${wrapper.topRightCorner.radiusX - inset},${wrapper.topRightCorner.radiusY - inset}` +
+            `v${rightLineLength}` +
+            `q0,${wrapper.bottomRightCorner.radiusY - inset} ${-(wrapper.bottomRightCorner.radiusX - inset)},${wrapper.bottomRightCorner.radiusY - inset}` +
+            `h${-bottomLineLength}` +
+            `q${-(wrapper.bottomLeftCorner.radiusX - inset)},0 ${-(wrapper.bottomLeftCorner.radiusX - inset)},${-(wrapper.bottomLeftCorner.radiusY - inset)}` +
+            'z ';
+        return path;
+    }
+}
+
+export function toClipPathId(node: Readonly<SShapeElement & Hoverable & Selectable>): string {
+    return `${node.id}_clip_path`;
+}

--- a/packages/client/src/views/rounded-corner.ts
+++ b/packages/client/src/views/rounded-corner.ts
@@ -1,0 +1,88 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Dimension, Hoverable, Selectable, SShapeElement } from 'sprotty/lib';
+
+import { CornerRadius } from '../utils/argument-utils';
+
+export interface RoundedCorner {
+    radiusX: number;
+    radiusY: number;
+}
+
+export class RoundedCornerWrapper {
+    protected _topLeftCorner: RoundedCorner;
+    protected _topRightCorner: RoundedCorner;
+    protected _bottomRightCorner: RoundedCorner;
+    protected _bottomLeftCorner: RoundedCorner;
+
+    constructor(public readonly element: SShapeElement & Hoverable & Selectable, public readonly cornerRadius: CornerRadius) {
+    }
+
+    get size(): Dimension {
+        return this.element.size;
+    }
+
+    get topLeftCorner(): RoundedCorner {
+        if (!this._topLeftCorner) {
+            this._topLeftCorner = {
+                radiusX: scaledRadius(this.cornerRadius.topLeft, this.element.size.width / 2),
+                radiusY: scaledRadius(this.cornerRadius.topLeft, this.element.size.height / 2)
+            };
+        }
+        return this._topLeftCorner;
+    }
+
+    get topRightCorner(): RoundedCorner {
+        if (!this._topRightCorner) {
+            this._topRightCorner = {
+                radiusX: scaledRadius(this.cornerRadius.topRight, this.element.size.width / 2),
+                radiusY: scaledRadius(this.cornerRadius.topRight, this.element.size.height / 2)
+            };
+        }
+        return this._topRightCorner;
+    }
+
+    get bottomRightCorner(): RoundedCorner {
+        if (!this._bottomRightCorner) {
+            this._bottomRightCorner = {
+                radiusX: scaledRadius(this.cornerRadius.bottomRight, this.element.size.width / 2),
+                radiusY: scaledRadius(this.cornerRadius.bottomRight, this.element.size.height / 2)
+            };
+        }
+        return this._bottomRightCorner;
+    }
+
+    get bottomLeftCorner(): RoundedCorner {
+        if (!this._bottomLeftCorner) {
+            this._bottomLeftCorner = {
+                radiusX: scaledRadius(this.cornerRadius.bottomLeft, this.element.size.width / 2),
+                radiusY: scaledRadius(this.cornerRadius.bottomLeft, this.element.size.height / 2)
+            };
+        }
+        return this._bottomLeftCorner;
+    }
+}
+
+/*
+* Scales the radius if necessary. (Percentual downscaling if the radius is bigger then the maximal allowed length)
+*/
+export function scaledRadius(radius: number, maximalLength: number): number {
+    if (radius <= maximalLength) {
+        return radius;
+    } else {
+        return radius * (maximalLength / radius);
+    }
+}


### PR DESCRIPTION
- Registrations
-- Provide default types as strings
-- Register elements for default types
-- Register views for default types
-- Ensure element and view registrations can be overwritten

- Views
-- Add rounded corner view that reads argument map for corner radius
-- Add edge view that supports custom padding for easier mouse handling
-- Move issue marker view to shared views folder

- Use custom edge and rounded corner view in example for new elements

Fixes https://github.com/eclipse-glsp/glsp/issues/180

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>