### PR TITLE
#633 Make `EditorContextService.sourceUri` async again

### DIFF
--- a/packages/client/src/features/navigation/navigation-target-resolver.ts
+++ b/packages/client/src/features/navigation/navigation-target-resolver.ts
@@ -33,7 +33,7 @@ export class NavigationTargetResolver {
 
     async resolve(navigationTarget: NavigationTarget): Promise<SetResolvedNavigationTargetAction | undefined> {
         const contextService = await this.editorContextService();
-        const sourceUri = contextService.sourceUri;
+        const sourceUri = await contextService.getSourceUri();
         return this.resolveWithSourceUri(sourceUri, navigationTarget);
     }
 

--- a/packages/client/src/features/validation/validate.ts
+++ b/packages/client/src/features/validation/validate.ts
@@ -98,7 +98,11 @@ export class SetMarkersActionHandler implements IActionHandler {
 
     handle(action: SetMarkersAction): void | Action | ICommand {
         const markers: Marker[] = action.markers;
-        const uri = this.editorContextService.sourceUri;
+        this.setMarkers(markers);
+    }
+
+    async setMarkers(markers: Marker[]): Promise<void> {
+        const uri = await this.editorContextService.getSourceUri();
         this.externalMarkerManager?.setMarkers(markers, uri);
         const applyMarkersAction = ApplyMarkersAction.create(markers);
         this.validationFeedbackEmitter.registerValidationFeedbackAction(applyMarkersAction);


### PR DESCRIPTION
Partly revert the changes made to the `EditorContextService` in  https://github.com/eclipse-glsp/glsp-client/pull/176 and make the `sourceUri` retrieval async again

Fixes eclipse-glsp/glsp/issues/633

Contributed on behalf of STMicroelectronics