### PR TITLE
Improve default configuration for foreign objects

### DIFF
--- a/packages/client/src/lib/model.ts
+++ b/packages/client/src/lib/model.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { SModelElementSchema } from '@eclipse-glsp/protocol';
-import { exportFeature, SGraph, SModelElement, viewportFeature } from 'sprotty/lib';
+import { exportFeature, SGraph, SModelElement, viewportFeature } from 'sprotty';
 import { Containable, containerFeature } from '../features/hints/model';
 import { Saveable, saveFeature } from '../features/save/model';
 

--- a/packages/client/src/views/base-view-module.ts
+++ b/packages/client/src/views/base-view-module.ts
@@ -26,6 +26,7 @@ import {
     ForeignObjectView,
     HtmlRoot,
     HtmlRootView,
+    moveFeature,
     PreRenderedElement,
     PreRenderedView,
     RectangularNode,
@@ -34,6 +35,7 @@ import {
     SCompartment,
     SCompartmentView,
     SEdge,
+    selectFeature,
     SGraphView,
     ShapedPreRenderedElement,
     SIssueMarker,
@@ -66,7 +68,9 @@ export function configureDefaultModelElements(context: ContainerContext): void {
     configureModelElement(context, DefaultTypes.HTML, HtmlRoot, HtmlRootView);
 
     // generic elements
-    configureModelElement(context, DefaultTypes.FOREIGN_OBJECT, ForeignObjectElement, ForeignObjectView);
+    configureModelElement(context, DefaultTypes.FOREIGN_OBJECT, ForeignObjectElement, ForeignObjectView, {
+        disable: [selectFeature, moveFeature]
+    });
     configureModelElement(context, DefaultTypes.PRE_RENDERED, PreRenderedElement, PreRenderedView);
     configureModelElement(context, DefaultTypes.SHAPE_PRE_RENDERED, ShapedPreRenderedElement, PreRenderedView);
 

--- a/packages/protocol/src/model/default-types.ts
+++ b/packages/protocol/src/model/default-types.ts
@@ -41,6 +41,7 @@ export namespace DefaultTypes {
     export const LABEL = 'label';
 
     // UI elements
+    export const BUTTON = 'button';
     export const BUTTON_EXPAND = 'button:expand';
     export const ISSUE_MARKER = 'marker';
 


### PR DESCRIPTION
Disable `selectFeature` and `moveFeature` for the default foreign object configuration.
The select feature doesn't make sense for `ForeignObjectElements` as each DOMElement rendered from the objects `code` property
might provide it's own selection behavior. In addition this ensure that the resize feature also works for nodes that contain `ForeignObjectElements`.

Typically `ForeignObjectElement`s are children of a GNode so we also disable the move feature as nested child elements should not be movable.

Also: Add missing `Button` definition to default types and clean up imports of  `model.ts`

Contributed on behalf of STMicroelectronics