### PR TITLE
Allow the first Manhattan routing point to be moved

### DIFF
--- a/packages/client/src/features/tools/di.config.ts
+++ b/packages/client/src/features/tools/di.config.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { TriggerEdgeCreationAction, TriggerNodeCreationAction } from '@eclipse-glsp/protocol';
 import { ContainerModule, interfaces } from 'inversify';
-import { configureActionHandler, configureModelElement } from 'sprotty';
+import { configureActionHandler, configureModelElement, ManhattanEdgeRouter } from 'sprotty';
 import { FocusStateChangedAction } from '../../base/actions/focus-change-action';
 import { TYPES } from '../../base/types';
 import { GLSPSvgExporter } from '../export/glsp-svg-exporter';
@@ -25,6 +25,7 @@ import { DelKeyDeleteTool, MouseDeleteTool } from './delete-tool';
 import { EdgeCreationTool } from './edge-creation-tool';
 import { EdgeEditTool } from './edge-edit-tool';
 import { EnableDefaultToolsOnFocusLossHandler } from './enable-default-tools-on-focus-loss';
+import { GSLPManhattanEdgeRouter } from './glsp-manhattan-edge-router';
 import { MarqueeMouseTool } from './marquee-mouse-tool';
 import { MarqueeTool } from './marquee-tool';
 import { MarqueeNode } from './model';
@@ -54,6 +55,9 @@ export const toolsModule = new ContainerModule((bind, _unbind, isBound, rebind) 
 
     bind(GLSPSvgExporter).toSelf().inSingletonScope();
     rebind(TYPES.SvgExporter).toService(GLSPSvgExporter);
+
+    bind(GSLPManhattanEdgeRouter).toSelf().inSingletonScope();
+    rebind(ManhattanEdgeRouter).toService(GSLPManhattanEdgeRouter);
 });
 
 export function configureMarqueeTool(context: { bind: interfaces.Bind; isBound: interfaces.IsBound }): void {

--- a/packages/client/src/features/tools/glsp-manhattan-edge-router.ts
+++ b/packages/client/src/features/tools/glsp-manhattan-edge-router.ts
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { almostEquals } from '@eclipse-glsp/protocol';
+import { ManhattanEdgeRouter, ResolvedHandleMove, SRoutableElement } from 'sprotty';
+
+export class GSLPManhattanEdgeRouter extends ManhattanEdgeRouter {
+    protected override applyInnerHandleMoves(edge: SRoutableElement, moves: ResolvedHandleMove[]): void {
+        const route = this.route(edge);
+        const routingPoints = edge.routingPoints;
+        const minimalPointDistance = this.getOptions(edge).minimalPointDistance;
+        moves.forEach(move => {
+            const handle = move.handle;
+            const index = handle.pointIndex;
+            const correctedX = this.correctX(routingPoints, index, move.toPosition.x, minimalPointDistance);
+            const correctedY = this.correctY(routingPoints, index, move.toPosition.y, minimalPointDistance);
+            switch (handle.kind) {
+                case 'manhattan-50%':
+                    if (index < 0) {
+                        if (routingPoints.length === 0) {
+                            routingPoints.push({ x: correctedX, y: correctedY });
+                            move.handle.pointIndex = 0;
+                        }
+                        else if (almostEquals(route[0].x, route[1].x)) { this.alignX(routingPoints, 0, correctedX); }
+                        else { this.alignY(routingPoints, 0, correctedY); }
+                    } else if (index < routingPoints.length - 1) {
+                        if (almostEquals(routingPoints[index].x, routingPoints[index + 1].x)) {
+                            this.alignX(routingPoints, index, correctedX);
+                            this.alignX(routingPoints, index + 1, correctedX);
+                        } else {
+                            this.alignY(routingPoints, index, correctedY);
+                            this.alignY(routingPoints, index + 1, correctedY);
+                        }
+                    } else {
+                        if (almostEquals(route[route.length - 2].x, route[route.length - 1].x)) {
+                            this.alignX(routingPoints, routingPoints.length - 1, correctedX);
+                        }
+                        else { this.alignY(routingPoints, routingPoints.length - 1, correctedY); }
+                    }
+                    break;
+            }
+        });
+    }
+}


### PR DESCRIPTION
This is not fixing the complete [issue as reported in Sprotty](https://github.com/eclipse/sprotty/issues/310) but mitigates the problem by making the routing point movable:

![image](https://user-images.githubusercontent.com/19170971/189324417-b1270647-3827-40d4-a116-465dfa5d0ad9.gif) 

Relates to https://github.com/eclipse-glsp/glsp/issues/657