### PR TITLE
GLSP-954 Ensure that bindAsAService also work with the DI container as context

### DIFF
--- a/examples/workflow-standalone/src/di.config.ts
+++ b/examples/workflow-standalone/src/di.config.ts
@@ -14,16 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { createWorkflowDiagramContainer } from '@eclipse-glsp-examples/workflow-glsp';
-import { ConsoleLogger, GLSPDiagramServer, LogLevel, TYPES } from '@eclipse-glsp/client';
+import { bindAsService, bindOrRebind, ConsoleLogger, GLSPDiagramServer, LogLevel, TYPES } from '@eclipse-glsp/client';
 import { Container } from 'inversify';
 import '../css/diagram.css';
 
 export default function createContainer(): Container {
     const container = createWorkflowDiagramContainer('sprotty');
-    container.bind(GLSPDiagramServer).toSelf().inSingletonScope();
-    container.bind(TYPES.ModelSource).toService(GLSPDiagramServer);
-    container.rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
-    container.rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
+    bindAsService(container, TYPES.ModelSource, GLSPDiagramServer);
+    bindOrRebind(container, TYPES.ModelSource).toService(GLSPDiagramServer);
+    bindOrRebind(container, TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
+    bindOrRebind(container, TYPES.LogLevel).toConstantValue(LogLevel.warn);
     container.bind(TYPES.IMarqueeBehavior).toConstantValue({ entireEdge: true, entireElement: true });
     return container;
 }

--- a/packages/protocol/src/utils/di-util.ts
+++ b/packages/protocol/src/utils/di-util.ts
@@ -160,7 +160,7 @@ export function bindAsService<S, T extends S>(
     serviceIdentifier: interfaces.ServiceIdentifier<S>,
     targetService: interfaces.ServiceIdentifier<T>
 ): void {
-    const bind = typeof context === 'object' ? context.bind : context;
+    const bind = typeof context === 'object' ? context.bind.bind(context) : context;
     bind(targetService).toSelf().inSingletonScope();
     bind(serviceIdentifier).toService(targetService);
 }


### PR DESCRIPTION
The `bindAsService` method failed when the DI container was used as context. To avoid this we have to make sure that the bind function receives the correct `this` arg.

Use utility functions in standalone di config