### PR TITLE
Update workflow example to not use `GLSPProjectionView`

### DIFF
--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -21,8 +21,6 @@ import {
     DeleteElementContextMenuItemProvider,
     DiamondNodeView,
     editLabelFeature,
-    GLSPGraph,
-    GLSPProjectionView,
     GridSnapper,
     LogLevel,
     overrideViewerOptions,
@@ -55,7 +53,6 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     const context = { bind, unbind, isBound, rebind };
 
     configureDefaultModelElements(context);
-    configureModelElement(context, DefaultTypes.GRAPH, GLSPGraph, GLSPProjectionView);
     configureModelElement(context, 'task:automated', TaskNode, RoundedCornerNodeView);
     configureModelElement(context, 'task:manual', TaskNode, RoundedCornerNodeView);
     configureModelElement(context, 'label:heading', SLabel, SLabelView, { enable: [editLabelFeature] });


### PR DESCRIPTION
Temporary remove usage of `GLSPProjectionView` in the workflow example. 
Can be readded once https://github.com/eclipse-glsp/glsp/issues/689 is resolved.