### PR TITLE
#604 Support snapping support for edges

### DIFF
--- a/packages/client/src/features/change-bounds/snap.spec.ts
+++ b/packages/client/src/features/change-bounds/snap.spec.ts
@@ -1,0 +1,89 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { SModelElement } from 'sprotty';
+import { GridSnapper, PointPositionUpdater } from './snap';
+
+describe('GridSnapper', () => {
+    it('snap', () => {
+        const element = new SModelElement();
+        const snapper = new GridSnapper();
+        expect(snapper.snap({ x: 0, y: 0 }, element)).to.be.deep.equals({ x: 0, y: 0 });
+        expect(snapper.snap({ x: 4, y: 5 }, element)).to.be.deep.equals({ x: 0, y: 10 });
+        expect(snapper.snap({ x: 8, y: 11 }, element)).to.be.deep.equals({ x: 10, y: 10 });
+        expect(snapper.snap({ x: -7, y: -4 }, element)).to.be.deep.equals({ x: -10, y: -0 });
+    });
+});
+
+describe('PointPositionUpdater', () => {
+    it('updatePosition with no last drag position', () => {
+        const element = new SModelElement();
+        const updater = new PointPositionUpdater();
+        expect(updater.updatePosition(element, { x: 0, y: 0 }, false)).to.be.undefined;
+        expect(updater.updatePosition(element, { x: 0, y: 0 }, true)).to.be.undefined;
+    });
+
+    it('update last position and reset', () => {
+        const updater = new PointPositionUpdater();
+        expect(updater.isLastDragPositionUndefined()).to.be.true;
+        updater.updateLastDragPosition({ x: 0, y: 0 });
+        expect(updater.isLastDragPositionUndefined()).to.be.false;
+        updater.resetPosition();
+        expect(updater.isLastDragPositionUndefined()).to.be.true;
+    });
+
+    it('updatePosition with no snapper', () => {
+        const element = new SModelElement();
+        const updater = new PointPositionUpdater();
+        resetUpdater(updater);
+        expect(updater.updatePosition(element, { x: 0, y: 0 }, false)).to.be.undefined;
+        expect(updater.updatePosition(element, { x: 0, y: 0 }, true)).to.be.undefined;
+
+        resetUpdater(updater);
+        expect(updater.updatePosition(element, { x: 5, y: 3 }, false)).to.be.deep.equals({ x: 5, y: 3 });
+        expect(updater.updatePosition(element, { x: 5, y: 3 }, true)).to.be.undefined;
+        expect(updater.updatePosition(element, { x: 11, y: 6 }, false)).to.be.deep.equals({ x: 6, y: 3 });
+        expect(updater.updatePosition(element, { x: -3, y: 2 }, true)).to.be.deep.equals({ x: -14, y: -4 });
+    });
+
+    it('updatePosition with snapper', () => {
+        const element = new SModelElement();
+        const snapper = new GridSnapper();
+        const updater = new PointPositionUpdater(snapper);
+        resetUpdater(updater);
+        expect(updater.updatePosition(element, { x: 0, y: 0 }, false)).to.be.undefined;
+        expect(updater.updatePosition(element, { x: 0, y: 0 }, true)).to.be.undefined;
+
+        resetUpdater(updater);
+        expect(updater.updatePosition(element, { x: 5, y: 3 }, true)).to.be.deep.equals({ x: 10, y: 0 });
+        expect(updater.updatePosition(element, { x: 5, y: 3 }, true)).to.be.undefined;
+        expect(updater.updatePosition(element, { x: 11, y: 6 }, true)).to.be.deep.equals({ x: 0, y: 10 });
+        expect(updater.updatePosition(element, { x: -3, y: 2 }, true)).to.be.deep.equals({ x: -10, y: -10 });
+
+        // disable snapping (alt key)
+        resetUpdater(updater);
+        expect(updater.updatePosition(element, { x: 5, y: 3 }, false)).to.be.deep.equals({ x: 5, y: 3 });
+        expect(updater.updatePosition(element, { x: 5, y: 3 }, false)).to.be.undefined;
+        expect(updater.updatePosition(element, { x: 11, y: 6 }, false)).to.be.deep.equals({ x: 6, y: 3 });
+        expect(updater.updatePosition(element, { x: -3, y: 2 }, false)).to.be.deep.equals({ x: -14, y: -4 });
+    });
+
+    function resetUpdater(updater: PointPositionUpdater): void {
+        updater.resetPosition();
+        updater.updateLastDragPosition({ x: 0, y: 0 });
+    }
+});

--- a/packages/client/src/features/change-bounds/snap.ts
+++ b/packages/client/src/features/change-bounds/snap.ts
@@ -36,31 +36,60 @@ export class GridSnapper implements ISnapper {
     }
 }
 
+/**
+ * This class can be used to calculate the current position, when an element is
+ * moved. This includes node movements, node resizing (resize handle movement)
+ * or edge routing-point movements.
+ *
+ * You can initialize a this class with a optional {@link ISnapper}. If a
+ * snapper is present, the positions will be snapped to the defined grid.
+ */
 export class PointPositionUpdater {
     protected lastDragPosition?: Point;
     protected positionDelta: WriteablePoint = { x: 0, y: 0 };
 
     constructor(protected snapper?: ISnapper) {}
 
+    /**
+     * Init the position with the {@link Point} of your mouse cursor.
+     * This method is normally called in the `mouseDown` event.
+     * @param mousePosition current mouse position e.g `{x: event.pageX, y: event.pageY }`
+     */
     public updateLastDragPosition(mousePosition: Point): void {
         this.lastDragPosition = mousePosition;
     }
 
+    /**
+     * Check if the mouse is currently not in a drag mode.
+     * @returns true if the last drag position is undefined
+     */
     public isLastDragPositionUndefined(): boolean {
         return this.lastDragPosition === undefined;
     }
 
+    /**
+     * Reset the updater for new movements.
+     * This method is normally called in the `mouseUp` event.
+     */
     public resetPosition(): void {
         this.lastDragPosition = undefined;
         this.positionDelta = { x: 0, y: 0 };
     }
 
+    /**
+     * Calculate the current position of your movement.
+     * This method is normally called in the `mouseMove` event.
+     * @param target node which is moved around
+     * @param mousePosition current mouse position e.g `{x: event.pageX, y: event.pageY }`
+     * @param isSnapEnabled if a snapper is defined you can disable it, e.g when a specific key is pressed `!event.altKey`
+     * @returns current position or undefined if updater has no last drag position initialized
+     */
     public updatePosition(target: SModelElement, mousePosition: Point, isSnapEnabled: boolean): Point | undefined {
         if (this.lastDragPosition) {
             const newDragPosition = mousePosition;
 
             const viewport = findParentByFeature(target, isViewport);
-            const zoom = viewport ? viewport.zoom : 1;
+            const zoom = viewport?.zoom ?? 1;
             const dx = (mousePosition.x - this.lastDragPosition.x) / zoom;
             const dy = (mousePosition.y - this.lastDragPosition.y) / zoom;
             const deltaToLastPosition = { x: dx, y: dy };

--- a/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
@@ -255,7 +255,7 @@ export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
         return [];
     }
 
-    private toElementMove(element: SRoutingHandle, positionDelta: Point): ElementMove | undefined {
+    protected toElementMove(element: SRoutingHandle, positionDelta: Point): ElementMove | undefined {
         const point = this.getHandlePosition(element);
         if (point !== undefined) {
             return {

--- a/packages/client/src/features/tools/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit-tool.ts
@@ -22,11 +22,13 @@ import {
     EdgeRouterRegistry,
     findParentByFeature,
     isConnectable,
+    ISnapper,
     isSelected,
     SModelElement,
     SModelRoot,
     SRoutableElement,
-    SRoutingHandle
+    SRoutingHandle,
+    TYPES
 } from 'sprotty';
 import { DragAwareMouseListener } from '../../base/drag-aware-mouse-listener';
 import { GLSP_TYPES } from '../../base/types';
@@ -53,6 +55,7 @@ export class EdgeEditTool extends BaseGLSPTool {
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;
     @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry;
     @inject(EdgeRouterRegistry) @optional() protected edgeRouterRegistry?: EdgeRouterRegistry;
+    @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
 
     protected feedbackEdgeSourceMovingListener: FeedbackEdgeSourceMovingMouseListener;
     protected feedbackEdgeTargetMovingListener: FeedbackEdgeTargetMovingMouseListener;
@@ -71,7 +74,7 @@ export class EdgeEditTool extends BaseGLSPTool {
         // install feedback move mouse listener for client-side move updates
         this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener(this.anchorRegistry);
         this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener(this.anchorRegistry);
-        this.feedbackMovingListener = new FeedbackEdgeRouteMovingMouseListener(this.edgeRouterRegistry);
+        this.feedbackMovingListener = new FeedbackEdgeRouteMovingMouseListener(this.edgeRouterRegistry, this.snapper);
     }
 
     registerFeedbackListeners(): void {


### PR DESCRIPTION
- Add snapping to mouseMove in FeedbackEdgeRouteMovingMouseListener
- Remove unused 'hasDragged' attribute from FeedbackEdgeRouteMovingMouseListener

Fixes: https://github.com/eclipse-glsp/glsp/issues/604