### PR TITLE
Fix wrong import

### DIFF
--- a/packages/protocol/src/jsonrpc/base-jsonrpc-glsp-client.ts
+++ b/packages/protocol/src/jsonrpc/base-jsonrpc-glsp-client.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 import { injectable } from 'inversify';
 import { Message, MessageConnection } from 'vscode-jsonrpc';
-import { GLSPClientProxy } from '..';
 import { ActionMessage } from '../action-protocol';
 import { ActionMessageHandler, ClientState, GLSPClient } from '../client-server-protocol/glsp-client';
+import { GLSPClientProxy } from '../client-server-protocol/glsp-server';
 import {
     DisposeClientSessionParameters,
     InitializeClientSessionParameters,


### PR DESCRIPTION
`GLSPClientProxy` was accidentally imported from the main index. This can cause circular dependency issues with inversify -> package internal dependencies should never use the main index.