### PR TITLE
GLSP-975: Rename `NodeGLSPClient`

### DIFF
--- a/packages/protocol/src/client-server-protocol/base-glsp-client.spec.ts
+++ b/packages/protocol/src/client-server-protocol/base-glsp-client.spec.ts
@@ -17,12 +17,12 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as util from 'util';
-import { Action, ActionMessage } from '../..';
-import { expectToThrowAsync } from '../../utils/test-util';
-import { ClientState } from '../glsp-client';
-import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from '../types';
+import { Action, ActionMessage } from '../action-protocol';
+import { expectToThrowAsync } from '../utils/test-util';
+import { BaseGLSPClient } from './base-glsp-client';
+import { ClientState } from './glsp-client';
 import { GLSPServer, GLSPServerListener } from './glsp-server';
-import { NodeGLSPClient } from './node-glsp-client';
+import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from './types';
 
 class StubGLSPServer implements GLSPServer {
     initialize(params: InitializeParameters): Promise<InitializeResult> {
@@ -52,10 +52,10 @@ describe('Node GLSP Client', () => {
     const server = sandbox.stub(new StubGLSPServer());
 
     // Shared test client instance that is already in running state
-    let client = new NodeGLSPClient({ id: 'test' });
+    let client = new BaseGLSPClient({ id: 'test' });
     function resetClient(setRunning = true): void {
         sandbox.reset();
-        client = new NodeGLSPClient({ id: 'test' });
+        client = new BaseGLSPClient({ id: 'test' });
         if (setRunning) {
             client['_server'] = server;
             client['state'] = ClientState.Running;

--- a/packages/protocol/src/client-server-protocol/base-glsp-client.ts
+++ b/packages/protocol/src/client-server-protocol/base-glsp-client.ts
@@ -16,17 +16,18 @@
 
 import { Deferred } from 'sprotty-protocol';
 import { Disposable } from 'vscode-jsonrpc';
-import { Action, ActionMessage } from '../../action-protocol';
-import { distinctAdd, remove } from '../../utils/array-util';
-import { ActionMessageHandler, ClientState, GLSPClient } from '../glsp-client';
-import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from '../types';
+import { Action, ActionMessage } from '../action-protocol';
+import { distinctAdd, remove } from '../utils/array-util';
+import { ActionMessageHandler, ClientState, GLSPClient } from './glsp-client';
 import { GLSPClientProxy, GLSPServer } from './glsp-server';
+import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from './types';
 
 /**
  * A simple {@link GLSPClient} implementation for use cases where the client & server are running
- * in the same (node) context i.e. process without a communication layer (like json-rpc) between.
+ * in the same context/process without a communication layer (like json-rpc) between. The client
+ * directly communicates with a given {@link GLSPServer} instance.
  */
-export class NodeGLSPClient implements GLSPClient {
+export class BaseGLSPClient implements GLSPClient {
     protected state: ClientState;
     protected _server?: GLSPServer;
     protected serverDeferred = new Deferred<GLSPServer>();

--- a/packages/protocol/src/client-server-protocol/glsp-server.ts
+++ b/packages/protocol/src/client-server-protocol/glsp-server.ts
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ActionMessage } from '../../action-protocol';
-import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from '../types';
+import { ActionMessage } from '../action-protocol';
+import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from './types';
 
 /**
  * Interface for implementations of a ts server component.

--- a/packages/protocol/src/client-server-protocol/jsonrpc/base-jsonrpc-glsp-client.ts
+++ b/packages/protocol/src/client-server-protocol/jsonrpc/base-jsonrpc-glsp-client.ts
@@ -17,7 +17,7 @@ import { injectable } from 'inversify';
 import { Disposable, Message, MessageConnection } from 'vscode-jsonrpc';
 import { ActionMessage } from '../../action-protocol';
 import { ActionMessageHandler, ClientState, GLSPClient } from '../glsp-client';
-import { GLSPClientProxy } from '../node/glsp-server';
+import { GLSPClientProxy } from '../glsp-server';
 import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from '../types';
 import { ConnectionProvider, JsonrpcGLSPClient } from './glsp-jsonrpc-client';
 

--- a/packages/protocol/src/client-server-protocol/jsonrpc/glsp-jsonrpc-server.ts
+++ b/packages/protocol/src/client-server-protocol/jsonrpc/glsp-jsonrpc-server.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { MessageConnection } from 'vscode-jsonrpc';
-import { GLSPServer } from '../node/glsp-server';
+import { GLSPServer } from '../glsp-server';
 import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters } from '../types';
 import { JsonrpcGLSPClient } from './glsp-jsonrpc-client';
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -47,13 +47,13 @@ export * from 'sprotty-protocol/lib/utils/json';
 export * from 'sprotty-protocol/lib/utils/model-utils';
 // Default export of @eclipse-glsp/protocol
 export * from './action-protocol';
+export * from './client-server-protocol/base-glsp-client';
 export * from './client-server-protocol/glsp-client';
+export * from './client-server-protocol/glsp-server';
 export * from './client-server-protocol/jsonrpc/base-jsonrpc-glsp-client';
 export * from './client-server-protocol/jsonrpc/glsp-jsonrpc-client';
 export * from './client-server-protocol/jsonrpc/glsp-jsonrpc-server';
 export * from './client-server-protocol/jsonrpc/websocket-connection';
-export * from './client-server-protocol/node/glsp-server';
-export * from './client-server-protocol/node/node-glsp-client';
 export * from './client-server-protocol/types';
 export * from './disposable/disposable';
 export * from './model/default-types';


### PR DESCRIPTION
The `NodeGLSPClient` can also be used in a browser context => rename to `BaseGLSPClient`. This way we can introduce a consistent naming scheme for generic base client implementations: `Base<communication-channel>GLSPClient`. 
For instance if are going to provide a REST implementation in the future it could be called `BaseRestGLSPClient`.