### PR TITLE
Fix focus and hovering on context menu show/hide

### DIFF
--- a/packages/client/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
+++ b/packages/client/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
@@ -22,8 +22,7 @@ import {
     isSelectable,
     MouseListener,
     SModelElement,
-    TYPES,
-    ViewerOptions
+    TYPES
 } from 'sprotty';
 import { FocusStateChangedAction } from '../../base/actions/focus-change-action';
 import { GLSP_TYPES } from '../../base/types';
@@ -34,7 +33,6 @@ export class SelectionServiceAwareContextMenuMouseListener extends MouseListener
     @inject(TYPES.IContextMenuServiceProvider) @optional() protected readonly contextMenuService: IContextMenuServiceProvider;
     @inject(TYPES.IContextMenuProviderRegistry) @optional() protected readonly menuProvider: ContextMenuProviderRegistry;
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
-    @inject(TYPES.ViewerOptions) protected options: ViewerOptions;
 
     /**
      * Opens the context menu on right-click.

--- a/packages/client/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
+++ b/packages/client/src/features/context-menu/selection-service-aware-context-menu-mouse-listener.ts
@@ -22,7 +22,8 @@ import {
     isSelectable,
     MouseListener,
     SModelElement,
-    TYPES
+    TYPES,
+    ViewerOptions
 } from 'sprotty';
 import { FocusStateChangedAction } from '../../base/actions/focus-change-action';
 import { GLSP_TYPES } from '../../base/types';
@@ -33,6 +34,7 @@ export class SelectionServiceAwareContextMenuMouseListener extends MouseListener
     @inject(TYPES.IContextMenuServiceProvider) @optional() protected readonly contextMenuService: IContextMenuServiceProvider;
     @inject(TYPES.IContextMenuProviderRegistry) @optional() protected readonly menuProvider: ContextMenuProviderRegistry;
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
+    @inject(TYPES.ViewerOptions) protected options: ViewerOptions;
 
     /**
      * Opens the context menu on right-click.
@@ -71,9 +73,10 @@ export class SelectionServiceAwareContextMenuMouseListener extends MouseListener
     }
 
     protected focusEventTarget(event: MouseEvent): void {
-        const svgElement = event.target instanceof SVGElement ? event.target : undefined;
-        if (svgElement) {
-            svgElement.focus();
+        const targetElement = event.target instanceof SVGElement ? event.target : undefined;
+        const svgParentElement = targetElement?.closest('svg');
+        if (svgParentElement) {
+            svgParentElement.focus();
         }
     }
 }

--- a/packages/client/src/features/hover/di.config.ts
+++ b/packages/client/src/features/hover/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2021 EclipseSource and others.
+ * Copyright (c) 2020-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,8 @@ import { GlspHoverMouseListener } from './hover';
 
 const glspHoverModule = new ContainerModule((bind, _unbind, isBound) => {
     bind(TYPES.PopupVNodePostprocessor).to(PopupPositionUpdater).inSingletonScope();
-    bind(TYPES.MouseListener).to(GlspHoverMouseListener);
+    bind(GlspHoverMouseListener).toSelf().inSingletonScope();
+    bind(TYPES.MouseListener).toService(GlspHoverMouseListener);
     bind(TYPES.PopupMouseListener).to(PopupHoverMouseListener);
     bind(TYPES.KeyListener).to(HoverKeyListener);
     bind<HoverState>(TYPES.HoverState).toConstantValue({
@@ -55,6 +56,7 @@ const glspHoverModule = new ContainerModule((bind, _unbind, isBound) => {
     configureActionHandler(context, SetViewportCommand.KIND, ClosePopupActionHandler);
     configureActionHandler(context, MoveCommand.KIND, ClosePopupActionHandler);
     configureActionHandler(context, FocusStateChangedAction.KIND, ClosePopupActionHandler);
+    configureActionHandler(context, FocusStateChangedAction.KIND, GlspHoverMouseListener);
 });
 
 export default glspHoverModule;


### PR DESCRIPTION
  * Restore focus of diagram after context menu is closed
  * Cancel hover timer when diagram looses focus
  * Clear hover state when diagram looses focus

Note that there is a separate hover issue with edges and handles, which is fixed in Sprotty directly. See https://github.com/eclipse/sprotty/issues/264

Fixes https://github.com/eclipse-glsp/glsp/issues/496
Fixes https://github.com/eclipse-glsp/glsp/issues/497

Contributed on behalf of STMicroelectronics.