### PR TITLE
#602 Fix SelectionService.getSelectedElements() method

### DIFF
--- a/packages/client/src/features/select/selection-service.ts
+++ b/packages/client/src/features/select/selection-service.ts
@@ -31,7 +31,7 @@ import {
 } from 'sprotty';
 import { SModelRootListener } from '../../base/model/update-model-command';
 import { GLSP_TYPES } from '../../base/types';
-import { getMatchingElements } from '../../utils/smodel-util';
+import { getElements } from '../../utils/smodel-util';
 import { IFeedbackActionDispatcher } from '../tool-feedback/feedback-action-dispatcher';
 import { SelectFeedbackAction } from './select-feedback-action';
 
@@ -124,7 +124,7 @@ export class SelectionService implements SModelRootListener {
     }
 
     getSelectedElements(): Readonly<SModelElement & Selectable>[] {
-        return getMatchingElements(this.root.index, isSelectable);
+        return getElements(this.root.index, Array.from(this.selectedElementIDs), isSelectable);
     }
 
     /**

--- a/packages/client/src/utils/smodel-util.ts
+++ b/packages/client/src/utils/smodel-util.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { distinctAdd, ElementAndRoutingPoints, remove } from '@eclipse-glsp/protocol';
+import { distinctAdd, ElementAndRoutingPoints, remove, TypeGuard } from '@eclipse-glsp/protocol';
 import {
     BoundsAware,
     ElementAndBounds,
@@ -74,6 +74,24 @@ export function getMatchingElements<T>(index: SModelIndex<SModelElement>, predic
     return Array.from(filter(index, predicate));
 }
 
+/**
+ * Invokes the given model index to retrieve the corresponding model elements for the given set of ids. Ids that
+ * have no corresponding element in the index will be ignored.
+ * @param index THe model index.
+ * @param elementsIDs The element ids.
+ * @param guard Optional typeguard. If defined only elements that match the guard will be returned.
+ * @returns An array of the model elements that correspond to the given ids and filter predicate.
+ */
+export function getElements<S extends SModelElement>(index: SModelIndex<SModelElement>, elementsIDs: string[], guard?: TypeGuard<S>): S[] {
+    // Internal filter function that filters out undefined model elements and runs an optional typeguard check.
+    const filterFn = (element?: SModelElement): element is S => {
+        if (element !== undefined) {
+            return guard ? guard(element) : true;
+        }
+        return false;
+    };
+    return elementsIDs.map(id => index.getById(id)).filter(filterFn);
+}
 /**
  * Retrieves the amount of currently selected elements in the given {@link SModelIndex}.
  * @param index The {@link SModelIndex}.

--- a/packages/protocol/src/utils/typeguard-util.ts
+++ b/packages/protocol/src/utils/typeguard-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2021-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
+/**
+ * Utility type to describe typeguard functions.
+ */
+export type TypeGuard<T> = (element: any, ...args: any[]) => element is T;
 
 /**
  * Validates whether the given object as a property of type `string` with the given key.


### PR DESCRIPTION
With eclipse-glsp/glsp-client/pull/167 a bug in the selection service was introduced. The `getSelectedElements()`  query method  returns
all `selectable` elements instead of the elements that are actually selected.

- Fix `SelectionService.getSelectedElements()` behavior. This also includes a performance improvement. We now only map the currently selected element ids to their SModelElement Instead of iterating over all elements of the index to receive the selected elements
- Introduce  a new  smodel util function that allows retrieving all model elements that correspond to a given set of element ids from the index.
- Introduce a `TypeGuard` convenience type to `typeguard-util`

Fixes eclipse-glsp/glsp/issues/602