### PR TITLE
Fix mousetool action dispatching & routing point flickering

### DIFF
--- a/packages/client/src/features/layout/di.config.ts
+++ b/packages/client/src/features/layout/di.config.ts
@@ -15,10 +15,14 @@
  ********************************************************************************/
 import { ContainerModule } from 'inversify';
 import { configureActionHandler, configureLayout, HBoxLayouter, VBoxLayouter } from 'sprotty';
-import { AlignElementsActionHandler } from '../..';
 import { FreeFormLayouter } from './freeform-layout';
 import { HBoxLayouterExt } from './hbox-layout';
-import { AlignElementsAction, ResizeElementsAction, ResizeElementsActionHandler } from './layout-elements-action';
+import {
+    AlignElementsAction,
+    AlignElementsActionHandler,
+    ResizeElementsAction,
+    ResizeElementsActionHandler
+} from './layout-elements-action';
 import { VBoxLayouterExt } from './vbox-layout';
 
 const layoutModule = new ContainerModule((bind, _unbind, isBound, rebind) => {

--- a/packages/client/src/features/mouse-tool/mouse-tool.ts
+++ b/packages/client/src/features/mouse-tool/mouse-tool.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Action } from '@eclipse-glsp/protocol';
 import { injectable, multiInject, optional } from 'inversify';
 import { MouseListener, MouseTool, SModelElement, SModelRoot } from 'sprotty';
 import { TYPES } from '../../base/types';
@@ -82,8 +83,13 @@ export class RankingMouseTool extends MouseTool implements IMouseTool {
         if (actions.length > 0) {
             event.preventDefault();
             for (const actionOrPromise of actions) {
-                const action = await actionOrPromise;
-                await this.actionDispatcher.dispatch(action);
+                if (Action.is(actionOrPromise)) {
+                    await this.actionDispatcher.dispatch(actionOrPromise);
+                } else {
+                    actionOrPromise.then((action: Action) => {
+                        this.actionDispatcher.dispatch(action);
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
- Ensure that aciion promises are correctly dispatched  (I.e. non-blocking) in the `MouseTool`
- Fix animation flickering for routing point changes by Removing the `EdgeMorphAnimation` from the `UpdateModelCommand

(Also: Fix circular import of `AlignElementsActionHandler)

Fixes https://github.com/eclipse-glsp/glsp/issues/653
Fixes https://github.com/eclipse-glsp/glsp/issues/654