### PR TITLE
Introduce list of keyboard shortcuts

### DIFF
--- a/packages/client/css/key-shortcut.css
+++ b/packages/client/css/key-shortcut.css
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.keyboard-shortcuts-menu {
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    background-color: #ededee;
+    margin-bottom: 20px;
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    bottom: 0;
+    right: 10px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    line-height: 1.5;
+    font-size: 16px;
+    z-index: 9999;
+    width: 400px;
+    max-height: 512px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+.keyboard-shortcuts-menu h3 {
+    font-size: 18px;
+    font-weight: bold;
+    margin: 0;
+    margin-bottom: 10px;
+    padding: 10px;
+}
+
+.keyboard-shortcuts-menu kbd {
+    background-color: #e4e1e1;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+    color: #333;
+    display: inline-block;
+    font-size: 0.85em;
+    font-weight: 600;
+    line-height: 1;
+    padding: 2px 4px;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+}
+
+.keyboard-shortcuts-menu kbd:active {
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2) inset;
+}
+
+.keyboard-shortcuts-container {
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+    padding: 10px;
+    padding-top: 3px;
+    overflow: auto;
+    right: 40px;
+    top: 25px;
+    text-align: left;
+    display: block;
+    z-index: 1000;
+    color: black;
+}
+
+.shortcut-entry-container {
+    display: flex;
+    justify-content: space-between;
+    margin-right: 10px;
+}
+
+#key-shortcut-close-btn {
+    position: absolute;
+    top: 14px;
+    right: 5px;
+    font-size: 16px;
+    font-weight: bold;
+    background: #cccccc;
+    border: none;
+    cursor: pointer;
+}
+
+.columnTitle {
+    text-align: left;
+}
+
+.menu-header {
+    padding: 0.4em;
+    text-align: left;
+    background: #cccccc;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}

--- a/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut-tool.ts
+++ b/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut-tool.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { Action, KeyListener, KeyTool, matchesKeystroke, SetUIExtensionVisibilityAction, SModelElement } from '~glsp-sprotty';
+import { BaseGLSPTool } from '../../tools/base-glsp-tool';
+import { KeyShortcutUIExtension } from './accessible-key-shortcut';
+
+@injectable()
+export class AccessibleKeyShortcutTool extends BaseGLSPTool {
+    static ID = 'accessible-key-shortcut-tool';
+
+    @inject(KeyTool) protected readonly keytool: KeyTool;
+
+    protected shortcutKeyListener = new AccessibleShortcutKeyListener();
+
+    get id(): string {
+        return AccessibleKeyShortcutTool.ID;
+    }
+
+    enable(): void {
+        this.keytool.register(this.shortcutKeyListener);
+    }
+
+    override disable(): void {
+        this.keytool.deregister(this.shortcutKeyListener);
+    }
+}
+
+export class AccessibleShortcutKeyListener extends KeyListener {
+    protected readonly token = Symbol(AccessibleShortcutKeyListener.name);
+    override keyDown(element: SModelElement, event: KeyboardEvent): Action[] {
+        if (this.matchesActivateShortcutHelpKeystroke(event)) {
+            return [SetUIExtensionVisibilityAction.create({ extensionId: KeyShortcutUIExtension.ID, visible: true })];
+        }
+        return [];
+    }
+
+    protected matchesActivateShortcutHelpKeystroke(event: KeyboardEvent): boolean {
+        return matchesKeystroke(event, 'KeyH', 'alt');
+    }
+}

--- a/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut.ts
+++ b/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut.ts
@@ -1,0 +1,182 @@
+/********************************************************************************
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { groupBy } from 'lodash';
+import { AbstractUIExtension, Action, IActionHandler, ICommand, matchesKeystroke, SModelRoot } from '~glsp-sprotty';
+
+export interface AccessibleKeyShortcutProvider {
+    registerShortcutKey(): void;
+}
+
+export interface AccessibleKeyShortcut {
+    shortcuts: string[];
+    description: string;
+    group: string;
+    position: number;
+}
+
+export interface SetAccessibleKeyShortcutAction extends Action {
+    kind: typeof SetAccessibleKeyShortcutAction.KIND;
+    token: string;
+    keys: AccessibleKeyShortcut[];
+}
+
+export namespace SetAccessibleKeyShortcutAction {
+    export const KIND = 'setAccessibleKeyShortcut';
+
+    export function is(object: any): object is SetAccessibleKeyShortcutAction {
+        return Action.hasKind(object, KIND);
+    }
+
+    export function create(options: { token: string; keys: AccessibleKeyShortcut[] }): SetAccessibleKeyShortcutAction {
+        return { kind: KIND, token: options.token, keys: options.keys };
+    }
+}
+
+@injectable()
+export class KeyShortcutUIExtension extends AbstractUIExtension implements IActionHandler {
+    static readonly ID = 'key-shortcut';
+    protected container: HTMLDivElement;
+    protected shortcutsContainer: HTMLDivElement;
+    protected registrations: Record<string, AccessibleKeyShortcut[]> = {};
+
+    handle(action: Action): ICommand | Action | void {
+        if (SetAccessibleKeyShortcutAction.is(action)) {
+            this.registrations[action.token] = action.keys;
+            if (this.containerElement) {
+                this.refreshUI();
+            }
+        }
+    }
+    id(): string {
+        return KeyShortcutUIExtension.ID;
+    }
+
+    containerClass(): string {
+        return KeyShortcutUIExtension.ID;
+    }
+
+    override show(root: Readonly<SModelRoot>, ...contextElementIds: string[]): void {
+        super.show(root, ...contextElementIds);
+        this.shortcutsContainer.focus();
+    }
+
+    protected refreshUI(): void {
+        this.shortcutsContainer.innerHTML = '';
+
+        const registrations = Object.values(this.registrations).flatMap(r => r);
+        registrations.sort((a, b) => {
+            if (a.group < b.group) {
+                return -1;
+            }
+            if (a.group > b.group) {
+                return 1;
+            }
+
+            return a.position - b.position;
+        });
+
+        const grouped = groupBy(registrations, k => k.group);
+
+        const groupTable = document.createElement('table');
+        const tableHead = document.createElement('thead');
+        const tableBody = document.createElement('tbody');
+
+        const headerRow = document.createElement('tr');
+        const commandCell = document.createElement('th');
+        const keybindingCell = document.createElement('th');
+
+        commandCell.classList.add('columnTitle');
+        commandCell.classList.add('columnTitle');
+
+        commandCell.innerText = 'Command';
+        keybindingCell.innerText = 'Keybinding';
+
+        headerRow.appendChild(commandCell);
+        headerRow.appendChild(keybindingCell);
+        tableHead.appendChild(headerRow);
+
+        for (const [, shortcuts] of Object.entries(grouped)) {
+            shortcuts.forEach(s => {
+                tableBody.appendChild(this.createEntry(s));
+            });
+        }
+
+        groupTable.appendChild(tableHead);
+        groupTable.appendChild(tableBody);
+
+        this.shortcutsContainer.append(groupTable);
+    }
+
+    protected getShortcutHTML(shortcuts: string[]): HTMLElement {
+        const shortcutKeys = document.createElement('span');
+        shortcutKeys.innerHTML = shortcuts.map(key => `<kbd>${key}</kbd>`).join(' + ');
+
+        return shortcutKeys;
+    }
+
+    protected createEntry(registration: AccessibleKeyShortcut): HTMLDivElement {
+        const entryRow = document.createElement('tr');
+        const shortcutElement = document.createElement('td');
+        const descElement = document.createElement('td');
+
+        const shortcut = this.getShortcutHTML(registration.shortcuts);
+        descElement.innerText = registration.description;
+
+        shortcutElement.appendChild(shortcut);
+        entryRow.appendChild(descElement);
+        entryRow.appendChild(shortcutElement);
+
+        return entryRow;
+    }
+
+    protected initializeContents(containerElement: HTMLElement): void {
+        this.container = document.createElement('div');
+        this.container.classList.add('keyboard-shortcuts-menu');
+
+        // create title
+        const menuTitle = document.createElement('h3');
+        menuTitle.classList.add('menu-header');
+        menuTitle.innerText = 'Keyboard Shortcuts';
+        this.container.appendChild(menuTitle);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.id = 'key-shortcut-close-btn';
+        closeBtn.textContent = 'x';
+        closeBtn.addEventListener('click', () => {
+            this.hide();
+        });
+
+        this.container.appendChild(closeBtn);
+
+        // create shortcuts container
+        this.shortcutsContainer = document.createElement('div');
+        this.shortcutsContainer.classList.add('keyboard-shortcuts-container');
+        this.shortcutsContainer.tabIndex = 30;
+        this.shortcutsContainer.addEventListener('keydown', (event: KeyboardEvent) => {
+            if (event.key === 'Escape' || matchesKeystroke(event, 'KeyH', 'alt')) {
+                this.hide();
+            }
+        });
+
+        this.container.appendChild(this.shortcutsContainer);
+        containerElement.appendChild(this.container);
+        containerElement.ariaLabel = 'Shortcut-Menu';
+
+        this.refreshUI();
+    }
+}

--- a/packages/client/src/features/accessibility/key-shortcut/di.config.ts
+++ b/packages/client/src/features/accessibility/key-shortcut/di.config.ts
@@ -14,21 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { FeatureModule } from '~glsp-sprotty';
-import { configureShortcutHelpTool } from './key-shortcut/di.config';
-import { configureMoveZoom } from './move-zoom/move-zoom-module';
-import { configureResizeTools } from './resize-key-tool/resize-key-module';
-import { configureSearchPaletteModule } from './search/search-palette-module';
-import { configureViewKeyTools } from './view-key-tools/view-key-tools-module';
+import { ContainerModule } from 'inversify';
+import { bindAsService, BindingContext, configureActionHandler, TYPES } from '~glsp-sprotty';
+import '../../../../css/key-shortcut.css';
+import { KeyShortcutUIExtension, SetAccessibleKeyShortcutAction } from './accessible-key-shortcut';
+import { AccessibleKeyShortcutTool } from './accessible-key-shortcut-tool';
 
 /**
- * Enables the accessibility tools for a keyboard-only-usage
+ * Handles actions for displaying help/information about keyboard shortcuts.
  */
-export const accessibilityModule = new FeatureModule((bind, unbind, isBound, rebind) => {
+export const glspShortcutHelpModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
-    configureResizeTools(context);
-    configureViewKeyTools(context);
-    configureMoveZoom(context);
-    configureSearchPaletteModule(context);
     configureShortcutHelpTool(context);
 });
+
+export function configureShortcutHelpTool(context: BindingContext): void {
+    bindAsService(context, TYPES.IDefaultTool, AccessibleKeyShortcutTool);
+    bindAsService(context, TYPES.IUIExtension, KeyShortcutUIExtension);
+    configureActionHandler(context, SetAccessibleKeyShortcutAction.KIND, KeyShortcutUIExtension);
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -46,6 +46,7 @@ export * from './features/accessibility/resize-key-tool/resize-key-tool';
 export * from './features/accessibility/view-key-tools/deselect-key-tool';
 export * from './features/accessibility/view-key-tools/movement-key-tool';
 export * from './features/accessibility/view-key-tools/zoom-key-tool';
+export * from './features/accessibility/key-shortcut/accessible-key-shortcut-tool';
 export * from './features/bounds/freeform-layout';
 export * from './features/bounds/glsp-hidden-bounds-updater';
 export * from './features/bounds/hbox-layout';


### PR DESCRIPTION
This PR is part of my diploma research conducted at the [Model Engineering lab](https://me.big.tuwien.ac.at/) of TU Wien in the [Business Informatics Group](https://www.big.tuwien.ac.at/). It introduces a list of existing keyboard shortcuts.

## Example

### Search
1. Focus is on viewport.
2. Use the shortcut  `ALT+H` to display the list of keyboard shortcuts.

@ndoschek @martin-fleck-at 

Part of https://github.com/eclipse-glsp/glsp/issues/1029
