### PR TITLE
#60 #229 Cleanup and add codestyle reporting to ci

### DIFF
--- a/examples/workflow-glsp/package.json
+++ b/examples/workflow-glsp/package.json
@@ -3,7 +3,17 @@
   "version": "0.9.0",
   "description": "GLSP diagrams for the Workflow DSL",
   "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
-  "author": "Eclipse GLSP",
+  "keywords": [
+    "glsp",
+    "workflow",
+    "diagram",
+    "example"
+  ],
+  "homepage": "https://www.eclipse.org/glsp/",
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
+  "author": {
+    "name": "Eclipse GLSP"
+  },
   "contributors": [
     {
       "name": "Philip Langer",
@@ -19,14 +29,17 @@
       "name": "Martin Fleck",
       "email": "mfleck@eclipsesource.com",
       "url": "https://www.eclipsesource.com"
+    },
+    {
+      "name": "Camille Letavernier",
+      "email": "cletavernier@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
     }
   ],
-  "keywords": [
-    "sprotty",
-    "workflow",
-    "diagram",
-    "example"
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-glsp/glsp-client.git"
+  },
   "dependencies": {
     "@eclipse-glsp/client": "0.9.0",
     "balloon-css": "^0.5.0"
@@ -37,9 +50,9 @@
     "typescript": "^3.9.2"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "yarn clean && yarn build",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run lint",
+    "build": "tsc && yarn lint",
     "lint": "eslint -c ./.eslintrc.js --ext .ts,.tsx ./src",
     "watch": "tsc -w"
   },

--- a/examples/workflow-standalone/package.json
+++ b/examples/workflow-standalone/package.json
@@ -3,11 +3,11 @@
   "name": "workflow-standalone",
   "version": "0.9.0",
   "description": "Standalone browser-app for the Workflow example",
-  "dependencies": {
-    "@eclipse-glsp-examples/workflow-glsp": "0.9.0",
-    "@eclipse-glsp/client": "0.9.0"
+  "homepage": "https://www.eclipse.org/glsp/",
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
+  "author": {
+    "name": "Eclipse GLSP"
   },
-  "author": "Eclipse GLSP",
   "contributors": [
     {
       "name": "Philip Langer",
@@ -23,8 +23,21 @@
       "name": "Martin Fleck",
       "email": "mfleck@eclipsesource.com",
       "url": "https://www.eclipsesource.com"
+    },
+    {
+      "name": "Camille Letavernier",
+      "email": "cletavernier@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-glsp/glsp-client.git"
+  },
+  "dependencies": {
+    "@eclipse-glsp-examples/workflow-glsp": "0.9.0",
+    "@eclipse-glsp/client": "0.9.0"
+  },
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/file-saver": "^0.0.1",
@@ -56,10 +69,10 @@
     "access": "public"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn build",
+    "prepare": "yarn clean && yarn build",
     "clean": "rimraf lib app/bundle.js app/bundle.js.map app/css",
     "lint": "eslint -c ./.eslintrc.js --ext .ts,.tsx ./src",
-    "build": "tsc && yarn lint && webpack",
+    "build": "tsc && yarn lint",
     "watch": "tsc -w -p ./tsconfig.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
     "yarn": "1.0.x || >=1.2.1"
   },
   "scripts": {
-    "test": "yarn",
     "prepare": "lerna run prepare",
     "watch": "lerna run --parallel watch",
-    "rebuild:browser": "theia rebuild:browser",
-    "publish": "yarn && yarn publish:latest",
+    "lint": "lerna run lint --",
+    "test": "lerna run test",
     "publish:latest": "lerna publish",
     "publish:next": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "upgrade:next": "yarn upgrade -p \"sprotty\" --next ",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,12 +13,7 @@
     "diagram editor"
   ],
   "homepage": "https://www.eclipse.org/glsp/",
-  "bugs": "https://github.com/eclipse-glsp/glsp-client/issues",
-  "files": [
-    "lib",
-    "src",
-    "css"
-  ],
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
   "author": {
     "name": "Eclipse GLSP"
   },
@@ -37,12 +32,22 @@
       "name": "Martin Fleck",
       "email": "mfleck@eclipsesource.com",
       "url": "https://www.eclipsesource.com"
+    },
+    {
+      "name": "Camille Letavernier",
+      "email": "cletavernier@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
     }
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-glsp/glsp-client.git"
   },
+  "files": [
+    "lib",
+    "src",
+    "css"
+  ],
   "dependencies": {
     "@eclipse-glsp/protocol": "0.9.0",
     "autocompleter": "5.1.0",
@@ -62,9 +67,9 @@
     "typescript": "^3.9.2"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "yarn clean && yarn build ",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run lint",
+    "build": "tsc && yarn lint",
     "lint": "eslint -c ./.eslintrc.js --ext .ts,.tsx ./src",
     "watch": "tsc -w",
     "test": "jenkins-mocha --opts ../../configs/mocha.opts \"./src/**/*.spec.?(ts|tsx)\""

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,11 +13,7 @@
     "diagram editor"
   ],
   "homepage": "https://www.eclipse.org/glsp/",
-  "bugs": "https://github.com/eclipse-glsp/glsp-client/issues",
-  "files": [
-    "lib",
-    "src"
-  ],
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
   "author": {
     "name": "Eclipse GLSP"
   },
@@ -36,12 +32,21 @@
       "name": "Martin Fleck",
       "email": "mfleck@eclipsesource.com",
       "url": "https://www.eclipsesource.com"
+    },
+    {
+      "name": "Camille Letavernier",
+      "email": "cletavernier@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
     }
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/eclipse-glsp/glsp-client.git"
   },
+  "files": [
+    "lib",
+    "src"
+  ],
   "dependencies": {
     "uuid": "7.0.3",
     "vscode-ws-jsonrpc": "0.2.0"
@@ -53,9 +58,9 @@
     "typescript": "^3.9.2"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "yarn clean && yarn build",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run lint",
+    "build": "tsc && yarn lint",
     "lint": "eslint -c ./.eslintrc.js --ext .ts ./src",
     "watch": "tsc -w"
   },


### PR DESCRIPTION
- Update metadata of all packages
- Add standalone eslint script (`yarn lint`)

Jenkinsfile
- Enable eslint reporting & publishing
- Move test execution into dedicated stage
- Only trigger deployment job if public package code was changed 
 (part of eclipse-glsp/glsp/issues/229)

Part of: eclipse-glsp/glsp/issues/60