### PR TITLE
#376 Element dragging without selection might not work with Firefox

### DIFF
--- a/packages/client/src/features/tool-feedback/change-bounds-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/change-bounds-tool-feedback.ts
@@ -214,7 +214,7 @@ export class FeedbackMoveMouseListener extends MouseListener {
     }
 
     mouseEnter(target: SModelElement, event: MouseEvent): Action[] {
-        if (target instanceof SModelRoot && event.buttons === 0) {
+        if (target instanceof SModelRoot && event.buttons === 0 && !this.startDragPosition) {
             this.mouseUp(target, event);
         }
         return [];


### PR DESCRIPTION
- Fix element movement without selection for Firefox by avoiding reset of `startDragPosition` on mouse entering (similar to other Firefox fixes in sprotty)

Fixes https://github.com/eclipse-glsp/glsp/issues/376