### PR TITLE
#377 Update to latest glsp-config version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,9 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "parent",
   "version": "0.9.0",
   "engines": {
-    "yarn": "1.0.x || >=1.2.1"
+    "yarn": ">=1.7.0 <2.x.x"
   },
   "scripts": {
     "prepare": "lerna run prepare",
@@ -18,7 +18,7 @@
     "download:exampleServer": "ts-node examples/workflow-glsp/scripts/download.ts"
   },
   "devDependencies": {
-    "@eclipse-glsp/config": "0.9.0-next.9648217c",
+    "@eclipse-glsp/config": "0.9.0-next.0e05932b",
     "lerna": "^2.11.0",
     "typescript": "^3.9.2"
   },

--- a/packages/client/src/base/actions/edit-validation-actions.ts
+++ b/packages/client/src/base/actions/edit-validation-actions.ts
@@ -24,7 +24,7 @@ export class RequestEditValidationAction implements RequestAction<SetEditValidat
         public readonly text: string,
         public readonly requestId: string = generateRequestId(),
         public readonly kind: string = RequestEditValidationAction.KIND
-    ) { }
+    ) {}
 }
 
 export class SetEditValidationResultAction implements ResponseAction {
@@ -34,7 +34,7 @@ export class SetEditValidationResultAction implements ResponseAction {
         public readonly responseId: string = '',
         public readonly args?: Args,
         public readonly kind: string = SetEditValidationResultAction.KIND
-    ) { }
+    ) {}
 }
 
 export function isSetEditValidationResultAction(action: Action): action is SetEditValidationResultAction {

--- a/packages/client/src/base/di.config.ts
+++ b/packages/client/src/base/di.config.ts
@@ -13,12 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import '../../css/glsp-sprotty.css';
-
 import { InitializeResult } from '@eclipse-glsp/protocol';
 import { Container, ContainerModule } from 'inversify';
 import { ActionHandlerRegistry, configureActionHandler, configureCommand, ModelSource, SetModelCommand, TYPES } from 'sprotty';
-
+import '../../css/glsp-sprotty.css';
 import { GLSPActionDispatcher } from './action-dispatcher';
 import { SetEditModeAction } from './actions/edit-mode-action';
 import { FocusStateChangedAction } from './actions/focus-change-action';
@@ -75,7 +73,8 @@ const defaultGLSPModule = new ContainerModule((bind, _unbind, isBound, rebind) =
 export default defaultGLSPModule;
 
 /**
- * Utility function to configure the {@link ModelSource}, i.e. the `DiagramServer`, as action handler for all server actions for the given diagramType.
+ * Utility function to configure the {@link ModelSource}, i.e. the `DiagramServer`, as action handler for all server actions for the given
+ * diagramType.
  * @param result A promise that resolves after all server actions have been registered.
  * @param diagramType The diagram type.
  * @param container The di container.

--- a/packages/client/src/base/model/update-model-command.ts
+++ b/packages/client/src/base/model/update-model-command.ts
@@ -29,7 +29,6 @@ import {
     TYPES
 } from 'sprotty';
 import { UpdateModelAction, UpdateModelCommand } from 'sprotty/lib/features/update/update-model';
-
 import { IFeedbackActionDispatcher } from '../../features/tool-feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../features/tool-feedback/model';
 import { GLSP_TYPES } from '../types';
@@ -54,8 +53,8 @@ export interface SModelRootListener {
 }
 
 /**
- * A special`UpdateModelCommand` that retrieves all registered `actions` from the `IFeedbackActionDispatcher` (if present) and applies their feedback
- * to the `newRoot` before performing the update
+ * A special`UpdateModelCommand` that retrieves all registered `actions` from the `IFeedbackActionDispatcher` (if present) and applies their
+ * feedback to the `newRoot` before performing the update
  */
 @injectable()
 export class FeedbackAwareUpdateModelCommand extends UpdateModelCommand {

--- a/packages/client/src/base/operations/operation.ts
+++ b/packages/client/src/base/operations/operation.ts
@@ -14,12 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { Action, ApplyLabelEditAction, ElementAndBounds, isAction, LayoutAction, Point } from 'sprotty';
-
 import { Args } from '../args';
 
 /**
- * Operations are actions that denote requests from the client to _modify_ the model. Model modifications are always performed by the server.
- * After a successful modification, the server sends the updated model back to the client using the `UpdateModelAction`.
+ * Operations are actions that denote requests from the client to _modify_ the model. Model modifications are always performed by the
+ * server. After a successful modification, the server sends the updated model back to the client using the `UpdateModelAction`.
  */
 export interface Operation extends Action {}
 

--- a/packages/client/src/features/change-bounds/model.ts
+++ b/packages/client/src/features/change-bounds/model.ts
@@ -29,7 +29,7 @@ import {
 
 export const resizeFeature = Symbol('resizeFeature');
 
-export interface Resizable extends BoundsAware, Selectable { }
+export interface Resizable extends BoundsAware, Selectable {}
 
 export function isResizable(element: SModelElement): element is SParentElement & Resizable {
     return isBoundsAware(element) && isSelectable(element) && element instanceof SParentElement && element.hasFeature(resizeFeature);

--- a/packages/client/src/features/context-menu/di.config.ts
+++ b/packages/client/src/features/context-menu/di.config.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 import { ContainerModule } from 'inversify';
 import { ContextMenuProviderRegistry, IContextMenuService, TYPES } from 'sprotty';
-
 import { SelectionServiceAwareContextMenuMouseListener } from './selection-service-aware-context-menu-mouse-listener';
 import { ServerContextMenuItemProvider } from './server-context-menu-provider';
 

--- a/packages/client/src/features/tools/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds-tool.ts
@@ -34,7 +34,6 @@ import {
     SParentElement,
     TYPES
 } from 'sprotty';
-
 import { DragAwareMouseListener } from '../../base/drag-aware-mouse-listener';
 import {
     ChangeBoundsOperation,
@@ -76,8 +75,8 @@ import { BaseGLSPTool } from './base-glsp-tool';
  * | Move      | MoveAction       | ChangeBoundsOperationAction
  * | Resize    | SetBoundsAction  | ChangeBoundsOperationAction
  *
- * To provide a visual client updates during move we install the `FeedbackMoveMouseListener` and to provide visual client updates during resize
- * and send the server updates we install the `ChangeBoundsListener`.
+ * To provide a visual client updates during move we install the `FeedbackMoveMouseListener` and to provide visual client updates during
+ * resize and send the server updates we install the `ChangeBoundsListener`.
  */
 @injectable()
 export class ChangeBoundsTool extends BaseGLSPTool {

--- a/packages/client/src/features/tools/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit-tool.ts
@@ -28,7 +28,6 @@ import {
     SRoutableElement,
     SRoutingHandle
 } from 'sprotty';
-
 import { DragAwareMouseListener } from '../../base/drag-aware-mouse-listener';
 import { ChangeRoutingPointsOperation, ReconnectEdgeOperation } from '../../base/operations/operation';
 import { GLSP_TYPES } from '../../base/types';
@@ -233,7 +232,8 @@ class EdgeEditListener extends DragAwareMouseListener implements SelectionListen
             }
             this.reset();
         } else if (this.edge && this.routingHandle) {
-            // we need to re-retrieve the edge as it might have changed due to a server udpate since we do not reset the state between reroute actions
+            // we need to re-retrieve the edge as it might have changed due to a server update since we do not reset the state between
+            // reroute actions
             const latestEdge = target.index.getById(this.edge.id);
             if (latestEdge && isRoutable(latestEdge)) {
                 result.push(new ChangeRoutingPointsOperation([{ elementId: latestEdge.id, newRoutingPoints: latestEdge.routingPoints }]));

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,19 +30,19 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@eclipse-glsp/config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-0.9.0-next.9648217c.tgz#4cd4ed484aa8e30cfd2bfa6196c8cddd3fd3ef67"
-  integrity sha512-u7Xu0//rKYrr+89pQYtRR86ZQt1Ey+m/nwY7OeowAJaeZdE/0fnaBUA71FTP86qS/Sht9Ec+GVGpQh6+T2v3mw==
+"@eclipse-glsp/config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-0.9.0-next.0e05932b.tgz#e491200537236d39d07b6c44640748a865f311f9"
+  integrity sha512-2umAyVWSyazzNNgIvvqci1vwTjvItLLBaLldaG4nMiSzjPS4bDTf1Y4etNtb6pdmtZ2IgJcFg03bXBWOGzCYvw==
   dependencies:
-    "@eclipse-glsp/eslint-config" "0.9.0-next.9648217c"
-    "@eclipse-glsp/prettier-config" "0.9.0-next.9648217c"
-    "@eclipse-glsp/ts-config" "0.9.0-next.9648217c"
+    "@eclipse-glsp/eslint-config" "0.9.0-next.0e05932b"
+    "@eclipse-glsp/prettier-config" "0.9.0-next.0e05932b"
+    "@eclipse-glsp/ts-config" "0.9.0-next.0e05932b"
 
-"@eclipse-glsp/eslint-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-0.9.0-next.9648217c.tgz#5f9e12653f646bebe7ae0a7a4fe00bfb187b8cb3"
-  integrity sha512-QRotLPdimHm70NWrr1TabJOgEEGHKqtt4RRtKUxsgjLwLEYKPKi2vnz0Oc9RPhCVoTsraOuzpyr/1jWJZY0grw==
+"@eclipse-glsp/eslint-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-0.9.0-next.0e05932b.tgz#8ed0092ed55027f18fc886c99fed4f84800f84ea"
+  integrity sha512-wBcqs/ncUSirIjiewoGWvwlAYBJjUUwNu5+vOlNWYsO1xW4xu+tuuIJ5jolmMcHpONa/TQws1B7MB1oLw3cWlA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.32.0"
     "@typescript-eslint/parser" "^4.32.0"
@@ -52,15 +52,15 @@
     eslint-plugin-import "^2.24.2"
     eslint-plugin-no-null "^1.0.2"
 
-"@eclipse-glsp/prettier-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.9.0-next.9648217c.tgz#d346ca86f59b5dc17f2721d31a1dda67864da783"
-  integrity sha512-GKpJp4HrDw66dzqA1RSPt1AjXFSEhtlHi10pSw3BfBqoRrXstTSwIOYwK0oAFz6R4ORE3WL5r5O4kQaS/CnANQ==
+"@eclipse-glsp/prettier-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.9.0-next.0e05932b.tgz#83469b5638673418cbb901df9710e31df1ab7f4b"
+  integrity sha512-xcpZ8qxhSAMocFKnKMRsGmMdFXUb9bvN5U2qBZJNqn4Oe5EB7hpJNkugUXHZODo15P4WgkSZXS9vPjCus90wqQ==
 
-"@eclipse-glsp/ts-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-0.9.0-next.9648217c.tgz#20a07d7105d2854ae838f7be95242fe6158ea80b"
-  integrity sha512-ZZ2HQ7S5p4EELJRxpzHxyd0hitH9y54Uf54E1RPwQPDcWR7Z1s7SK6y/CoRBs2SQ6vzEjG2WV/j21ULt34G8rQ==
+"@eclipse-glsp/ts-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-0.9.0-next.0e05932b.tgz#6be3648264e4c53db88946b7e7830e983b4f7845"
+  integrity sha512-sjlIirOmnsXrdS1csbcBW2M25UjPzMt50aYwoKbjTsC0u3SJFxXXgmy4ZJwtxdDN90gsBntRT2G/3iT/e7CvNg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Update to latest glsp-config version to consume https://github.com/eclipse-glsp/glsp/pull/405
(Update eslint-config to display formatting linting issues that get autofixed by prettier as warning)
(This is possible for all formatting linting rules except the "indent" rule. This rule has to be disabled. Prettier uses a dynamic indent size (e.g. spread objects (...) are formatted with two additional spaces, whereas es-lint only supports a static/fixed indent size. This causes unfixable warnings if the rule is activated. Prettier will still format and indent all lines correctly on save.

This means the developer should now get direct feedback in the editor again if there is a formatting issue like using " instead of ', multiple consecutive  empty lines, missing semicolons etc.

Also:
- Align yarn version range with Theia
- Add prettier as default formatter for "javascriptreact" (.jsx files).
- Fix minor formatting inconsistencies