### PR TITLE
694: Improve Layouter to support more dynamic layouts and complex parent/children node structures

### DIFF
--- a/examples/workflow-glsp/css/diagram.css
+++ b/examples/workflow-glsp/css/diagram.css
@@ -65,6 +65,13 @@
     fill: #5c87bd;
 }
 
+.category .category > .sprotty-node {
+    /** Add a border to nested categories, so we can distinguish them */
+    stroke: #38679a;
+    fill: #6f9ad0;
+    stroke-width: 1;
+}
+
 .sprotty-edge.weighted.low:not(.selected),
 .sprotty-edge.weighted.low:not(.selected) .arrow {
     stroke: rgb(128, 90, 233);

--- a/packages/client/src/features/layout/di.config.ts
+++ b/packages/client/src/features/layout/di.config.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ContainerModule } from 'inversify';
-import { configureActionHandler, configureLayout, HBoxLayouter, VBoxLayouter } from 'sprotty';
+import { configureActionHandler, configureLayout, HBoxLayouter, TYPES, VBoxLayouter } from 'sprotty';
 import { FreeFormLayouter } from './freeform-layout';
 import { HBoxLayouterExt } from './hbox-layout';
 import {
@@ -23,6 +23,7 @@ import {
     ResizeElementsAction,
     ResizeElementsActionHandler
 } from './layout-elements-action';
+import { LayouterExt } from './layouter';
 import { VBoxLayouterExt } from './vbox-layout';
 
 const layoutModule = new ContainerModule((bind, _unbind, isBound, rebind) => {
@@ -32,6 +33,7 @@ const layoutModule = new ContainerModule((bind, _unbind, isBound, rebind) => {
 
     rebind(VBoxLayouter).to(VBoxLayouterExt);
     rebind(HBoxLayouter).to(HBoxLayouterExt);
+    rebind(TYPES.Layouter).to(LayouterExt);
     configureLayout({ bind, isBound }, FreeFormLayouter.KIND, FreeFormLayouter);
 });
 

--- a/packages/client/src/features/layout/layouter.ts
+++ b/packages/client/src/features/layout/layouter.ts
@@ -1,0 +1,137 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    BoundsData,
+    ILogger,
+    LayoutRegistry,
+    StatefulLayouter,
+    SModelElement,
+    Layouter,
+    SParentElement,
+    LayoutContainer,
+    isLayoutContainer
+} from 'sprotty';
+import { injectable } from 'inversify';
+import { Bounds } from 'sprotty-protocol/lib/utils/geometry';
+
+@injectable()
+export class LayouterExt extends Layouter {
+    override layout(element2boundsData: Map<SModelElement, BoundsData>): void {
+        new StatefulLayouterExt(element2boundsData, this.layoutRegistry, this.logger).layout();
+    }
+}
+
+// 2-pass layout:
+// Step 1: Find "rendered size" of each element (may take resizeContainer into account)
+// Child-to-parent layout
+// Step 2: Extend parents as necessary, then use the adjusted parent size to properly
+// align children (center/end alignments, hGrab/vGrab)
+// Parent-to-children layout
+
+export class StatefulLayouterExt extends StatefulLayouter {
+    protected toBeLayouted2: (SParentElement & LayoutContainer)[];
+
+    /**
+     *
+     * @param elementToBoundsData The map of element to bounds data. Bounds Data are computed from the hidden
+     * SVG rendering pass.
+     * @param layoutRegistry2 The registry of available layouts.
+     * @param log The log.
+     */
+    constructor(
+        protected readonly elementToBoundsData: Map<SModelElement, BoundsData>,
+        protected readonly layoutRegistry2: LayoutRegistry,
+        log: ILogger
+    ) {
+        super(elementToBoundsData, layoutRegistry2, log);
+        this.toBeLayouted2 = [];
+        elementToBoundsData.forEach((data, element) => {
+            if (isLayoutContainer(element)) {
+                this.toBeLayouted2.push(element);
+            }
+        });
+        for (const element of this.toBeLayouted2) {
+            // Clear previous layout information for dynamic-layout objects
+            elementToBoundsData.delete(element);
+        }
+    }
+
+    override getBoundsData(element: SModelElement): BoundsData {
+        let boundsData = this.elementToBoundsData.get(element);
+        let bounds = (element as any).bounds;
+        if (isLayoutContainer(element) && this.toBeLayouted2.indexOf(element) >= 0) {
+            bounds = this.doLayout(element);
+        } else if (isLayoutContainer(element)) {
+            bounds = {
+                x: 0,
+                y: 0,
+                width: -1,
+                height: -1
+            };
+        }
+        if (!boundsData) {
+            boundsData = {
+                bounds: bounds,
+                boundsChanged: false,
+                alignmentChanged: false
+            };
+            this.elementToBoundsData.set(element, boundsData);
+        }
+        return boundsData;
+    }
+
+    override layout(): void {
+        // First pass: apply layout with cleared container data. Will get
+        // preferred size for all elements (Children first, then parents)
+        while (this.toBeLayouted2.length > 0) {
+            const element = this.toBeLayouted2[0];
+            this.doLayout(element);
+        }
+
+        this.toBeLayouted2 = [];
+        this.elementToBoundsData.forEach((data, element) => {
+            if (isLayoutContainer(element)) {
+                this.toBeLayouted2.push(element);
+            }
+        });
+
+        // Second pass: apply layout with initial size data for all
+        // nodes. Update the position/size of all elements, taking
+        // vGrab/hGrab into account (parent -> children).
+        while (this.toBeLayouted2.length > 0) {
+            const element = this.toBeLayouted2[0];
+            this.doLayout(element);
+        }
+    }
+
+    protected override doLayout(element: SParentElement & LayoutContainer): Bounds {
+        const index = this.toBeLayouted2.indexOf(element);
+        if (index >= 0) {
+            this.toBeLayouted2.splice(index, 1);
+        }
+        const layout = this.layoutRegistry2.get(element.layout);
+        if (layout) {
+            layout.layout(element, this);
+        }
+        const boundsData = this.elementToBoundsData.get(element);
+        if (boundsData !== undefined && boundsData.bounds !== undefined) {
+            return boundsData.bounds;
+        } else {
+            this.log.error(element, 'Layout failed');
+            return Bounds.EMPTY;
+        }
+    }
+}


### PR DESCRIPTION
This PR depends on https://github.com/eclipse-glsp/glsp-server/pull/175

- Introduce a new StatefulLayouter, which applies layout in 2 passes: children -> parent for the "minimal size" (resizeContainer), then parent -> children to take the correct parent size into account for alignment (alignment, vGrab/hGrab)
- Update HBox and VBox layouts to take the new layouter into account
- Do not inherit child-specific layout properties (PrefSize, Grab)
- Properly take padding into account
- Update the Style for nested categories, to make them more readable (Add a border, use a different color for nested categories)

fixes https://github.com/eclipse-glsp/glsp/issues/694
fixes https://github.com/eclipse-glsp/glsp/issues/610
fixes https://github.com/eclipse-glsp/glsp/issues/471

Contributed on behalf of STMicroelectronics.