### PR TITLE
Cleanup diagram modules

### DIFF
--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -17,7 +17,7 @@ import {
     configureDefaultModelElements,
     configureModelElement,
     ConsoleLogger,
-    createClientContainer,
+    createDiagramContainer,
     DeleteElementContextMenuItemProvider,
     DiamondNodeView,
     editLabelFeature,
@@ -74,7 +74,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
 });
 
 export default function createContainer(widgetId: string): Container {
-    const container = createClientContainer(workflowDiagramModule, directTaskEditor);
+    const container = createDiagramContainer(workflowDiagramModule, directTaskEditor);
     overrideViewerOptions(container, {
         baseDiv: widgetId,
         hiddenDiv: widgetId + '_hidden'

--- a/packages/client/src/features/export/di.config.ts
+++ b/packages/client/src/features/export/di.config.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from 'inversify';
+import { configureCommand, ExportSvgCommand, ExportSvgKeyListener, ExportSvgPostprocessor, TYPES } from 'sprotty';
+import { GLSPSvgExporter } from './glsp-svg-exporter';
+
+const glspExportSvgModule = new ContainerModule((bind, _unbind, isBound) => {
+    bind(ExportSvgKeyListener).toSelf().inSingletonScope();
+    bind(TYPES.KeyListener).toService(ExportSvgKeyListener);
+    bind(TYPES.HiddenVNodePostprocessor).to(ExportSvgPostprocessor).inSingletonScope();
+    configureCommand({ bind, isBound }, ExportSvgCommand);
+    bind(TYPES.SvgExporter).to(GLSPSvgExporter).inSingletonScope();
+});
+
+export default glspExportSvgModule;

--- a/packages/client/src/features/layout/tests/layouter-test-util.ts
+++ b/packages/client/src/features/layout/tests/layouter-test-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 STMicroelectronics and others.
+ * Copyright (c) 2022-2023 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,7 +30,7 @@ import {
     SParentElement,
     TYPES
 } from 'sprotty';
-import { createClientContainer } from '../../../base/container-modules';
+import { createDiagramContainer } from '../../../base/container-modules';
 import { GLSPGraph } from '../../../lib/model';
 import { StatefulLayouterExt } from '../layouter';
 
@@ -117,6 +117,6 @@ export function layout(
 export function setupLayoutRegistry(): LayoutRegistry {
     // Generic Test setup
     // create client container that registers all default modules including the layoutModule
-    const layoutContainer = createClientContainer();
+    const layoutContainer = createDiagramContainer();
     return layoutContainer.get<LayoutRegistry>(TYPES.LayoutRegistry);
 }

--- a/packages/client/src/features/tools/di.config.ts
+++ b/packages/client/src/features/tools/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2022 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,7 +18,6 @@ import { ContainerModule, interfaces } from 'inversify';
 import { configureActionHandler, configureModelElement, ManhattanEdgeRouter } from 'sprotty';
 import { FocusStateChangedAction } from '../../base/actions/focus-change-action';
 import { TYPES } from '../../base/types';
-import { GLSPSvgExporter } from '../export/glsp-svg-exporter';
 import { MARQUEE } from '../tool-feedback/marquee-tool-feedback';
 import { ChangeBoundsTool } from './change-bounds-tool';
 import { DelKeyDeleteTool, MouseDeleteTool } from './delete-tool';
@@ -52,9 +51,6 @@ export const toolsModule = new ContainerModule((bind, _unbind, isBound, rebind) 
     configureMarqueeTool({ bind, isBound });
     configureActionHandler({ bind, isBound }, TriggerNodeCreationAction.KIND, NodeCreationTool);
     configureActionHandler({ bind, isBound }, TriggerEdgeCreationAction.KIND, EdgeCreationTool);
-
-    bind(GLSPSvgExporter).toSelf().inSingletonScope();
-    rebind(TYPES.SvgExporter).toService(GLSPSvgExporter);
 
     bind(GSLPManhattanEdgeRouter).toSelf().inSingletonScope();
     rebind(ManhattanEdgeRouter).toService(GSLPManhattanEdgeRouter);


### PR DESCRIPTION
- Remove interdependency between exportSvg module and toolsModule by creating a `glspExportSvgModule`
- Use `glspExportSvgModule` as drop-in replacement for sprotty's exportSvgModule (DEFAULT_MODULES)
- Make `DEFAULT_MODULES` a readonly tuple instead of an modifiable array (as const)
- Introduce new `createDiagramContainer` utility function and deprecate `createClientContainer` function We typically refer to the sprotty DI container as `diagram container`, so the utility function should also reflect this naming convention. In addition, exclude descriptions can now be passed as optional arguments. This allows to dynamically exclude a default module before loading it in the container. This avoids the overhead of (unnecessary loading and )manually unloading a default module after the container creation.