### PR TITLE
470: Remove custom LayoutRegistry and reuse the one from Sprotty

### DIFF
--- a/packages/client/src/features/layout/di.config.ts
+++ b/packages/client/src/features/layout/di.config.ts
@@ -13,8 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ContainerModule, inject, injectable, multiInject, optional } from 'inversify';
-import { configureCommand, configureLayout, ILogger, LayoutRegistration, LayoutRegistry, TYPES } from 'sprotty';
+import { ContainerModule } from 'inversify';
+import { configureCommand, configureLayout, VBoxLayouter } from 'sprotty';
 import { FreeFormLayouter } from './freeform-layout';
 import { AlignElementsCommand, ResizeElementsCommand } from './layout-commands';
 import { VBoxLayouterExt } from './vbox-layout';
@@ -23,30 +23,8 @@ const layoutCommandsModule = new ContainerModule((bind, _unbind, isBound, rebind
     configureCommand({ bind, isBound }, ResizeElementsCommand);
     configureCommand({ bind, isBound }, AlignElementsCommand);
 
-    configureLayout({ bind, isBound }, VBoxLayouterExt.KIND, VBoxLayouterExt);
+    rebind(VBoxLayouter).to(VBoxLayouterExt);
     configureLayout({ bind, isBound }, FreeFormLayouter.KIND, FreeFormLayouter);
-
-    bind(OverridableLayoutRegistry).toSelf().inSingletonScope();
-    rebind(TYPES.LayoutRegistry).toService(OverridableLayoutRegistry);
 });
 
 export default layoutCommandsModule;
-
-@injectable()
-export class OverridableLayoutRegistry extends LayoutRegistry {
-    // ensure logger is already used in constructor as otherwise not usable
-    constructor(
-        @multiInject(TYPES.LayoutRegistration) @optional() layouts: LayoutRegistration[] = [],
-        @inject(TYPES.ILogger) logger: ILogger
-    ) {
-        super();
-        layouts.forEach(layout => {
-            if (this.hasKey(layout.layoutKind)) {
-                logger.warn('Layout kind is already defined and will be overridden: ', layout.layoutKind);
-                this.deregister(layout.layoutKind);
-            }
-            // allow overriding an existing layout kind
-            this.register(layout.layoutKind, layout.factory());
-        });
-    }
-}


### PR DESCRIPTION
Note: there is one minor difference between the Sprotty registry and the one introduced in #470. When multiple layouts are bound to the same key, Sprotty logs a warning and rejects the new one; in the custom registry, since default layouts were not registered via dependency injection, we allowed overriding them (also after logging a warning).

We now have the expected Sprotty behavior: registering 2 different layouts on the same key is not allowed, and the first one wins. We must use rebind() instead.