### PR TITLE
Adjust WebSocketWrapper

### DIFF
--- a/packages/protocol/src/client-server-protocol/jsonrpc/websocket-connection.ts
+++ b/packages/protocol/src/client-server-protocol/jsonrpc/websocket-connection.ts
@@ -35,7 +35,7 @@ import {
  * independent of the underlying WebSocket implementation/library. e.g. one could use Socket.io instead of plain WebSockets
  */
 export interface WebSocketWrapper extends Disposable {
-    send(content: string): void;
+    send(content: string | ArrayBufferLike | ArrayBufferView): void;
     onMessage(cb: (data: any) => void): void;
     onError(cb: (reason: any) => void): void;
     onClose(cb: (code: number, reason: string) => void): void;


### PR DESCRIPTION
Adapt send() method of the `WebSocketWrapper` to support all types that are supported by the underlying websocket send method as well.