### PR TITLE
Rename `ModelSourceChangedAction` to `SourceModelChangedAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     <br>[#472](https://github.com/eclipse-glsp/glsp-client/pull/171) - Contributed on behalf of STMicroelectronics
 -   [DI] Unified the sprotty `TYPE` and `GLSP_TYPE` service identifier constants. They are reexported from the client main index as `TYPE`. The old `GLSP_TYPE` constant definition has been
     deprecated will potentially be removed in the future. [#472](https://github.com/eclipse-glsp/glsp-client/pull/171)
+-   [protocol] Rename `ModelSourceChangedAction` to `SourceModelChangedAction` including handlers etc [#655](https://github.com/eclipse-glsp/glsp-client/pull/184)
 
 ## [v0.9.0- 09/12/2021](https://github.com/eclipse-glsp/glsp-client/releases/tag/v0.9.0)
 

--- a/packages/client/src/base/container-modules.ts
+++ b/packages/client/src/base/container-modules.ts
@@ -38,10 +38,10 @@ import glspEditLabelModule from '../features/edit-label/di.config';
 import modelHintsModule from '../features/hints/di.config';
 import glspHoverModule from '../features/hover/di.config';
 import layoutModule from '../features/layout/di.config';
-import modelSourceWatcherModule from '../features/model-source-watcher/di.config';
 import glspMouseToolModule from '../features/mouse-tool/di.config';
 import { navigationModule } from '../features/navigation/di.config';
 import glspSelectModule from '../features/select/di.config';
+import sourceModelWatcherModule from '../features/source-model-watcher/di.config';
 import toolFeedbackModule from '../features/tool-feedback/di.config';
 import toolPaletteModule from '../features/tool-palette/di.config';
 import { enableDefaultToolsOnFocusLossModule, toolsModule } from '../features/tools/di.config';
@@ -73,7 +73,7 @@ export const DEFAULT_MODULES = [
     markerNavigatorModule,
     modelHintsModule,
     modelSourceModule,
-    modelSourceWatcherModule,
+    sourceModelWatcherModule,
     navigationModule,
     openModule,
     toolPaletteModule,

--- a/packages/client/src/features/source-model-watcher/di.config.ts
+++ b/packages/client/src/features/source-model-watcher/di.config.ts
@@ -13,13 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ModelSourceChangedAction } from '@eclipse-glsp/protocol';
+import { SourceModelChangedAction } from '@eclipse-glsp/protocol';
 import { ContainerModule } from 'inversify';
 import { configureActionHandler } from 'sprotty';
-import { ModelSourceChangedActionHandler } from './model-source-changed-action-handler';
+import { SourceModelChangedActionHandler } from './source-model-changed-action-handler';
 
-const modelSourceWatcherModule = new ContainerModule((bind, _unbind, isBound) => {
-    configureActionHandler({ bind, isBound }, ModelSourceChangedAction.KIND, ModelSourceChangedActionHandler);
+const sourceModelWatcherModule = new ContainerModule((bind, _unbind, isBound) => {
+    configureActionHandler({ bind, isBound }, SourceModelChangedAction.KIND, SourceModelChangedActionHandler);
 });
 
-export default modelSourceWatcherModule;
+export default sourceModelWatcherModule;

--- a/packages/client/src/features/source-model-watcher/source-model-changed-action-handler.ts
+++ b/packages/client/src/features/source-model-watcher/source-model-changed-action-handler.ts
@@ -13,43 +13,43 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, ModelSourceChangedAction, ServerMessageAction, ServerStatusAction } from '@eclipse-glsp/protocol';
+import { Action, ServerMessageAction, ServerStatusAction, SourceModelChangedAction } from '@eclipse-glsp/protocol';
 import { inject, injectable, optional } from 'inversify';
 import { IActionDispatcher, IActionHandler, ViewerOptions } from 'sprotty';
 import { TYPES } from '../../base/types';
 
 /**
- * An external handler of the model source change event.
+ * An external handler of the source model change event.
  *
  * This allows external applications to react specifically to this event, e.g. by bringing up the diagram,
  * check their dirty state, show a dialog, etc.
  */
 @injectable()
-export abstract class ExternalModelSourceChangedHandler {
+export abstract class ExternalSourceModelChangedHandler {
     /**
-     * Notifies about a change of the model source.
+     * Notifies about a change of the source model.
      * @returns actions to be dispatched after the notification.
      */
-    abstract notifyModelSourceChange(modelSourceName: string, options: ViewerOptions): Promise<Action[]>;
+    abstract notifySourceModelChange(sourceModelName: string, options: ViewerOptions): Promise<Action[]>;
 }
 
 @injectable()
-export class ModelSourceChangedActionHandler implements IActionHandler {
+export class SourceModelChangedActionHandler implements IActionHandler {
     @inject(TYPES.IActionDispatcher)
     protected dispatcher: IActionDispatcher;
 
     @inject(TYPES.ViewerOptions)
     protected options: ViewerOptions;
 
-    @inject(ExternalModelSourceChangedHandler)
+    @inject(ExternalSourceModelChangedHandler)
     @optional()
-    protected externalModelSourceChangedHandler?: ExternalModelSourceChangedHandler;
+    protected externalModelSourceChangedHandler?: ExternalSourceModelChangedHandler;
 
     handle(action: Action): void {
-        if (ModelSourceChangedAction.is(action)) {
+        if (SourceModelChangedAction.is(action)) {
             if (this.externalModelSourceChangedHandler) {
                 this.externalModelSourceChangedHandler
-                    .notifyModelSourceChange(action.modelSourceName, this.options)
+                    .notifySourceModelChange(action.sourceModelName, this.options)
                     .then(actions => this.dispatcher.dispatchAll(actions));
                 return;
             }
@@ -57,8 +57,8 @@ export class ModelSourceChangedActionHandler implements IActionHandler {
         }
     }
 
-    protected showSimpleNotification(action: ModelSourceChangedAction): void {
-        const message = `The model source ${action.modelSourceName} has changed. You might want to consider reloading.`;
+    protected showSimpleNotification(action: SourceModelChangedAction): void {
+        const message = `The source model ${action.sourceModelName} has changed. You might want to consider reloading.`;
         const timeout = 0;
         const severity = 'WARNING';
         this.dispatcher.dispatchAll([

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -22,11 +22,11 @@ import glspEditLabelModule from './features/edit-label/di.config';
 import modelHintsModule from './features/hints/di.config';
 import glspHoverModule from './features/hover/di.config';
 import layoutModule from './features/layout/di.config';
-import modelSourceWatcherModule from './features/model-source-watcher/di.config';
 import glspMouseToolModule from './features/mouse-tool/di.config';
 import { navigationModule } from './features/navigation/di.config';
 import saveModule from './features/save/di.config';
 import glspSelectModule from './features/select/di.config';
+import sourceModelWatcherModule from './features/source-model-watcher/di.config';
 import toolFeedbackModule from './features/tool-feedback/di.config';
 import paletteModule from './features/tool-palette/di.config';
 import { enableDefaultToolsOnFocusLossModule, toolsModule } from './features/tools/di.config';
@@ -66,7 +66,6 @@ export * from './features/hints/model';
 export * from './features/hints/type-hints';
 export * from './features/hover/hover';
 export * from './features/layout/layout-elements-action';
-export * from './features/model-source-watcher/model-source-changed-action-handler';
 export * from './features/mouse-tool/mouse-tool';
 export * from './features/navigation/navigation-action-handler';
 export * from './features/navigation/navigation-target-resolver';
@@ -74,6 +73,7 @@ export * from './features/rank/model';
 export * from './features/reconnect/model';
 export * from './features/save/model';
 export * from './features/save/save-keylistener';
+export * from './features/source-model-watcher/source-model-changed-action-handler';
 export * from './features/tool-feedback/change-bounds-tool-feedback';
 export * from './features/tool-feedback/creation-tool-feedback';
 export * from './features/tool-feedback/css-feedback';
@@ -121,6 +121,6 @@ export {
     navigationModule,
     markerNavigatorModule,
     glspDecorationModule,
-    modelSourceWatcherModule,
+    sourceModelWatcherModule as modelSourceWatcherModule,
     glspViewportModule
 };

--- a/packages/protocol/src/action-protocol/element-navigation.ts
+++ b/packages/protocol/src/action-protocol/element-navigation.ts
@@ -324,7 +324,7 @@ export namespace SetResolvedNavigationTargetAction {
 }
 
 /**
- * If a {@link NavigationTarget} cannot be resolved or the resolved target is something that is not part of our model source, e.g.,
+ * If a {@link NavigationTarget} cannot be resolved or the resolved target is something that is not part of our source model, e.g.,
  * a separate documentation file, a {@link NavigateToExternalTargetAction} may be sent. Since the target it outside of the model scope such
  * an action would be typically handled by an integration layer (such as the surrounding IDE).
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks

--- a/packages/protocol/src/action-protocol/model-data.spec.ts
+++ b/packages/protocol/src/action-protocol/model-data.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 /* eslint-disable max-len */
 import { expect } from 'chai';
-import { ModelSourceChangedAction, RequestModelAction, SetModelAction, UpdateModelAction } from './model-data';
+import { RequestModelAction, SetModelAction, SourceModelChangedAction, UpdateModelAction } from './model-data';
 /**
  * Tests for the utility functions declared in the namespaces of the protocol
  * action definitions.
@@ -140,31 +140,31 @@ describe('Model data actions', () => {
         });
     });
 
-    describe('ModelSourceChangedAction', () => {
+    describe('SourceModelChangedAction', () => {
         describe('is', () => {
             it('should return true for an object having the correct type and a value for all required interface properties', () => {
-                const action: ModelSourceChangedAction = {
-                    kind: 'modelSourceChanged',
-                    modelSourceName: ''
+                const action: SourceModelChangedAction = {
+                    kind: 'sourceModelChanged',
+                    sourceModelName: ''
                 };
-                expect(ModelSourceChangedAction.is(action)).to.be.true;
+                expect(SourceModelChangedAction.is(action)).to.be.true;
             });
             it('should return false for `undefined`', () => {
-                expect(ModelSourceChangedAction.is(undefined)).to.be.false;
+                expect(SourceModelChangedAction.is(undefined)).to.be.false;
             });
             it('should return false for an object that does not have all required interface properties', () => {
-                expect(ModelSourceChangedAction.is({ kind: 'notTheRightOne' })).to.be.false;
+                expect(SourceModelChangedAction.is({ kind: 'notTheRightOne' })).to.be.false;
             });
         });
 
         describe('create', () => {
             it('should return an object conforming to the interface with matching properties for the given required arguments', () => {
-                const expected: ModelSourceChangedAction = {
-                    kind: 'modelSourceChanged',
-                    modelSourceName: 'myModelSource'
+                const expected: SourceModelChangedAction = {
+                    kind: 'sourceModelChanged',
+                    sourceModelName: 'myModelSource'
                 };
-                const { modelSourceName } = expected;
-                expect(ModelSourceChangedAction.create(modelSourceName)).to.deep.equals(expected);
+                const { sourceModelName: sourceModelName } = expected;
+                expect(SourceModelChangedAction.create(sourceModelName)).to.deep.equals(expected);
             });
         });
     });

--- a/packages/protocol/src/action-protocol/model-data.ts
+++ b/packages/protocol/src/action-protocol/model-data.ts
@@ -50,7 +50,7 @@ export namespace RequestModelAction {
 }
 
 /**
- * Sent from the model source to the client in order to set the model. If a model is already present, it is replaced.
+ * Sent from the server to the client in order to set the model. If a model is already present, it is replaced.
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
  * and creating new `SetModelActions`.
  */
@@ -113,31 +113,31 @@ export namespace UpdateModelAction {
 }
 
 /**
- * Sent from the server to the client in order to indicate that the model source has changed.
- * The model source denotes the data source from which the diagram has been originally derived (such as a file, a database, etc.).
+ * Sent from the server to the client in order to indicate that the source model has changed.
+ * The source model denotes the data source from which the diagram has been originally derived (such as a file, a database, etc.).
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
- * and creating new `ModelSourceChangedActions`.
+ * and creating new `SourceModelChangedActions`.
  */
-export interface ModelSourceChangedAction extends Action {
-    kind: typeof ModelSourceChangedAction.KIND;
+export interface SourceModelChangedAction extends Action {
+    kind: typeof SourceModelChangedAction.KIND;
 
     /**
-     * A human readable name of the model source (e.g. the file name).
+     * A human readable name of the source model (e.g. the file name).
      */
-    modelSourceName: string;
+    sourceModelName: string;
 }
 
-export namespace ModelSourceChangedAction {
-    export const KIND = 'modelSourceChanged';
+export namespace SourceModelChangedAction {
+    export const KIND = 'sourceModelChanged';
 
-    export function is(object: any): object is ModelSourceChangedAction {
-        return Action.hasKind(object, KIND) && hasStringProp(object, 'modelSourceName');
+    export function is(object: any): object is SourceModelChangedAction {
+        return Action.hasKind(object, KIND) && hasStringProp(object, 'sourceModelName');
     }
 
-    export function create(modelSourceName: string): ModelSourceChangedAction {
+    export function create(sourceModelName: string): SourceModelChangedAction {
         return {
             kind: KIND,
-            modelSourceName
+            sourceModelName: sourceModelName
         };
     }
 }

--- a/packages/protocol/src/action-protocol/model-saving.ts
+++ b/packages/protocol/src/action-protocol/model-saving.ts
@@ -17,8 +17,8 @@ import { hasBooleanProp, hasStringProp } from '../utils/type-util';
 import { Action, RequestAction, ResponseAction } from './base-protocol';
 
 /**
- * Sent from the client to the server in order to persist the current model state back to the model source.
- * A new fileUri can be defined to save the model to a new destination different from its original model source.
+ * Sent from the client to the server in order to persist the current model state back to the source model.
+ * A new fileUri can be defined to save the model to a new destination different from its original source model.
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
  * and creating new `SaveModelActions`.
  */
@@ -47,7 +47,7 @@ export namespace SaveModelAction {
 
 /**
  * The server sends this action to indicate to the client that the current model state on the server does not correspond
- * to the persisted model state of the model source. A client may ignore such an action or use it to indicate to the user the dirty state.
+ * to the persisted model state of the source model. A client may ignore such an action or use it to indicate to the user the dirty state.
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
  * and creating new `SetDirtyStateActions`.
  */


### PR DESCRIPTION
This is to be consistent with the term source model that we now use to refer to the underlying model from which the GModel is created.

https://github.com/eclipse-glsp/glsp/issues/655