### PR TITLE
Extend type-util

### DIFF
--- a/packages/protocol/src/utils/type-util.spec.ts
+++ b/packages/protocol/src/utils/type-util.spec.ts
@@ -54,8 +54,14 @@ describe('TypeUtil', () => {
         it('should return false for an object that has a property that matches the given but not the given type', () => {
             expect(hasStringProp({ someProp: 123 }, 'someProp')).to.be.false;
         });
-        it('should return false for an object that does not have a property that matches the given key.', () => {
+        it('should return false for an object that does not have a property that matches the given key', () => {
             expect(hasStringProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        });
+        it('should return true for an object that does not have a matching key when using the optional flag', () => {
+            expect(hasStringProp({ anotherProp: 123 }, 'someProp', true)).to.be.true;
+        });
+        it('should return false for an object that has a property with matching name but invalid type when using the optional flag', () => {
+            expect(hasStringProp({ someProp: 123 }, 'someProp', true)).to.be.false;
         });
     });
 
@@ -66,8 +72,14 @@ describe('TypeUtil', () => {
         it('should return false for an object that has a property that matches the given but not the given type', () => {
             expect(hasBooleanProp({ someProp: 123 }, 'someProp')).to.be.false;
         });
-        it('should return false for an object that does not have a property that matches the given key.', () => {
+        it('should return false for an object that does not have a property that matches the given key', () => {
             expect(hasBooleanProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        });
+        it('should return true for an object that does not have a matching key when using the optional flag', () => {
+            expect(hasBooleanProp({ anotherProp: 123 }, 'someProp', true)).to.be.true;
+        });
+        it('should return false for an object that has a property with matching name but invalid type when using the optional flag', () => {
+            expect(hasBooleanProp({ someProp: 123 }, 'someProp', true)).to.be.false;
         });
     });
 
@@ -78,8 +90,14 @@ describe('TypeUtil', () => {
         it('should return false for an object that has a property that matches the given but not the given type', () => {
             expect(hasNumberProp({ someProp: '123' }, 'someProp')).to.be.false;
         });
-        it('should return false for an object that does not have a property that matches the given key.', () => {
-            expect(hasBooleanProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        it('should return false for an object that does not have a property that matches the given key', () => {
+            expect(hasNumberProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        });
+        it('should return true for an object that does not have a matching key when using the optional flag', () => {
+            expect(hasNumberProp({ anotherProp: 123 }, 'someProp', true)).to.be.true;
+        });
+        it('should return false for an object that has a property with matching name but invalid type when using the optional flag', () => {
+            expect(hasNumberProp({ someProp: '123' }, 'someProp', true)).to.be.false;
         });
     });
 
@@ -90,8 +108,14 @@ describe('TypeUtil', () => {
         it('should return false for an object that has a property that matches the given but not the given type', () => {
             expect(hasObjectProp({ someProp: '123' }, 'someProp')).to.be.false;
         });
-        it('should return false for an object that does not have a property that matches the given key.', () => {
+        it('should return false for an object that does not have a property that matches the given key', () => {
             expect(hasObjectProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        });
+        it('should return true for an object that does not have a matching key when using the optional flag', () => {
+            expect(hasObjectProp({ anotherProp: 123 }, 'someProp', true)).to.be.true;
+        });
+        it('should return false for an object that has a property with matching name but invalid type when using the optional flag', () => {
+            expect(hasObjectProp({ someProp: 123 }, 'someProp', true)).to.be.false;
         });
     });
 
@@ -103,8 +127,14 @@ describe('TypeUtil', () => {
         it('should return false for an object that has a property that matches the given but not the given type', () => {
             expect(hasFunctionProp({ someProp: '123' }, 'someProp')).to.be.false;
         });
-        it('should return false for an object that does not have a property that matches the given key.', () => {
+        it('should return false for an object that does not have a property that matches the given key', () => {
             expect(hasFunctionProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        });
+        it('should return true for an object that does not have a matching key when using the optional flag', () => {
+            expect(hasFunctionProp({ anotherProp: 123 }, 'someProp', true)).to.be.true;
+        });
+        it('should return false for an object that has a property with matching name but invalid type when using the optional flag', () => {
+            expect(hasFunctionProp({ someProp: 123 }, 'someProp', true)).to.be.false;
         });
     });
 
@@ -115,8 +145,14 @@ describe('TypeUtil', () => {
         it('should return false for an object that has a property that matches the given but not the given type', () => {
             expect(hasArrayProp({ someProp: '123' }, 'someProp')).to.be.false;
         });
-        it('should return false for an object that does not have a property that matches the given key.', () => {
+        it('should return false for an object that does not have a property that matches the given key', () => {
             expect(hasArrayProp({ anotherProp: 123 }, 'someProp')).to.be.false;
+        });
+        it('should return true for an object that does not have a matching key when using the optional flag', () => {
+            expect(hasArrayProp({ anotherProp: 123 }, 'someProp', true)).to.be.true;
+        });
+        it('should return false for an object that has a property with matching name but invalid type when using the optional flag', () => {
+            expect(hasArrayProp({ someProp: 123 }, 'someProp', true)).to.be.false;
         });
     });
 });

--- a/packages/protocol/src/utils/type-util.ts
+++ b/packages/protocol/src/utils/type-util.ts
@@ -72,58 +72,64 @@ export function toTypeGuard<G>(constructor: Constructor<G>): TypeGuard<G> {
  * Validates whether the given object as a property of type `string` with the given key.
  * @param object The object that should be validated
  * @param propertyKey The key of the property
+ * @param optional Flag to indicate wether the property can be optional i.e. also return true if the given key is undefined
  * @returns `true` if the object has property with matching key of type `string`.
  */
-export function hasStringProp(object: AnyObject, propertyKey: string): boolean {
-    return !!object && propertyKey in object && typeof (object as any)[propertyKey] === 'string';
+export function hasStringProp(object: AnyObject, propertyKey: string, optional = false): boolean {
+    return propertyKey in object ? typeof (object as any)[propertyKey] === 'string' : optional;
 }
 
 /**
  * Validates whether the given object as a property of type `boolean` with the given key.
  * @param object The object that should be validated
  * @param propertyKey The key of the property
+ * @param optional Flag to indicate wether the property can be optional i.e. also return true if the given key is undefined
  * @returns `true` if the object has property with matching key of type `boolean`.
  */
-export function hasBooleanProp(object: AnyObject, propertyKey: string): boolean {
-    return propertyKey in object && typeof (object as any)[propertyKey] === 'boolean';
+export function hasBooleanProp(object: AnyObject, propertyKey: string, optional = false): boolean {
+    return propertyKey in object ? typeof (object as any)[propertyKey] === 'boolean' : optional;
 }
 
 /**
  * Validates whether the given object as a property of type `number` with the given key.
  * @param object The object that should be validated
  * @param propertyKey The key of the property
+ * @param optional Flag to indicate wether the property can be optional i.e. also return true if the given key is undefined
  * @returns `true` if the object has property with matching key of type `number`.
  */
-export function hasNumberProp(object: AnyObject, propertyKey: string): boolean {
-    return propertyKey in object && typeof (object as any)[propertyKey] === 'number';
+export function hasNumberProp(object: AnyObject, propertyKey: string, optional = false): boolean {
+    return propertyKey in object ? typeof (object as any)[propertyKey] === 'number' : optional;
 }
 
 /**
  * Validates whether the given object as a property of type `object` with the given key.
  * @param object The object that should be validated
  * @param propertyKey The key of the property
+ * @param optional Flag to indicate wether the property can be optional i.e. also return true if the given key is undefined
  * @returns `true` if the object has property with matching key of type `object`.
  */
-export function hasObjectProp(object: AnyObject, propertyKey: string): boolean {
-    return propertyKey in object && AnyObject.is((object as any)[propertyKey]);
+export function hasObjectProp(object: AnyObject, propertyKey: string, optional = false): boolean {
+    return propertyKey in object ? AnyObject.is((object as any)[propertyKey]) : optional;
 }
 
 /**
  * Validates whether the given object as a property of type `function` with the given key.
  * @param object The object that should be validated
  * @param propertyKey The key of the property
+ * @param optional Flag to indicate wether the property can be optional i.e. also return true if the given key is undefined
  * @returns `true` if the object has property with matching key of type `function`.
  */
-export function hasFunctionProp(object: AnyObject, propertyKey: string): boolean {
-    return propertyKey in object && typeof (object as any)[propertyKey] === 'function';
+export function hasFunctionProp(object: AnyObject, propertyKey: string, optional = false): boolean {
+    return propertyKey in object ? typeof (object as any)[propertyKey] === 'function' : optional;
 }
 
 /**
  * Validates whether the given object as a property of type `Array` with the given key.
  * @param object The object that should be validated
  * @param propertyKey The key of the property
+ * @param optional Flag to indicate wether the property can be optional i.e. also return true if the given key is undefined
  * @returns `true` if the object has property with matching key of type `Array`.
  */
-export function hasArrayProp(object: AnyObject, propertyKey: string): boolean {
-    return propertyKey in object && Array.isArray((object as any)[propertyKey]);
+export function hasArrayProp(object: AnyObject, propertyKey: string, optional = false): boolean {
+    return propertyKey in object ? Array.isArray((object as any)[propertyKey]) : optional;
 }


### PR DESCRIPTION
Extends property check utility functions to also support checking of optional properties.