### PR TITLE
#429 Fix bug in `isResponseAction()` guard function

### DIFF
--- a/examples/workflow-standalone/webpack.config.js
+++ b/examples/workflow-standalone/webpack.config.js
@@ -27,10 +27,9 @@ module.exports = {
         path: appRoot
     },
     mode: 'development',
-    devtool: 'eval-source-map',
+    devtool: 'source-map',
     resolve: {
-        // Add `.ts` and `.tsx` as a resolvable extension.
-        extensions: ['.webpack.js', '.web.js', '.ts', '.tsx', '.js']
+        extensions: ['.ts', '.tsx', '.js']
     },
     module: {
         rules: [

--- a/packages/protocol/src/action-protocol/base-protocol.ts
+++ b/packages/protocol/src/action-protocol/base-protocol.ts
@@ -86,7 +86,7 @@ export interface ResponseAction extends Action {
 }
 
 export function isResponseAction(action?: any): action is ResponseAction {
-    return isAction(action) && isString(action, 'responseId');
+    return isAction(action) && 'responseId' in action && typeof action['responseId'] === 'string' && action['responseId'] !== '';
 }
 
 /**


### PR DESCRIPTION
Fixes eclipse-glsp/glsp/issues/429

Also: Update webpack config for standalone example to enable proper debugging with ts sources.