### PR TITLE
Refactor `createDiagramContainer` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 -   [routing] Ensured that routes are properly re-calculated when moving a routing point [#198](https://github.com/eclipse-glsp/glsp-client/pull/198)
 -   [diagram] Fixed a bug in the `EditLabelUIExtension` where the diagram becomes dirt wihtout an acual change. [#766](https://github.com/eclipse-glsp/glsp/issues/766)
 -   [diagram] Extends `ComputedBoundsAction` definition with routing information. This enables proper forwarding of cliend-side computed routes to the server. [#201](https://github.com/eclipse-glsp/glsp-client/pull/201/)
--   [DI] The `createClientContainer` function is now deprecated. Please use `createDiagramContainer` instead. This new function also can be used with `ModuleConfiguration` which allow fine granular configuration including the removal of default modules.[#218](https://github.com/eclipse-glsp/glsp/issues/218)[#231](https://github.com/eclipse-glsp/glsp-client/pull/231)
+-   [DI] The `createClientContainer` function is now deprecated. Please use `createDiagramContainer` instead. This new function also can be used with `ModuleConfigurations` which allow a more fine granular configuration by adding new modules and/or removing default modules. [#218](https://github.com/eclipse-glsp/glsp/issues/218) [#231](https://github.com/eclipse-glsp/glsp-client/pull/231)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 -   [layout] Improve Layouter to support more dynamic layouts and complex parent/children node structures [#187](https://github.com/eclipse-glsp/glsp-client/pull/187) - Contributed on behalf of STMicroelectronics
 -   [diagram] Fixed SVG export for nested root elements e.g. `GLSPProjectionView` [#196](https://github.com/eclipse-glsp/glsp-client/pull/196)
 -   [diagram] scope the styles to not break existing application layout [#209](https://github.com/eclipse-glsp/glsp-client/pull/209)
--   [routing] Ensured that routes are properly re-calculated  when moving a routing point [#198](https://github.com/eclipse-glsp/glsp-client/pull/198)
+-   [routing] Ensured that routes are properly re-calculated when moving a routing point [#198](https://github.com/eclipse-glsp/glsp-client/pull/198)
 -   [diagram] Fixed a bug in the `EditLabelUIExtension` where the diagram becomes dirt wihtout an acual change. [#766](https://github.com/eclipse-glsp/glsp/issues/766)
 -   [diagram] Extends `ComputedBoundsAction` definition with routing information. This enables proper forwarding of cliend-side computed routes to the server. [#201](https://github.com/eclipse-glsp/glsp-client/pull/201/)
+-   [DI] The `createClientContainer` function is now deprecated. Please use `createDiagramContainer` instead. This new function also can be used with `ModuleConfiguration` which allow fine granular configuration including the removal of default modules.[#218](https://github.com/eclipse-glsp/glsp/issues/218)[#231](https://github.com/eclipse-glsp/glsp-client/pull/231)
 
 ### Breaking Changes
 

--- a/packages/protocol/src/utils/array-util.ts
+++ b/packages/protocol/src/utils/array-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2022 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -98,6 +98,17 @@ export function flatPush<T>(array: T[], toPush: MaybeArray<T>[]): void {
     toPush.forEach(value => (Array.isArray(value) ? array.push(...value) : array.push(value)));
 }
 
+/**
+ * Helper function to convert a {@link MaybeArray} into an array.
+ * @param maybe The MaybeArray to convert
+ * @returns The corresponding array
+ */
+export function asArray<T>(maybe: MaybeArray<T>): T[] {
+    if (Array.isArray(maybe)) {
+        return maybe;
+    }
+    return [maybe];
+}
 /**
  * Adds the given values to the given array. The add operation is executed distinct meaning
  * a value will not be pushed to the array if its already present in the array.


### PR DESCRIPTION
Replace `ExcludeDescription`s with `ModuleConfiguration` which can be used for both adding (one or more) additional modules and removing (one or more)  default modules. This makes the entire configuration process more convenient.

For example:
```ts
const container= createDiagramContainer(myModule1, myModule2, { exclude: toolsModule}, myToolsModule, {exclude: toolPaletteModule}, myToolPaletteModule)
```
can now be configured as follows
```ts
const container= createDiagramContainer({
 add:[myModule1,myModule2,myToolsModule,myToolPaletteModule],
 remove:[toolsModules,toolPaletteModule]})
```
Naturally its also possible to directly include modules and use multiple module configurations e.g:

```ts
const container= createDiagramContainer(myModule1, myModule2, {remove: toolsModule, add:myToolsModule}, {remove:toolPaletteModule, add:myToolPaletteModule})
```
