### PR TITLE
Add keyboard support for resizing elements

### DIFF
--- a/packages/client/src/features/accessibility/resize-key-tool/di.config.ts
+++ b/packages/client/src/features/accessibility/resize-key-tool/di.config.ts
@@ -14,19 +14,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { bindAsService, BindingContext } from '@eclipse-glsp/protocol';
 import { ContainerModule } from 'inversify';
-import { configureMoveZoom } from './move-zoom/di.config';
-import { configureResizeTools } from './resize-key-tool/di.config';
-import { configureSearchPaletteModule } from './search/di.config';
-import { configureViewKeyTools } from './view-key-tools/di.config';
+import { configureActionHandler } from 'sprotty';
+import { TYPES } from '../../../base/types';
+import { ResizeElementAction, ResizeElementHandler } from './resize-key-handler';
+import { ResizeKeyTool } from './resize-key-tool';
 
 /**
- * Enables the accessibility tools for a keyboard-only-usage
+ * Handles resize actions.
  */
-export const glspAccessibilityModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+export const glspResizeKeyModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
     configureResizeTools(context);
-    configureViewKeyTools(context);
-    configureMoveZoom(context);
-    configureSearchPaletteModule(context);
 });
+
+export function configureResizeTools(context: BindingContext): void {
+    context.bind(ResizeElementHandler).toSelf().inSingletonScope();
+
+    configureActionHandler(context, ResizeElementAction.KIND, ResizeElementHandler);
+    bindAsService(context, TYPES.IDefaultTool, ResizeKeyTool);
+}

--- a/packages/client/src/features/accessibility/resize-key-tool/resize-key-handler.ts
+++ b/packages/client/src/features/accessibility/resize-key-tool/resize-key-handler.ts
@@ -1,0 +1,120 @@
+/********************************************************************************
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Action, ChangeBoundsOperation, Dimension, Point } from '@eclipse-glsp/protocol';
+import { inject, injectable, optional } from 'inversify';
+import { IActionDispatcher, IActionHandler, ICommand, ISnapper, SModelElement, SParentElement } from 'sprotty';
+import { EditorContextService } from '../../../base/editor-context-service';
+import { TYPES } from '../../../base/types';
+import { isValidMove, isValidSize, minHeight, minWidth } from '../../../utils/layout-utils';
+import { getElements, isSelectableAndBoundsAware, SelectableBoundsAware, toElementAndBounds } from '../../../utils/smodel-util';
+import { Resizable } from '../../change-bounds/model';
+import { GridSnapper } from '../../change-bounds/snap';
+
+// eslint-disable-next-line no-shadow
+export enum ResizeType {
+    Increase,
+    Decrease,
+    MinSize
+}
+
+/**
+ * Action for triggering resizing of elements.
+ */
+export interface ResizeElementAction extends Action {
+    kind: typeof ResizeElementAction.KIND;
+    elementIds: string[];
+    resizeType: ResizeType;
+}
+export namespace ResizeElementAction {
+    export const KIND = 'resizeElementAction';
+
+    export function is(object: any): object is ResizeElementAction {
+        return Action.hasKind(object, KIND);
+    }
+
+    export function create(elementIds: string[], resizeType: ResizeType): ResizeElementAction {
+        return { kind: KIND, elementIds, resizeType };
+    }
+}
+
+/* The ResizeElementHandler class is an implementation of the IActionHandler interface that handles
+resizing of elements. */
+@injectable()
+export class ResizeElementHandler implements IActionHandler {
+    @inject(EditorContextService)
+    protected editorContextService: EditorContextService;
+
+    @inject(TYPES.IActionDispatcher) protected dispatcher: IActionDispatcher;
+
+    // Default x resize used if GridSnapper is not provided
+    static readonly defaultResizeX = 20;
+
+    // Default y resize used if GridSnapper is not provided
+    static readonly defaultResizeY = 20;
+    protected grid = { x: ResizeElementHandler.defaultResizeX, y: ResizeElementHandler.defaultResizeY };
+
+    protected isEditMode = false;
+
+    constructor(@inject(TYPES.ISnapper) @optional() protected readonly snapper?: ISnapper) {
+        if (snapper instanceof GridSnapper) {
+            this.grid = snapper.grid;
+        }
+    }
+
+    handle(action: Action): void | Action | ICommand {
+        if (ResizeElementAction.is(action)) {
+            this.handleResizeElement(action);
+        }
+    }
+
+    handleResizeElement(action: ResizeElementAction): void {
+        const elements = getElements(this.editorContextService.modelRoot.index, action.elementIds, isSelectableAndBoundsAware);
+        this.dispatcher.dispatchAll(this.resize(elements, action));
+    }
+
+    protected resize(elements: SelectableBoundsAware[], action: ResizeElementAction): Action[] {
+        const actions: Action[] = [];
+
+        elements.forEach(element => {
+            const { x, y, width: oldWidth, height: oldHeight } = element.bounds;
+            let width = 0;
+            let height = 0;
+
+            if (action.resizeType === ResizeType.Decrease) {
+                width = oldWidth - this.grid.x;
+                height = oldHeight - this.grid.y;
+            } else if (action.resizeType === ResizeType.Increase) {
+                width = oldWidth + this.grid.x;
+                height = oldHeight + this.grid.y;
+            } else if (action.resizeType === ResizeType.MinSize) {
+                width = minWidth(element);
+                height = minHeight(element);
+            }
+
+            if (this.isValidBoundChange(element, { x, y }, { width, height })) {
+                const resizeElement = { id: element.id, bounds: { x, y, width, height } } as SModelElement & SParentElement & Resizable;
+                actions.push(ChangeBoundsOperation.create([toElementAndBounds(resizeElement)]));
+            }
+        });
+
+        return actions;
+    }
+
+    protected isValidBoundChange(element: SelectableBoundsAware, newPosition: Point, newSize: Dimension): boolean {
+        return isValidSize(element, newSize) && isValidMove(element, newPosition);
+    }
+}

--- a/packages/client/src/features/accessibility/resize-key-tool/resize-key-tool.ts
+++ b/packages/client/src/features/accessibility/resize-key-tool/resize-key-tool.ts
@@ -1,0 +1,108 @@
+/********************************************************************************
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Action } from '@eclipse-glsp/protocol';
+import { inject, injectable, optional } from 'inversify';
+import { EnableDefaultToolsAction, EnableToolsAction, ISnapper, KeyListener, KeyTool, SModelElement } from 'sprotty';
+import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
+import { GLSPTool } from '../../../base/tool-manager/glsp-tool-manager';
+import { TYPES } from '../../../base/types';
+import { IMovementRestrictor } from '../../change-bounds/movement-restrictor';
+import { SelectionService } from '../../select/selection-service';
+import { ResizeElementAction, ResizeType } from './resize-key-handler';
+
+@injectable()
+export class ResizeKeyTool implements GLSPTool {
+    static ID = 'glsp.resize-key-tool';
+
+    isEditTool = true;
+
+    @inject(KeyTool) protected readonly keytool: KeyTool;
+    @inject(TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
+    @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
+    @inject(TYPES.SelectionService) readonly selectionService: SelectionService;
+
+    protected resizeKeyListener: ResizeKeyListener = new ResizeKeyListener(this);
+
+    get id(): string {
+        return ResizeKeyTool.ID;
+    }
+
+    enable(): void {
+        this.keytool.register(this.resizeKeyListener);
+    }
+
+    disable(): void {
+        this.keytool.deregister(this.resizeKeyListener);
+    }
+}
+@injectable()
+export class ResizeKeyListener extends KeyListener {
+    protected isEditMode = false;
+
+    constructor(protected readonly tool: ResizeKeyTool) {
+        super();
+    }
+
+    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+        const actions = [];
+        const selectedElementsIds = this.tool.selectionService.getSelectedElementIDs();
+
+        if (this.isEditMode && this.matchesDeactivateResizeModeKeystroke(event)) {
+            this.isEditMode = false;
+            actions.push(EnableDefaultToolsAction.create());
+        }
+
+        if (selectedElementsIds.length > 0) {
+            if (!this.isEditMode && this.matchesActivateResizeModeKeystroke(event)) {
+                this.isEditMode = true;
+                actions.push(EnableToolsAction.create([ResizeKeyTool.ID]));
+            }
+
+            if (this.isEditMode) {
+                if (this.matchesIncreaseSizeKeystroke(event)) {
+                    actions.push(ResizeElementAction.create(selectedElementsIds, ResizeType.Increase));
+                } else if (this.matchesDecreaseSizeKeystroke(event)) {
+                    actions.push(ResizeElementAction.create(selectedElementsIds, ResizeType.Decrease));
+                } else if (this.matchesMinSizeKeystroke(event)) {
+                    actions.push(ResizeElementAction.create(selectedElementsIds, ResizeType.MinSize));
+                }
+            }
+        }
+        return actions;
+    }
+
+    protected matchesIncreaseSizeKeystroke(event: KeyboardEvent): boolean {
+        /** here event.key is used for '+', as keycode 187 is already declared for 'Equals' in {@link matchesKeystroke}.*/
+        return event.key === '+' || matchesKeystroke(event, 'NumpadAdd');
+    }
+
+    protected matchesActivateResizeModeKeystroke(event: KeyboardEvent): boolean {
+        return matchesKeystroke(event, 'KeyA', 'alt');
+    }
+
+    protected matchesDeactivateResizeModeKeystroke(event: KeyboardEvent): boolean {
+        return matchesKeystroke(event, 'Escape');
+    }
+
+    protected matchesMinSizeKeystroke(event: KeyboardEvent): boolean {
+        return matchesKeystroke(event, 'Digit0', 'ctrl') || matchesKeystroke(event, 'Numpad0', 'ctrl');
+    }
+
+    protected matchesDecreaseSizeKeystroke(event: KeyboardEvent): boolean {
+        return matchesKeystroke(event, 'Minus') || matchesKeystroke(event, 'NumpadSubtract');
+    }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,6 +16,7 @@
 import defaultGLSPModule from './base/di.config';
 import { glspAccessibilityModule } from './features/accessibility/di.config';
 import { glspMoveZoomModule } from './features/accessibility/move-zoom/di.config';
+import { glspResizeKeyModule } from './features/accessibility/resize-key-tool/di.config';
 import { glspSearchPaletteModule } from './features/accessibility/search/di.config';
 import { glspViewKeyToolsModule } from './features/accessibility/view-key-tools/di.config';
 import glspCommandPaletteModule from './features/command-palette/di.config';
@@ -60,6 +61,7 @@ export * from './base/tool-manager/glsp-tool-manager';
 export * from './base/tool-manager/tool-actions';
 export * from './base/types';
 export * from './base/view/view-registry';
+export * from './features/accessibility/resize-key-tool/resize-key-tool';
 export * from './features/accessibility/view-key-tools/deselect-key-tool';
 export * from './features/accessibility/view-key-tools/movement-key-tool';
 export * from './features/accessibility/view-key-tools/zoom-key-tool';
@@ -162,8 +164,9 @@ export {
     markerNavigatorContextMenuModule,
     glspViewportModule,
     svgMetadataModule,
-    glspViewKeyToolsModule,
-    glspMoveZoomModule,
+    glspResizeKeyModule,
+    glspSearchPaletteModule,
     glspAccessibilityModule,
-    glspSearchPaletteModule
+    glspViewKeyToolsModule,
+    glspMoveZoomModule
 };


### PR DESCRIPTION
This PR is part of my diploma research conducted at the [Model Engineering lab](https://me.big.tuwien.ac.at/) of TU Wien in the [Business Informatics Group](https://www.big.tuwien.ac.at/). It introduces the **resize** functionality.

## Example

1. Select one or multiple elements
2. Use the shortcut  `ALT + A` to activate the resize mode
3. Use the keys  `+` or  `-` to resize the element accordingly
4. Use `CTRL + 0` to reset to default size 

## Hints

1. The shortcut `ALT + A` is necessary, as later, `+` or  `-` , will also be used for other functionalities (e.g. zoom).
2. In a different PR, a user notification will be displayed if the mode is activated.

@martin-fleck-at, @ndoschek

Part of https://github.com/eclipse-glsp/glsp/issues/1029