### PR TITLE
Add custom 'GEdge' that provides a 'localToParent' calculation

### DIFF
--- a/examples/workflow-glsp/src/di.config.ts
+++ b/examples/workflow-glsp/src/di.config.ts
@@ -21,6 +21,7 @@ import {
     DeleteElementContextMenuItemProvider,
     DiamondNodeView,
     editLabelFeature,
+    GEdge,
     GLSPGraph,
     GLSPProjectionView,
     GridSnapper,
@@ -31,7 +32,6 @@ import {
     RoundedCornerNodeView,
     SCompartment,
     SCompartmentView,
-    SEdge,
     SLabel,
     SLabelView,
     StructureCompartmentView,
@@ -61,7 +61,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView);
     configureModelElement(context, 'comp:header', SCompartment, SCompartmentView);
     configureModelElement(context, 'label:icon', SLabel, SLabelView);
-    configureModelElement(context, DefaultTypes.EDGE, SEdge, WorkflowEdgeView);
+    configureModelElement(context, DefaultTypes.EDGE, GEdge, WorkflowEdgeView);
     configureModelElement(context, 'edge:weighted', WeightedEdge, WorkflowEdgeView);
     configureModelElement(context, 'icon', Icon, IconView);
     configureModelElement(context, 'activityNode:merge', ActivityNode, DiamondNodeView);

--- a/examples/workflow-glsp/src/model.ts
+++ b/examples/workflow-glsp/src/model.ts
@@ -20,6 +20,7 @@ import {
     DiamondNode,
     EditableLabel,
     fadeFeature,
+    GEdge,
     hoverFeedbackFeature,
     isEditableLabel,
     layoutableChildFeature,
@@ -31,7 +32,6 @@ import {
     popupFeature,
     RectangularNode,
     SChildElement,
-    SEdge,
     selectFeature,
     SModelElement,
     SShapeElement,
@@ -75,7 +75,7 @@ export function isTaskNode(element: SModelElement): element is TaskNode {
     return element instanceof TaskNode || false;
 }
 
-export class WeightedEdge extends SEdge {
+export class WeightedEdge extends GEdge {
     probability?: string;
 }
 

--- a/packages/client/src/lib/model.ts
+++ b/packages/client/src/lib/model.ts
@@ -13,8 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { SModelElementSchema } from '@eclipse-glsp/protocol';
-import { exportFeature, SGraph, SModelElement, viewportFeature } from 'sprotty';
+import { Bounds, isBounds, Point, SModelElementSchema } from '@eclipse-glsp/protocol';
+import { exportFeature, getRouteBounds, SEdge, SGraph, SModelElement, viewportFeature } from 'sprotty';
 import { Containable, containerFeature } from '../features/hints/model';
 import { Saveable, saveFeature } from '../features/save/model';
 
@@ -23,5 +23,37 @@ export class GLSPGraph extends SGraph implements Saveable, Containable {
     dirty = false;
     isContainableElement(input: string | SModelElement | SModelElementSchema): boolean {
         return true;
+    }
+}
+
+export class GEdge extends SEdge {
+    override localToParent(point: Point | Bounds): Bounds {
+        const bounds = getRouteBounds(this.routingPoints);
+        const result = {
+            x: point.x + bounds.x,
+            y: point.y + bounds.y,
+            width: -1,
+            height: -1
+        };
+        if (isBounds(point)) {
+            result.width = point.width;
+            result.height = point.height;
+        }
+        return result;
+    }
+
+    override parentToLocal(point: Point | Bounds): Bounds {
+        const bounds = getRouteBounds(this.routingPoints);
+        const result = {
+            x: point.x - bounds.x,
+            y: point.y - bounds.y,
+            width: -1,
+            height: -1
+        };
+        if (isBounds(point)) {
+            result.width = point.width;
+            result.height = point.height;
+        }
+        return result;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-glsp/glsp/issues/855

![fix-hover](https://user-images.githubusercontent.com/19170971/212076438-6796e4bc-98d5-4da8-a6cc-c18ed585f533.gif)

So far I did not detect any side effects. If that keeps being true, we should contribute this back to Sprotty as well.