### PR TITLE
#253 Align operation definitions for ChangeContainerOperation

### DIFF
--- a/packages/client/src/base/operations/operation.ts
+++ b/packages/client/src/base/operations/operation.ts
@@ -82,7 +82,7 @@ export class ChangeContainerOperation implements Operation {
     static readonly KIND = 'changeContainer';
     constructor(public readonly elementId: string,
         public readonly targetContainerId: string,
-        public readonly location?: string,
+        public readonly location?: Point,
         public readonly kind: string = ChangeContainerOperation.KIND) { }
 }
 


### PR DESCRIPTION
The definition of the optional member variable location in ChangeContainerOperation does not match on server and client side.

Please see also server change: https://github.com/eclipse-glsp/glsp-server/pull/115

Fixes https://github.com/eclipse-glsp/glsp/issues/253