### PR TITLE
Fix isSetEditValidationResultAction() function

### DIFF
--- a/packages/protocol/src/action-protocol/element-text-editing.ts
+++ b/packages/protocol/src/action-protocol/element-text-editing.ts
@@ -55,7 +55,7 @@ export class SetEditValidationResultAction implements ResponseAction {
 }
 
 export function isSetEditValidationResultAction(action: Action): action is SetEditValidationResultAction {
-    return isActionKind(action, SetEditValidationResultAction.KIND) && isObject(action, 'status') && isString(action, 'response');
+    return isActionKind(action, SetEditValidationResultAction.KIND) && isObject(action, 'status') && isString(action, 'responseId');
 }
 
 export class ApplyLabelEditOperation implements Operation {


### PR DESCRIPTION
This function wrongly checked for property `response`, while it actually should check for `repsonseId`.