### PR TITLE
#220 Rework workflow-example

### DIFF
--- a/examples/workflow-glsp/css/diagram.css
+++ b/examples/workflow-glsp/css/diagram.css
@@ -120,11 +120,11 @@
     opacity: 0.2;
 }
 
-.sprotty-node.task.automated {
+.task.automated>.sprotty-node {
     fill: gray;
 }
 
-.sprotty-node.task.manual {
+.task.manual>.sprotty-node {
     fill: lightblue;
 }
 

--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -57,6 +57,7 @@ import {
     overrideViewerOptions,
     paletteModule,
     RevealNamedElementActionProvider,
+    RoundedCornerNodeView,
     routingModule,
     SCompartment,
     SCompartmentView,
@@ -67,13 +68,14 @@ import {
     toolsModule,
     TYPES,
     validationModule,
-    zorderModule
+    zorderModule,
+    RectangularNodeView
 } from '@eclipse-glsp/client';
 import { Container, ContainerModule } from 'inversify';
 
 import { directTaskEditor } from './direct-task-editing/di.config';
 import { ActivityNode, Icon, TaskNode, WeightedEdge } from './model';
-import { ForkOrJoinNodeView, IconView, TaskNodeView, WeightedEdgeView, WorkflowEdgeView } from './workflow-views';
+import { IconView, WorkflowEdgeView } from './workflow-views';
 
 const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
@@ -85,19 +87,19 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     const context = { bind, unbind, isBound, rebind };
 
     configureDefaultModelElements(context);
-    configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);
-    configureModelElement(context, 'task:manual', TaskNode, TaskNodeView);
+    configureModelElement(context, 'task:automated', TaskNode, RoundedCornerNodeView);
+    configureModelElement(context, 'task:manual', TaskNode, RoundedCornerNodeView);
     configureModelElement(context, 'label:heading', SLabel, SLabelView, { enable: [editLabelFeature] });
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
     configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
     configureModelElement(context, 'label:icon', SLabel, SLabelView);
     configureModelElement(context, DefaultTypes.EDGE, SEdge, WorkflowEdgeView);
-    configureModelElement(context, 'edge:weighted', WeightedEdge, WeightedEdgeView);
+    configureModelElement(context, 'edge:weighted', WeightedEdge, WorkflowEdgeView);
     configureModelElement(context, 'icon', Icon, IconView);
     configureModelElement(context, 'activityNode:merge', ActivityNode, DiamondNodeView);
     configureModelElement(context, 'activityNode:decision', ActivityNode, DiamondNodeView);
-    configureModelElement(context, 'activityNode:fork', ActivityNode, ForkOrJoinNodeView);
-    configureModelElement(context, 'activityNode:join', ActivityNode, ForkOrJoinNodeView);
+    configureModelElement(context, 'activityNode:fork', ActivityNode, RectangularNodeView);
+    configureModelElement(context, 'activityNode:join', ActivityNode, RectangularNodeView);
 });
 
 export default function createContainer(widgetId: string): Container {

--- a/examples/workflow-glsp/src/workflow-views.tsx
+++ b/examples/workflow-glsp/src/workflow-views.tsx
@@ -16,67 +16,20 @@
 import {
     angleOfPoint,
     GEdgeView,
-    Hoverable,
     IView,
     Point,
-    RectangularNodeView,
     RenderingContext,
-    RoundedCornerNodeView,
     SEdge,
-    Selectable,
-    SShapeElement,
     toDegrees
 } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 import * as snabbdom from 'snabbdom-jsx';
-import { Classes } from 'snabbdom/modules/class';
 import { VNode } from 'snabbdom/vnode';
 
-import { ActivityNode, Icon, TaskNode, WeightedEdge } from './model';
+import { Icon } from './model';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const JSX = { createElement: snabbdom.svg };
-
-@injectable()
-export class TaskNodeView extends RoundedCornerNodeView {
-    protected renderWithoutRadius(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode {
-        const task = node as TaskNode;
-        const rcr = this.getRoundedCornerRadius(task);
-        const graph = <g>
-            <rect class-sprotty-node={true} class-selected={node.selected} class-mouseover={node.hoverFeedback}
-                {...this.additionalClasses(task, context)}
-                x={0} y={0} rx={rcr} ry={rcr}
-                width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
-            {context.renderChildren(node)}
-        </g>;
-        return graph;
-    }
-
-    protected getRoundedCornerRadius(_node: TaskNode): number {
-        return 5;
-    }
-
-    protected additionalClasses(element: Readonly<SShapeElement & Hoverable & Selectable>, _context: RenderingContext): Classes {
-        const node = element as TaskNode;
-        return {
-            'class-task': true,
-            'class-automated': node.taskType === 'automated',
-            'class-manual': node.taskType === 'manual'
-        };
-    }
-}
-
-@injectable()
-export class ForkOrJoinNodeView extends RectangularNodeView {
-    render(node: ActivityNode, context: RenderingContext): VNode {
-        const graph = <g>
-            <rect class-sprotty-node={true} class-forkOrJoin={true}
-                class-mouseover={node.hoverFeedback} class-selected={node.selected}
-                width={10} height={Math.max(50, node.bounds.height)}></rect>
-        </g>;
-        return graph;
-    }
-}
 
 @injectable()
 export class WorkflowEdgeView extends GEdgeView {
@@ -88,19 +41,6 @@ export class WorkflowEdgeView extends GEdgeView {
             transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`} />;
         additionals.push(arrow);
         return additionals;
-    }
-}
-
-@injectable()
-export class WeightedEdgeView extends WorkflowEdgeView {
-    protected addtionalClasses(edge: Readonly<SEdge>, _context: RenderingContext): Classes {
-        const wedge = edge as WeightedEdge;
-        return {
-            'class-no-probability': !wedge.probability,
-            'class-low': wedge.probability === 'low',
-            'class-medium': wedge.probability === 'medium',
-            'class-high': wedge.probability === 'high'
-        };
     }
 }
 

--- a/examples/workflow-standalone/app/example1.wf
+++ b/examples/workflow-standalone/app/example1.wf
@@ -5,6 +5,10 @@
       "name": "Push",
       "taskType": "manual",
       "id": "task0",
+      "cssClasses": [
+        "task",
+        "manual"
+      ],
       "children": [
         {
           "id": "task0_header",
@@ -17,16 +21,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.65625,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.6875,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -50,16 +54,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
                 "width": 48.90625,
-                "height": 22.40625
+                "height": 22.0
               },
               "text": "Push",
               "alignment": {
                 "x": 24.453125,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -84,12 +88,22 @@
         "width": 101.90625,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "ManualTask1",
       "taskType": "manual",
       "id": "task1",
+      "cssClasses": [
+        "task",
+        "manual"
+      ],
       "children": [
         {
           "id": "task1_header",
@@ -102,16 +116,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.65625,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.6875,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -135,16 +149,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 53.5625,
-                "height": 22.40625
+                "width": 52.5625,
+                "height": 22.0
               },
               "text": "RflWt",
               "alignment": {
                 "x": 26.109375,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -154,7 +168,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 96.5625,
+            "width": 95.5625,
             "height": 42.0
           },
           "layout": "hbox"
@@ -163,18 +177,28 @@
       "type": "task:manual",
       "position": {
         "x": 930.0,
-        "y": 110.0
+        "y": 150.0
       },
       "size": {
-        "width": 106.5625,
+        "width": 105.5625,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "ManualTask2",
       "taskType": "manual",
       "id": "task2",
+      "cssClasses": [
+        "task",
+        "manual"
+      ],
       "children": [
         {
           "id": "task2_header",
@@ -187,16 +211,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.65625,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.6875,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -220,16 +244,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 62.8125,
-                "height": 22.40625
+                "width": 62.21875,
+                "height": 22.0
               },
               "text": "ChkTp",
               "alignment": {
                 "x": 31.109375,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -239,7 +263,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 105.8125,
+            "width": 105.21875,
             "height": 42.0
           },
           "layout": "hbox"
@@ -248,18 +272,28 @@
       "type": "task:manual",
       "position": {
         "x": 670.0,
-        "y": 350.0
+        "y": 320.0
       },
       "size": {
-        "width": 115.8125,
+        "width": 115.21875,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "ManualTask3",
       "taskType": "manual",
       "id": "task3",
+      "cssClasses": [
+        "task",
+        "manual"
+      ],
       "children": [
         {
           "id": "task3_header",
@@ -272,16 +306,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.65625,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.6875,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -305,16 +339,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 76.953125,
-                "height": 22.40625
+                "width": 75.953125,
+                "height": 22.0
               },
               "text": "PreHeat",
               "alignment": {
                 "x": 37.8125,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -324,7 +358,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 119.953125,
+            "width": 118.953125,
             "height": 42.0
           },
           "layout": "hbox"
@@ -332,19 +366,29 @@
       ],
       "type": "task:manual",
       "position": {
-        "x": 920.0,
-        "y": 390.0
+        "x": 930.0,
+        "y": 360.0
       },
       "size": {
-        "width": 129.953125,
+        "width": 128.953125,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "ManualTask4",
       "taskType": "manual",
       "id": "task4",
+      "cssClasses": [
+        "task",
+        "manual"
+      ],
       "children": [
         {
           "id": "task4_header",
@@ -357,16 +401,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.65625,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.6875,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -390,16 +434,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 50.15625,
-                "height": 22.40625
+                "width": 49.359375,
+                "height": 22.0
               },
               "text": "Brew",
               "alignment": {
                 "x": 24.453125,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -409,7 +453,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 93.15625,
+            "width": 92.359375,
             "height": 42.0
           },
           "layout": "hbox"
@@ -417,19 +461,29 @@
       ],
       "type": "task:manual",
       "position": {
-        "x": 1280.0,
-        "y": 260.0
+        "x": 1260.0,
+        "y": 250.0
       },
       "size": {
-        "width": 103.15625,
+        "width": 102.359375,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "ManualTask6",
       "taskType": "manual",
       "id": "task6",
+      "cssClasses": [
+        "task",
+        "manual"
+      ],
       "children": [
         {
           "id": "task6_header",
@@ -442,16 +496,16 @@
                   "type": "label:icon",
                   "position": {
                     "x": 7.65625,
-                    "y": 4.796875
+                    "y": 5.0
                   },
                   "size": {
                     "width": 16.6875,
-                    "height": 22.40625
+                    "height": 22.0
                   },
                   "text": "M",
                   "alignment": {
                     "x": 8.34375,
-                    "y": 18.40625
+                    "y": 18.0
                   }
                 }
               ],
@@ -475,16 +529,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 73.9375,
-                "height": 22.40625
+                "width": 73.34375,
+                "height": 22.0
               },
               "text": "KeepTp",
               "alignment": {
                 "x": 36.671875,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -494,7 +548,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 116.9375,
+            "width": 116.34375,
             "height": 42.0
           },
           "layout": "hbox"
@@ -502,19 +556,29 @@
       ],
       "type": "task:manual",
       "position": {
-        "x": 920.0,
-        "y": 300.0
+        "x": 930.0,
+        "y": 290.0
       },
       "size": {
-        "width": 126.9375,
+        "width": 126.34375,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "AutomatedTask8",
       "taskType": "automated",
       "id": "task8",
+      "cssClasses": [
+        "task",
+        "automated"
+      ],
       "children": [
         {
           "id": "task8_header",
@@ -526,17 +590,17 @@
                   "id": "task8_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.9921875,
-                    "y": 4.796875
+                    "x": 8.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.015625,
-                    "height": 22.40625
+                    "width": 15.015625,
+                    "height": 22.0
                   },
                   "text": "A",
                   "alignment": {
-                    "x": 8.28125,
-                    "y": 18.40625
+                    "x": 7.671875,
+                    "y": 18.0
                   }
                 }
               ],
@@ -560,16 +624,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 64.671875,
-                "height": 22.40625
+                "width": 63.671875,
+                "height": 22.0
               },
               "text": "ChkWt",
               "alignment": {
                 "x": 31.671875,
-                "y": 18.40625
+                "y": 18.0
               }
             }
           ],
@@ -579,7 +643,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 107.671875,
+            "width": 106.671875,
             "height": 42.0
           },
           "layout": "hbox"
@@ -587,19 +651,29 @@
       ],
       "type": "task:automated",
       "position": {
-        "x": 680.0,
-        "y": 160.0
+        "x": 670.0,
+        "y": 180.0
       },
       "size": {
-        "width": 117.671875,
+        "width": 116.671875,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "name": "AutomatedTask9",
       "taskType": "automated",
       "id": "task9",
+      "cssClasses": [
+        "task",
+        "automated"
+      ],
       "children": [
         {
           "id": "task9_header",
@@ -611,17 +685,17 @@
                   "id": "task9_ticon",
                   "type": "label:icon",
                   "position": {
-                    "x": 7.9921875,
-                    "y": 4.796875
+                    "x": 8.4921875,
+                    "y": 5.0
                   },
                   "size": {
-                    "width": 16.015625,
-                    "height": 22.40625
+                    "width": 15.015625,
+                    "height": 22.0
                   },
                   "text": "A",
                   "alignment": {
-                    "x": 8.28125,
-                    "y": 18.40625
+                    "x": 7.671875,
+                    "y": 18.0
                   }
                 }
               ],
@@ -645,16 +719,16 @@
               "type": "label:heading",
               "position": {
                 "x": 38.0,
-                "y": 9.796875
+                "y": 10.0
               },
               "size": {
-                "width": 57.109375,
-                "height": 22.40625
+                "width": 56.109375,
+                "height": 22.0
               },
               "text": "WtOK",
               "alignment": {
-                "x": 28.578125,
-                "y": 18.40625
+                "x": 27.78125,
+                "y": 18.0
               }
             }
           ],
@@ -664,7 +738,7 @@
             "y": 5.0
           },
           "size": {
-            "width": 100.109375,
+            "width": 99.109375,
             "height": 42.0
           },
           "layout": "hbox"
@@ -673,13 +747,19 @@
       "type": "task:automated",
       "position": {
         "x": 930.0,
-        "y": 190.0
+        "y": 220.0
       },
       "size": {
-        "width": 110.109375,
+        "width": 109.109375,
         "height": 52.0
       },
-      "layout": "vbox"
+      "layout": "vbox",
+      "args": {
+        "radiusBottomLeft": 5.0,
+        "radiusTopLeft": 5.0,
+        "radiusTopRight": 5.0,
+        "radiusBottomRight": 5.0
+      }
     },
     {
       "nodeType": "mergeNode",
@@ -687,7 +767,7 @@
       "type": "activityNode:merge",
       "position": {
         "x": 1100.0,
-        "y": 170.0
+        "y": 190.0
       },
       "size": {
         "width": 32.0,
@@ -716,7 +796,7 @@
       "type": "activityNode:decision",
       "position": {
         "x": 840.0,
-        "y": 360.0
+        "y": 330.0
       },
       "size": {
         "width": 32.0,
@@ -738,8 +818,8 @@
       "id": "activityNode4",
       "type": "activityNode:merge",
       "position": {
-        "x": 1100.0,
-        "y": 350.0
+        "x": 1110.0,
+        "y": 330.0
       },
       "size": {
         "width": 32.0,
@@ -767,8 +847,8 @@
       "id": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
       "type": "activityNode:decision",
       "position": {
-        "x": 840.0,
-        "y": 170.0
+        "x": 830.0,
+        "y": 190.0
       },
       "size": {
         "width": 32.0,
@@ -781,19 +861,19 @@
     },
     {
       "id": "69d7d698-c5ce-4e85-be06-d9bd9357322d",
+      "cssClasses": [
+        "medium"
+      ],
       "type": "edge:weighted",
       "sourceId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
       "targetId": "task1"
     },
     {
-      "id": "9c6a2ca0-e178-4b38-abea-33b07aecad54",
-      "type": "edge:weighted",
-      "sourceId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
-      "targetId": "task9"
-    },
-    {
       "nodeType": "forkNode",
       "id": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
+      "cssClasses": [
+        "forkOrJoin"
+      ],
       "type": "activityNode:fork",
       "position": {
         "x": 590.0,
@@ -811,18 +891,6 @@
       "targetId": "bb2709f5-0ff0-4438-8853-b7e934b506d7"
     },
     {
-      "id": "ce77c929-f358-4a13-97c4-62c6792a644c",
-      "type": "edge",
-      "sourceId": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
-      "targetId": "task8"
-    },
-    {
-      "id": "e346b1f6-dec9-40a5-a838-22dae399b8e9",
-      "type": "edge",
-      "sourceId": "task8",
-      "targetId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4"
-    },
-    {
       "id": "5eeaa218-ad56-4052-8b28-bbc08d82ed34",
       "type": "edge",
       "sourceId": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
@@ -831,10 +899,13 @@
     {
       "nodeType": "joinNode",
       "id": "bd94e44e-19f9-446e-89d4-97ca1a63c17b",
+      "cssClasses": [
+        "forkOrJoin"
+      ],
       "type": "activityNode:join",
       "position": {
         "x": 1220.0,
-        "y": 260.0
+        "y": 250.0
       },
       "size": {
         "width": 10.0,
@@ -843,12 +914,18 @@
     },
     {
       "id": "2f57af4e-2960-496e-992d-03c8b021d81a",
+      "cssClasses": [
+        "medium"
+      ],
       "type": "edge:weighted",
       "sourceId": "activityNode2",
       "targetId": "task6"
     },
     {
       "id": "2c7427b0-9743-4bfb-b04c-078ba98f8d7e",
+      "cssClasses": [
+        "medium"
+      ],
       "type": "edge:weighted",
       "sourceId": "activityNode2",
       "targetId": "task3"
@@ -870,7 +947,29 @@
       "type": "edge",
       "sourceId": "bd94e44e-19f9-446e-89d4-97ca1a63c17b",
       "targetId": "task4"
+    },
+    {
+      "id": "e9aa796a-aa5b-4e6d-8860-4b9c5a5b8d89",
+      "cssClasses": [
+        "medium"
+      ],
+      "type": "edge:weighted",
+      "sourceId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
+      "targetId": "task9"
+    },
+    {
+      "id": "f49a588c-618c-4d9f-96fc-feee776a0ead",
+      "type": "edge",
+      "sourceId": "task8",
+      "targetId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4"
+    },
+    {
+      "id": "568d91e3-d5bf-464d-923e-9769a8a651f3",
+      "type": "edge",
+      "sourceId": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
+      "targetId": "task8"
     }
   ],
-  "type": "graph"
+  "type": "graph",
+  "revision": 18
 }

--- a/examples/workflow-standalone/css/diagram.css
+++ b/examples/workflow-standalone/css/diagram.css
@@ -28,11 +28,11 @@
     stroke: black;
 }
 
-.sprotty-node.forkOrJoin {
+.forkOrJoin>.sprotty-node {
     fill: black;
 }
 
-.sprotty-node.forkOrJoin.selected {
+.forkOrJoin>.sprotty-node.selected {
     stroke: rgb(87, 87, 214);
 }
 


### PR DESCRIPTION
**Note:** Depends on https://github.com/eclipse-glsp/glsp-server/pull/107 being merged.

* Remove custom views that were only used to apply custom css classes
  * TaskNodeView
  * ForkOrJoinNodeView
* Use default Sprotty views instead and set css classes in the backend via SModelElement.cssClasses
* Adapt di config and diagram css

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>