### PR TITLE
Fix copy&paste support for GLSPProjectionView

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf lib tsconfig.tsbuildinfo ",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
     "lint": "eslint --ext .ts,.tsx ./src",
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
     "prepare": "yarn clean && yarn build",

--- a/packages/client/src/features/copy-paste/copy-paste-handler.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-handler.ts
@@ -134,19 +134,15 @@ export class ServerCopyPasteHandler implements ICopyPasteHandler {
         }
     }
 
-    protected shouldCopy(_event: ClipboardEvent): boolean | null {
+    protected shouldCopy(_event: ClipboardEvent): boolean {
         return this.editorContext.get().selectedElementIds.length > 0 && this.isDiagramActive();
     }
 
-    protected shouldPaste(_event: ClipboardEvent): boolean | null {
+    protected shouldPaste(_event: ClipboardEvent): boolean {
         return this.isDiagramActive();
     }
 
-    private isDiagramActive(): boolean | null {
-        return (
-            document.activeElement instanceof SVGElement &&
-            document.activeElement.parentElement &&
-            document.activeElement.parentElement.id === this.viewerOptions.baseDiv
-        );
+    private isDiagramActive(): boolean {
+        return document.activeElement?.parentElement?.id === this.viewerOptions.baseDiv;
     }
 }


### PR DESCRIPTION
The `isDiagramActive` method of the copy-paste handler did check whether the active element is an instance of svg. 
In the case of the `GLSPProjectionView` this check failed because the SVG is contained by a wrapper container.
We can omit this part of the check entirely because we already know that the diagram is active if the parent of the active element is the `baseDiv`

Fixes https://github.com/eclipse-glsp/glsp/issues/827