### PR TITLE
#258 Remove name property from GLSPClient

### DIFF
--- a/examples/workflow-standalone/src/main.ts
+++ b/examples/workflow-standalone/src/main.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,7 +29,6 @@ import createContainer from './di.config';
 
 const port = 8081;
 const id = 'workflow';
-const name = 'workflow';
 const websocket = new WebSocket(`ws://localhost:${port}/${id}`);
 const container = createContainer();
 
@@ -44,7 +43,7 @@ const actionDispatcher = container.get<IActionDispatcher>(TYPES.IActionDispatche
 
 websocket.onopen = () => {
     const connectionProvider = JsonrpcGLSPClient.createWebsocketConnectionProvider(websocket);
-    const glspClient = new BaseJsonrpcGLSPClient({ id, name, connectionProvider });
+    const glspClient = new BaseJsonrpcGLSPClient({ id, connectionProvider });
     diagramServer.connect(glspClient).then(client => {
         client.initializeServer({ applicationId: ApplicationIdProvider.get() });
         actionDispatcher.dispatch(new InitializeClientSessionAction(diagramServer.clientId));

--- a/packages/protocol/src/glsp-client.ts
+++ b/packages/protocol/src/glsp-client.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2020-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -78,11 +78,6 @@ export interface GLSPClient {
     readonly id: string;
 
     /**
-     * Client name.
-     */
-    readonly name: string;
-
-    /**
      * Current client state.
      */
     currentState(): ClientState;
@@ -128,11 +123,9 @@ export interface GLSPClient {
 export namespace GLSPClient {
     export interface Options {
         id: string;
-        name: string;
     }
 
     export function isOptions(object: any): object is Options {
-        return object !== undefined && 'id' in object && typeof object['id'] === 'string'
-            && 'name' in object && typeof object['name'] === 'string';
+        return object !== undefined && 'id' in object && typeof object['id'] === 'string';
     }
 }

--- a/packages/protocol/src/jsonrpc/base-jsonrpc-glsp-client.ts
+++ b/packages/protocol/src/jsonrpc/base-jsonrpc-glsp-client.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2020 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,6 @@ import { ConnectionProvider, JsonrpcGLSPClient } from './glsp-jsonrpc-client';
 
 export class BaseJsonrpcGLSPClient implements GLSPClient {
 
-    readonly name: string;
     readonly id: string;
     protected readonly connectionProvider: ConnectionProvider;
     protected connectionPromise?: Promise<MessageConnection>;


### PR DESCRIPTION
A client is already uniquely identified via its id, there is no need for an additional name property. In our current implementing projects the name property is always equal to the id and therefore redundant.

Part of eclipse-glsp/glsp/issues/258