### PR TITLE
Ensure that startup UI extensions are rendered correctly

### DIFF
--- a/examples/workflow-standalone/src/app.ts
+++ b/examples/workflow-standalone/src/app.ts
@@ -18,9 +18,9 @@ import {
     BaseJsonrpcGLSPClient,
     configureServerActions,
     EnableToolPaletteAction,
+    GLSPActionDispatcher,
     GLSPClient,
     GLSPDiagramServer,
-    IActionDispatcher,
     RequestModelAction,
     RequestTypeHintsAction,
     TYPES
@@ -56,7 +56,7 @@ async function initialize(connectionProvider: MessageConnection): Promise<void> 
     });
     await configureServerActions(result, diagramType, container);
 
-    const actionDispatcher = container.get<IActionDispatcher>(TYPES.IActionDispatcher);
+    const actionDispatcher = container.get(GLSPActionDispatcher);
 
     await client.initializeClientSession({ clientSessionId: diagramServer.clientId, diagramType });
     actionDispatcher.dispatch(
@@ -68,6 +68,7 @@ async function initialize(connectionProvider: MessageConnection): Promise<void> 
         })
     );
     actionDispatcher.dispatch(RequestTypeHintsAction.create());
+    await actionDispatcher.onceModelInitialized();
     actionDispatcher.dispatch(EnableToolPaletteAction.create());
 }
 


### PR DESCRIPTION
UI extensions that should be active i.e. visible on startup might be activated to early (before the initial model loading is completed) which can cause rendering issues in some cases. This can be avoided by enabling these UI extensions after the model has been initialized. (see also https://github.com/eclipse-glsp/glsp/issues/585)

For the ToolPalette in particular this issue is not noticeable in the workflow diagram because the extension is activated after it has retrieved all tool palette items from the server. This typically takes longer than the initial model loading. Nevertheless we should simply establish the best practice of always enabling UI extensions after the model initialization.