### PR TITLE
Update sprotty + use new button registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   [layout] Improve Layouter to support more dynamic layouts and complex parent/children node structures [#187](https://github.com/eclipse-glsp/glsp-client/pull/187) - Contributed on behalf of STMicroelectronics
 
+### Breaking Changes
+
+-   [DI] Injecting an `IButtonHandler` constructor is now deprecated. Please use `configureButtonHandler()` instead. [#195](https://github.com/eclipse-glsp/glsp-client/pull/195) - Contributed on behalf of STMicroelectronics
+
 ## [v1.0.0 - 30/06/2022](https://github.com/eclipse-glsp/glsp-client/releases/tag/v1.0.0)
 
 ### Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@eclipse-glsp/protocol": "1.1.0-next",
     "autocompleter": "5.1.0",
-    "sprotty": "0.12.0"
+    "sprotty": "0.13.0-next.1c4343c.328"
   },
   "devDependencies": {
     "@vscode/codicons": "^0.0.25",

--- a/packages/client/src/sprotty-reexport.ts
+++ b/packages/client/src/sprotty-reexport.ts
@@ -104,7 +104,12 @@ export {
 export * from 'sprotty/lib/features/bounds/stack-layout';
 export * from 'sprotty/lib/features/bounds/vbox-layout';
 export * from 'sprotty/lib/features/bounds/views';
-export * from 'sprotty/lib/features/button/button-handler';
+export {
+    ButtonHandlerRegistry,
+    configureButtonHandler,
+    IButtonHandler,
+    IButtonHandlerRegistration
+} from 'sprotty/lib/features/button/button-handler';
 export * from 'sprotty/lib/features/button/model';
 export * from 'sprotty/lib/features/command-palette/action-providers';
 export * from 'sprotty/lib/features/command-palette/command-palette';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6832,22 +6832,27 @@ split@^1.0.0:
   dependencies:
     through "2"
 
-sprotty-protocol@0.12.0, sprotty-protocol@~0.12.0:
+sprotty-protocol@0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.12.0.tgz#542eb6396a645f85f8cfc2e7ef1d9b90c7b1980b"
   integrity sha512-vbov+XfbmSeMYb46vm6dJvK3q7YKUvg0q7JnM6H7Ca5qY8TaZCEZ5Vc8zHKFZGWchcwnQYKqLTzwDItsMikD0A==
 
-sprotty@0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.12.0.tgz#693432346d9321bb19f368c6806641539962db99"
-  integrity sha512-0RjRn3iR9McDt+LZ+cyySfdBdWyzR4kPbg4xESumvoSPziHphs6TdM7CvJ9ywTMmG131nKUF6GgbzhQZ+L6cGg==
+sprotty-protocol@0.13.0-next.1c4343c.328+1c4343c:
+  version "0.13.0-next.1c4343c.328"
+  resolved "https://registry.npmjs.org/sprotty-protocol/-/sprotty-protocol-0.13.0-next.1c4343c.328.tgz#3354fbf5eb405b289f0784f70c508cc99d6ef131"
+  integrity sha512-sprFlSDmNBHlgAgAq2vM7hllfvb8GTVAM6u0Ws7tPAnicTAA/ulmiYbeYfvJZH5uuAasSW2B7ieWzg1+kgF/xg==
+
+sprotty@0.13.0-next.1c4343c.328:
+  version "0.13.0-next.1c4343c.328"
+  resolved "https://registry.npmjs.org/sprotty/-/sprotty-0.13.0-next.1c4343c.328.tgz#ab943696ebae2be75dedc33e751b2792ec6914c8"
+  integrity sha512-6+//jO+c3ix5Sj2JG6lkHlp81PSY1/7ZGIw5DLipLwmZ/VSgFyU4JbOlXdk2FCMqUCgA77QZnU8mMmMwrDDm9A==
   dependencies:
     "@vscode/codicons" "^0.0.25"
     autocompleter "^5.1.0"
     file-saver "^2.0.2"
     inversify "^5.1.1"
     snabbdom "^3.0.3"
-    sprotty-protocol "~0.12.0"
+    sprotty-protocol "0.13.0-next.1c4343c.328+1c4343c"
     tinyqueue "^2.0.3"
 
 sshpk@^1.7.0:


### PR DESCRIPTION
Injecting a `ButtonHandler` constructor is deprecated by sprotty.
Stop reexporting the deprecated registration.
Reexport new registration method `configureButtonHandler`.

Contributed on behalf of STMicroelectronics