### PR TITLE
Fix keylisteners when using 'GLSPProjectionView'

### DIFF
--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -21,6 +21,8 @@ import {
     DeleteElementContextMenuItemProvider,
     DiamondNodeView,
     editLabelFeature,
+    GLSPGraph,
+    GLSPProjectionView,
     GridSnapper,
     LogLevel,
     overrideViewerOptions,
@@ -66,7 +68,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     configureModelElement(context, 'activityNode:decision', ActivityNode, DiamondNodeView);
     configureModelElement(context, 'activityNode:fork', ActivityNode, RectangularNodeView);
     configureModelElement(context, 'activityNode:join', ActivityNode, RectangularNodeView);
-
+    configureModelElement(context, DefaultTypes.GRAPH, GLSPGraph, GLSPProjectionView);
     configureModelElement(context, 'category', CategoryNode, RoundedCornerNodeView);
     configureModelElement(context, 'struct', SCompartment, StructureCompartmentView);
 });

--- a/packages/client/src/views/glsp-projection-view.tsx
+++ b/packages/client/src/views/glsp-projection-view.tsx
@@ -25,6 +25,7 @@ import {
     ProjectedViewportView,
     ProjectionParams,
     RenderingContext,
+    setAttr,
     setClass,
     ViewportRootElement,
     ViewProjection
@@ -36,12 +37,18 @@ import {
 @injectable()
 export class GLSPProjectionView extends ProjectedViewportView {
     override render(model: Readonly<ViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode {
-        return (
-            <div class-sprotty-graph={true} style={{ width: '100%' }}>
-                {this.renderSvg(model, context, args)}
+        const svgElem = this.renderSvg(model, context, args);
+        if (svgElem.data) {
+            svgElem.data!.class = { 'sprotty-graph': true };
+        }
+        const rootNode: VNode = (
+            <div class-sprotty-graph={false} style={{ width: '100%' }}>
+                {svgElem}
                 {this.renderProjections(model, context, args)}
             </div>
         );
+        setAttr(rootNode, 'tabindex', 0);
+        return rootNode;
     }
 
     protected override renderSvg(model: Readonly<ViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode {

--- a/packages/client/src/views/glsp-projection-view.tsx
+++ b/packages/client/src/views/glsp-projection-view.tsx
@@ -42,7 +42,7 @@ export class GLSPProjectionView extends ProjectedViewportView {
             svgElem.data!.class = { 'sprotty-graph': true };
         }
         const rootNode: VNode = (
-            <div class-sprotty-graph={false} style={{ width: '100%' }}>
+            <div class-sprotty-graph={false} style={{ width: '100%', height: '100%' }}>
                 {svgElem}
                 {this.renderProjections(model, context, args)}
             </div>


### PR DESCRIPTION
Fixes the [Broken Keylisteners](https://github.com/eclipse-glsp/glsp/issues/689) when using the GLSPProjection view by making the container `div` focusable.