### PR TITLE
224: FeedbackEdge uses wrong child when used inside container element

### DIFF
--- a/packages/client/src/views/compartments.tsx
+++ b/packages/client/src/views/compartments.tsx
@@ -29,7 +29,7 @@ export class StructureCompartmentView extends ShapeView {
 
         return (
             <g>
-                <rect class-sprotty-comp={true} class-debug={true} x='0' y='0' width={model.size.width} height={model.size.height}></rect>
+                <rect class-sprotty-comp={true} class-debug={false} x='0' y='0' width={model.size.width} height={model.size.height}></rect>
                 {context.renderChildren(model)}
             </g>
         );


### PR DESCRIPTION
- Fix anchor computation for nested elements

Unrelated: remove the debug-attribute on Category compartments (Blue border around the compartment)

fixes eclipse-glsp/glsp/issues/224