### PR TITLE
Upgrade Sprotty to consume label edit UI fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   [DI] Injecting an `IButtonHandler` constructor is now deprecated. Please use `configureButtonHandler()` instead. [#195](https://github.com/eclipse-glsp/glsp-client/pull/195) - Contributed on behalf of STMicroelectronics
 -   [protocol] Update vscode-ws-jsonrpc to version 2.0.1 [#210](https://github.com/eclipse-glsp/glsp-client/pull/210)
 -   [node] Update minimum requirements for Node to >=16.11.0 [#210](https://github.com/eclipse-glsp/glsp-client/pull/210)
+-   [protocol] Renamed `UndoOperation` and `RedoOperation` to `UndoAction` and `RedoAction` to match operation specification [#216](https://github.com/eclipse-glsp/glsp-client/pull/216)
 
 ## [v1.0.0 - 30/06/2022](https://github.com/eclipse-glsp/glsp-client/releases/tag/v1.0.0)
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@eclipse-glsp/protocol": "1.1.0-next",
     "autocompleter": "5.1.0",
-    "sprotty": "0.13.0-next.1c4343c.328"
+    "sprotty": "0.13.0-next.f4445dd.342"
   },
   "devDependencies": {
     "@vscode/codicons": "^0.0.25"

--- a/packages/client/src/base/command-stack.ts
+++ b/packages/client/src/base/command-stack.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { RedoOperation, UndoOperation } from '@eclipse-glsp/protocol';
+import { RedoAction, UndoAction } from '@eclipse-glsp/protocol';
 import { inject, injectable } from 'inversify';
 import { CommandStack, IActionDispatcher, SModelRoot } from 'sprotty';
 import { TYPES } from './types';
@@ -23,12 +23,12 @@ export class GLSPCommandStack extends CommandStack {
     @inject(TYPES.IActionDispatcherProvider) protected actionDispatcher: () => Promise<IActionDispatcher>;
 
     override undo(): Promise<SModelRoot> {
-        this.actionDispatcher().then(dispatcher => dispatcher.dispatch(UndoOperation.create()));
+        this.actionDispatcher().then(dispatcher => dispatcher.dispatch(UndoAction.create()));
         return this.thenUpdate();
     }
 
     override redo(): Promise<SModelRoot> {
-        this.actionDispatcher().then(dispatcher => dispatcher.dispatch(RedoOperation.create()));
+        this.actionDispatcher().then(dispatcher => dispatcher.dispatch(RedoAction.create()));
         return this.thenUpdate();
     }
 }

--- a/packages/client/src/features/hover/hover.ts
+++ b/packages/client/src/features/hover/hover.ts
@@ -23,7 +23,8 @@ import {
     SModelRootSchema
 } from '@eclipse-glsp/protocol';
 import { injectable } from 'inversify';
-import { EMPTY_ROOT, HoverFeedbackAction, HoverMouseListener, IActionHandler, ICommand, SModelElement } from 'sprotty';
+import { EMPTY_ROOT, HoverMouseListener, IActionHandler, ICommand, SModelElement } from 'sprotty';
+import { HoverFeedbackAction } from 'sprotty-protocol/lib/actions';
 import { FocusStateChangedAction } from '../../base/actions/focus-change-action';
 import { EnableDefaultToolsAction, EnableToolsAction } from '../../base/tool-manager/tool-actions';
 import { EdgeCreationTool } from '../tools/edge-creation-tool';

--- a/packages/client/src/features/layout/layout-elements-action.ts
+++ b/packages/client/src/features/layout/layout-elements-action.ts
@@ -24,7 +24,8 @@ import {
     Writable
 } from '@eclipse-glsp/protocol';
 import { inject, injectable, optional } from 'inversify';
-import { ElementMove, IActionDispatcher, IActionHandler, ICommand, MoveAction, SModelElement } from 'sprotty';
+import { ElementMove, IActionDispatcher, IActionHandler, ICommand, SModelElement } from 'sprotty';
+import { MoveAction } from 'sprotty-protocol/lib/actions';
 import { TYPES } from '../../base/types';
 import { toValidElementAndBounds, toValidElementMove } from '../../utils/layout-utils';
 import { BoundsAwareModelElement, getElements } from '../../utils/smodel-util';

--- a/packages/client/src/features/select/select-mouse-listener.ts
+++ b/packages/client/src/features/select/select-mouse-listener.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 import { Action, SelectAction } from '@eclipse-glsp/protocol';
 import {
-    BringToFrontAction,
     findParentByFeature,
     isCtrlOrCmd,
     isSelectable,
@@ -27,6 +26,7 @@ import {
     SRoutingHandle,
     SwitchEditModeAction
 } from 'sprotty';
+import { BringToFrontAction } from 'sprotty-protocol/lib/actions';
 import { toArray } from 'sprotty/lib/utils/iterable';
 import { DEFAULT_RANK, Ranked } from '../rank/model';
 
@@ -37,7 +37,7 @@ import { DEFAULT_RANK, Ranked } from '../rank/model';
 export class RankedSelectMouseListener extends SelectMouseListener implements Ranked {
     rank: number = DEFAULT_RANK - 1; /* we want to be executed before all default mouse listeners */
 
-    override mouseDown(target: SModelElement, event: MouseEvent): Action[] {
+    override mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         const result: Action[] = [];
         if (this.buttonHandlerRegistry !== undefined && target instanceof SButton && target.enabled) {
             const buttonHandler = this.buttonHandlerRegistry.get(target.type);

--- a/packages/client/src/features/tool-feedback/change-bounds-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/change-bounds-tool-feedback.ts
@@ -25,12 +25,12 @@ import {
     isSelectable,
     isViewport,
     MouseListener,
-    MoveAction,
     SChildElement,
     SModelElement,
     SModelRoot,
     TYPES
 } from 'sprotty';
+import { MoveAction } from 'sprotty-protocol/lib/actions';
 import { forEachElement } from '../../utils/smodel-util';
 import { addResizeHandles, isResizable, removeResizeHandles, SResizeHandle } from '../change-bounds/model';
 import { createMovementRestrictionFeedback, removeMovementRestrictionFeedback } from '../change-bounds/movement-restrictor';

--- a/packages/client/src/features/tool-feedback/creation-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/creation-tool-feedback.ts
@@ -24,7 +24,6 @@ import {
     isBoundsAware,
     isConnectable,
     MouseListener,
-    MoveAction,
     PolylineEdgeRouter,
     SChildElement,
     SConnectableElement,
@@ -35,6 +34,7 @@ import {
     SRoutableElement,
     TYPES
 } from 'sprotty';
+import { MoveAction } from 'sprotty-protocol/lib/actions';
 import { BoundsAwareModelElement, isRoutable } from '../../utils/smodel-util';
 import { getAbsolutePosition, toAbsoluteBounds, toAbsolutePosition } from '../../utils/viewpoint-util';
 import { FeedbackCommand } from './model';

--- a/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
@@ -29,7 +29,6 @@ import {
     ISnapper,
     isSelected,
     MouseListener,
-    MoveAction,
     PolylineEdgeRouter,
     SConnectableElement,
     SModelElement,
@@ -39,6 +38,7 @@ import {
     SwitchEditModeCommand,
     TYPES
 } from 'sprotty';
+import { MoveAction } from 'sprotty-protocol/lib/actions';
 import { forEachElement, isRoutable, isRoutingHandle } from '../../utils/smodel-util';
 import { getAbsolutePosition, toAbsoluteBounds } from '../../utils/viewpoint-util';
 import { PointPositionUpdater } from '../change-bounds/snap';

--- a/packages/client/src/sprotty-reexport.ts
+++ b/packages/client/src/sprotty-reexport.ts
@@ -22,7 +22,10 @@
 
 export * from '@eclipse-glsp/protocol';
 // sprotty-protocol
-export { CollapseExpandAction, CollapseExpandAllAction, ElementAndAlignment, SetBoundsAction } from 'sprotty-protocol/lib/actions';
+export {
+    BringToFrontAction, CollapseExpandAction, CollapseExpandAllAction,
+    ElementAndAlignment, HoverFeedbackAction, MoveAction, SetBoundsAction
+} from 'sprotty-protocol/lib/actions';
 export { Viewport } from 'sprotty-protocol/lib/model';
 // ------------------ Base ------------------
 export * from 'sprotty/lib/base/actions/action-dispatcher';
@@ -144,7 +147,6 @@ export * from 'sprotty/lib/features/fade/model';
 export {
     AbstractHoverMouseListener,
     ClosePopupActionHandler,
-    HoverFeedbackAction,
     HoverFeedbackCommand,
     HoverKeyListener,
     HoverMouseListener,
@@ -154,7 +156,10 @@ export {
 } from 'sprotty/lib/features/hover/hover';
 export * from 'sprotty/lib/features/hover/model';
 export * from 'sprotty/lib/features/move/model';
-export * from 'sprotty/lib/features/move/move';
+export {
+    ElementMove, LocationPostprocessor, MorphEdgesAnimation, MoveAnimation,
+    MoveCommand, MoveMouseListener, ResolvedElementMove, ResolvedHandleMove
+} from 'sprotty/lib/features/move/move';
 export * from 'sprotty/lib/features/move/snap';
 export * from 'sprotty/lib/features/nameable/model';
 export * from 'sprotty/lib/features/open/model';
@@ -182,7 +187,7 @@ export {
     SelectKeyboardListener,
     SelectMouseListener
 } from 'sprotty/lib/features/select/select';
-export * from 'sprotty/lib/features/undo-redo/undo-redo';
+export { UndoRedoKeyListener } from 'sprotty/lib/features/undo-redo/undo-redo';
 export * from 'sprotty/lib/features/update/model-matching';
 export { UpdateAnimationData, UpdateModelCommand } from 'sprotty/lib/features/update/update-model';
 export {
@@ -202,7 +207,7 @@ export {
 } from 'sprotty/lib/features/viewport/viewport';
 export * from 'sprotty/lib/features/viewport/viewport-root';
 export * from 'sprotty/lib/features/viewport/zoom';
-export * from 'sprotty/lib/features/zorder/zorder';
+export { BringToFrontCommand, ZOrderElement } from 'sprotty/lib/features/zorder/zorder';
 export { SCompartment, SEdge, SGraph, SGraphIndex, SLabel, SNode, SPort } from 'sprotty/lib/graph/sgraph';
 // ------------------ Graph ------------------
 export * from 'sprotty/lib/graph/sgraph-factory';
@@ -286,3 +291,4 @@ import viewportModule from 'sprotty/lib/features/viewport/di.config';
 import zorderModule from 'sprotty/lib/features/zorder/di.config';
 import graphModule from 'sprotty/lib/graph/di.config';
 import modelSourceModule from 'sprotty/lib/model-source/di.config';
+

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -33,7 +33,7 @@
     "src"
   ],
   "dependencies": {
-    "sprotty-protocol": "0.12.0",
+    "sprotty-protocol": "0.13.0-next.f4445dd.342",
     "vscode-ws-jsonrpc": "^2.0.1",
     "uuid": "7.0.3"
   },

--- a/packages/protocol/src/action-protocol/element-creation.ts
+++ b/packages/protocol/src/action-protocol/element-creation.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { Point } from 'sprotty-protocol';
+import * as sprotty from 'sprotty-protocol/lib/actions';
 import { hasArrayProp, hasStringProp } from '../utils/type-util';
 import { Operation } from './base-protocol';
 import { Args } from './types';
@@ -131,7 +132,7 @@ export namespace CreateEdgeOperation {
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
  * and creating new `DeleteElementOperations`.
  */
-export interface DeleteElementOperation extends Operation {
+export interface DeleteElementOperation extends Operation, Omit<sprotty.DeleteElementAction, 'kind'> {
     kind: typeof DeleteElementOperation.KIND;
 
     /**

--- a/packages/protocol/src/action-protocol/element-text-editing.ts
+++ b/packages/protocol/src/action-protocol/element-text-editing.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import * as sprotty from 'sprotty-protocol/lib/actions';
 import { hasObjectProp, hasStringProp } from '../utils/type-util';
 import { Action, Operation, RequestAction, ResponseAction } from './base-protocol';
 import { Args } from './types';
@@ -107,7 +108,7 @@ export namespace SetEditValidationResultAction {
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
  * and creating new `ApplyLabelEditOperations`.
  */
-export interface ApplyLabelEditOperation extends Operation {
+export interface ApplyLabelEditOperation extends Operation, sprotty.ApplyLabelEditAction {
     kind: typeof ApplyLabelEditOperation.KIND;
 
     /**

--- a/packages/protocol/src/action-protocol/undo-redo.spec.ts
+++ b/packages/protocol/src/action-protocol/undo-redo.spec.ts
@@ -14,61 +14,57 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { expect } from 'chai';
-import { RedoOperation, UndoOperation } from './undo-redo';
+import { RedoAction, UndoAction } from './undo-redo';
 
 describe('Undo & Redo Actions', () => {
-    describe('UndoOperation', () => {
+    describe('UndoAction', () => {
         describe('is', () => {
             it('should return true for an object having the correct type and a value for all required interface properties', () => {
-                const action: UndoOperation = {
-                    kind: 'glspUndo',
-                    isOperation: true
+                const action: UndoAction = {
+                    kind: 'glspUndo'
                 };
-                expect(UndoOperation.is(action)).to.be.true;
+                expect(UndoAction.is(action)).to.be.true;
             });
             it('should return false for `undefined`', () => {
-                expect(UndoOperation.is(undefined)).to.be.false;
+                expect(UndoAction.is(undefined)).to.be.false;
             });
             it('should return false for an object that does not have all required interface properties', () => {
-                expect(UndoOperation.is({ kind: 'notTheRightOne' })).to.be.false;
+                expect(UndoAction.is({ kind: 'notTheRightOne' })).to.be.false;
             });
         });
 
         describe('create', () => {
             it('should return an object conforming to the interface with matching properties for the given required arguments', () => {
-                const expected: UndoOperation = {
-                    kind: 'glspUndo',
-                    isOperation: true
+                const expected: UndoAction = {
+                    kind: 'glspUndo'
                 };
-                expect(UndoOperation.create()).to.deep.equals(expected);
+                expect(UndoAction.create()).to.deep.equals(expected);
             });
         });
     });
 
-    describe('RedoOperation', () => {
+    describe('RedoAction', () => {
         describe('is', () => {
             it('should return true for an object having the correct type and a value for all required interface properties', () => {
-                const action: RedoOperation = {
-                    kind: 'glspRedo',
-                    isOperation: true
+                const action: RedoAction = {
+                    kind: 'glspRedo'
                 };
-                expect(RedoOperation.is(action)).to.be.true;
+                expect(RedoAction.is(action)).to.be.true;
             });
             it('should return false for `undefined`', () => {
-                expect(RedoOperation.is(undefined)).to.be.false;
+                expect(RedoAction.is(undefined)).to.be.false;
             });
             it('should return false for an object that does not have all required interface properties', () => {
-                expect(RedoOperation.is({ kind: 'notTheRightOne' })).to.be.false;
+                expect(RedoAction.is({ kind: 'notTheRightOne' })).to.be.false;
             });
         });
 
         describe('create', () => {
             it('should return an object conforming to the interface with matching properties for the given required arguments', () => {
-                const expected: RedoOperation = {
-                    kind: 'glspRedo',
-                    isOperation: true
+                const expected: RedoAction = {
+                    kind: 'glspRedo'
                 };
-                expect(RedoOperation.create()).to.deep.equals(expected);
+                expect(RedoAction.create()).to.deep.equals(expected);
             });
         });
     });

--- a/packages/protocol/src/action-protocol/undo-redo.ts
+++ b/packages/protocol/src/action-protocol/undo-redo.ts
@@ -14,28 +14,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Operation } from './base-protocol';
-
+import * as sprotty from 'sprotty-protocol/lib/actions';
+import { Action } from './base-protocol';
 /**
  * Trigger an undo of the latest executed command.
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
- * and creating new `UndoOperations`.
+ * and creating new `UndoAction`.
  */
-export interface UndoOperation extends Operation {
-    kind: typeof UndoOperation.KIND;
+export interface UndoAction extends Omit<sprotty.UndoAction, 'kind'> {
+    kind: typeof UndoAction.KIND;
 }
 
-export namespace UndoOperation {
+export namespace UndoAction {
     export const KIND = 'glspUndo';
 
-    export function is(object: any): object is UndoOperation {
-        return Operation.hasKind(object, KIND);
+    export function is(object: any): object is UndoAction {
+        return Action.hasKind(object, KIND);
     }
 
-    export function create(): UndoOperation {
+    export function create(): UndoAction {
         return {
-            kind: KIND,
-            isOperation: true
+            kind: KIND
         };
     }
 }
@@ -43,23 +42,22 @@ export namespace UndoOperation {
 /**
  * Trigger a redo of the latest undone command.
  * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
- * and creating new `RedoOperations`.
+ * and creating new `RedoAction`.
  */
-export interface RedoOperation extends Operation {
-    kind: typeof RedoOperation.KIND;
+export interface RedoAction extends Omit<sprotty.RedoAction, 'kind'> {
+    kind: typeof RedoAction.KIND;
 }
 
-export namespace RedoOperation {
+export namespace RedoAction {
     export const KIND = 'glspRedo';
 
-    export function is(object: any): object is RedoOperation {
-        return Operation.hasKind(object, KIND);
+    export function is(object: any): object is RedoAction {
+        return Action.hasKind(object, KIND);
     }
 
-    export function create(): RedoOperation {
+    export function create(): RedoAction {
         return {
-            kind: KIND,
-            isOperation: true
+            kind: KIND
         };
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5738,27 +5738,21 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sprotty-protocol@0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.12.0.tgz#542eb6396a645f85f8cfc2e7ef1d9b90c7b1980b"
-  integrity sha512-vbov+XfbmSeMYb46vm6dJvK3q7YKUvg0q7JnM6H7Ca5qY8TaZCEZ5Vc8zHKFZGWchcwnQYKqLTzwDItsMikD0A==
+sprotty-protocol@0.13.0-next.f4445dd.342, sprotty-protocol@0.13.0-next.f4445dd.342+f4445dd:
+  version "0.13.0-next.f4445dd.342"
+  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.13.0-next.f4445dd.342.tgz#79e39a3427202d59173f61f3f03429dfdec7ab9c"
+  integrity sha512-6cNoZrvay1Gk3uk6NqlmraBy68dskvhuDKDiUlpxbzFQ/ZVO4MKY2D41S5AXzjDyOtYQO6tZjlPrNCjmj5Kvrg==
 
-sprotty-protocol@0.13.0-next.1c4343c.328+1c4343c:
-  version "0.13.0-next.1c4343c.328"
-  resolved "https://registry.npmjs.org/sprotty-protocol/-/sprotty-protocol-0.13.0-next.1c4343c.328.tgz#3354fbf5eb405b289f0784f70c508cc99d6ef131"
-  integrity sha512-sprFlSDmNBHlgAgAq2vM7hllfvb8GTVAM6u0Ws7tPAnicTAA/ulmiYbeYfvJZH5uuAasSW2B7ieWzg1+kgF/xg==
-
-sprotty@0.13.0-next.1c4343c.328:
-  version "0.13.0-next.1c4343c.328"
-  resolved "https://registry.npmjs.org/sprotty/-/sprotty-0.13.0-next.1c4343c.328.tgz#ab943696ebae2be75dedc33e751b2792ec6914c8"
-  integrity sha512-6+//jO+c3ix5Sj2JG6lkHlp81PSY1/7ZGIw5DLipLwmZ/VSgFyU4JbOlXdk2FCMqUCgA77QZnU8mMmMwrDDm9A==
+sprotty@0.13.0-next.f4445dd.342:
+  version "0.13.0-next.f4445dd.342"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.13.0-next.f4445dd.342.tgz#053fc2863109bc56f32ab6582a9c8ce46dc10cbd"
+  integrity sha512-OdaNjgaITsQz71w+omc9ZSP3TJ/66vlVdWkVg+zGPQ1spAmS/iXvYhizax7OuP5J+GsjQemCDw9ZWH8lTnbgrw==
   dependencies:
-    "@vscode/codicons" "^0.0.25"
     autocompleter "^5.1.0"
     file-saver "^2.0.2"
     inversify "^5.1.1"
     snabbdom "^3.0.3"
-    sprotty-protocol "0.13.0-next.1c4343c.328+1c4343c"
+    sprotty-protocol "0.13.0-next.f4445dd.342+f4445dd"
     tinyqueue "^2.0.3"
 
 ssri@^9.0.0, ssri@^9.0.1:


### PR DESCRIPTION
- Keep kind for DeleteElementOperation, UndoAction and RedoAction

Part of https://github.com/eclipse-glsp/glsp/issues/766