### PR TITLE
Ensure edge routing point can be grabbed in Firefox Browser

### DIFF
--- a/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tool-feedback/edge-edit-tool-feedback.ts
@@ -32,7 +32,6 @@ import {
     PolylineEdgeRouter,
     SConnectableElement,
     SModelElement,
-    SModelRoot,
     SRoutingHandle,
     SwitchEditModeAction,
     SwitchEditModeCommand,
@@ -326,14 +325,7 @@ export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
         return undefined;
     }
 
-    override mouseEnter(target: SModelElement, event: MouseEvent): Action[] {
-        if (target instanceof SModelRoot && event.buttons === 0) {
-            this.mouseUp(target, event);
-        }
-        return [];
-    }
-
-    override mouseUp(_target: SModelElement, event: MouseEvent): Action[] {
+    override mouseUp(_target: SModelElement, _event: MouseEvent): Action[] {
         this.pointPositionUpdater.resetPosition();
         return [];
     }


### PR DESCRIPTION
It seems that in Firefox the 'mouseEnter' event is fired directly after the 'mouseDown' event which caused us to reset the position. However, we should only reset the position if no moving is in progress (i.e., there is no current position tracking/dragging going on). But in that case there is no need to reset the position at all, therefore we can safely remove the 'mouseEnter' event handling for edge routing editing.

Fixes https://github.com/eclipse-glsp/glsp/issues/877