### PR TITLE
GLSP-1026 Resolve circular dependency between client and node-server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
     root: true,
     extends: '@eclipse-glsp',
-    ignorePatterns: ['**/{node_modules,lib}', '**/.eslintrc.js'],
+    ignorePatterns: ['**/{node_modules,lib}', '**/.eslintrc.js', '**/scripts/*.ts'],
 
     parserOptions: {
         tsconfigRootDir: __dirname,

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ examples/workflow-standalone/app
 tsconfig.tsbuildinfo
 eslint.xml
 report.xml
+
+examples/workflow-standalone/server

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clone this repository and build the glsp-client packages:
 yarn install
 ```
 
-Next, start a pre-built version of the Workflow Example Node Diagram Server:
+Next, download and start a pre-built version of the Workflow Example Node Diagram Server with:
 
 ```bash
 yarn start:exampleServer

--- a/examples/workflow-standalone/package.json
+++ b/examples/workflow-standalone/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint --ext .ts,.tsx ./src",
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
     "prepare": "yarn clean && yarn build",
+    "start:exampleServer": "yarn ts-node ./scripts/start-example-server.ts",
     "watch": "tsc -w -p ./tsconfig.json"
   },
   "dependencies": {
@@ -34,7 +35,8 @@
     "@eclipse-glsp/client": "1.1.0-next"
   },
   "devDependencies": {
-    "@eclipse-glsp-examples/workflow-server-bundled": "next",
+    "@types/shelljs": "0.8.12",
+    "@types/tar": "6.1.5",
     "circular-dependency-plugin": "^5.2.2",
     "css-loader": "^6.7.1",
     "inversify": "^6.0.1",

--- a/examples/workflow-standalone/scripts/config.json
+++ b/examples/workflow-standalone/scripts/config.json
@@ -1,0 +1,4 @@
+{
+  "fileName": "workflow-server",
+  "version": "next"
+}

--- a/examples/workflow-standalone/scripts/start-example-server.ts
+++ b/examples/workflow-standalone/scripts/start-example-server.ts
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (c) 2019-2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sh from 'shelljs';
+import { extract } from 'tar';
+import * as config from './config.json';
+const serverDirPath = path.resolve(__dirname, '..', 'server');
+
+async function run() {
+    const serverFile = await downloadIfNecessary();
+    console.log();
+    sh.cd(serverDirPath);
+    sh.exec(`node ${serverFile} -w -p 8081`);
+}
+
+async function downloadIfNecessary(): Promise<string> {
+    console.log(`Check if server executable with version ${config.version} is present.`);
+
+    const existingServer = fs.readdirSync(serverDirPath).find(file => file.startsWith(config.fileName));
+    if (existingServer) {
+        const existingVersion = existingServer.replace(config.fileName + '-', '').replace('.js', '');
+        const latestVersion = sh
+            .exec(`npm show @eclipse-glsp-examples/workflow-server-bundled@${config.version} version`, { silent: true })
+            .stdout.trim();
+        if (existingVersion === latestVersion) {
+            console.log('Server executable already present. Skip download"');
+            return existingServer;
+        }
+    }
+
+    console.log('Server executable with correct version not found.  Download from npm.');
+    if (existingServer) {
+        fs.rmSync(existingServer);
+    }
+    sh.cd(serverDirPath);
+    const packResultJson = sh
+        .exec(`npm pack @eclipse-glsp-examples/workflow-server-bundled@${config.version} --json`, { silent: true })
+        .stdout.trim();
+    const version = JSON.parse(packResultJson)[0].version;
+    const tarBall = fs.readdirSync(serverDirPath).find(file => file.endsWith('.tgz' || '.tar.gz'))!;
+    console.log('Extract downloaded server tarball');
+    await extract({
+        file: tarBall,
+        cwd: serverDirPath
+    });
+
+    const tempDir = path.resolve(serverDirPath, 'package');
+    fs.copyFileSync(path.resolve(tempDir, 'wf-glsp-server-node.js'), path.resolve(serverDirPath, `${config.fileName}-${version}.js`));
+    fs.copyFileSync(
+        path.resolve(tempDir, 'wf-glsp-server-node.js.map'),
+        path.resolve(serverDirPath, `${config.fileName}-${version}.js.map`)
+    );
+
+    console.log('Remove temporary files');
+    fs.rmSync(tempDir, { force: true, recursive: true });
+    fs.rmSync(path.resolve(serverDirPath, tarBall), { force: true });
+    return `${config.fileName}-${version}.js`;
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "publish:latest": "lerna publish from-git --no-git-reset --no-git-tag-version --no-verify-access --no-push",
     "publish:next": "SHA=$(git rev-parse --short HEAD) && lerna publish preminor --exact --canary --preid next.${SHA} --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes --no-verify-access",
     "publish:prepare": "lerna version --ignore-scripts --yes --no-push",
-    "start:exampleServer": "node node_modules/@eclipse-glsp-examples/workflow-server-bundled/wf-glsp-server-node.js -w -p 8081",
+    "start:exampleServer": "yarn --cwd ./examples/workflow-standalone start:exampleServer",
     "test": "lerna run test",
     "test:ci": "lerna run test:ci",
     "test:coverage": "lerna run test:coverage",

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,11 +203,6 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs%2fjson-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eclipse-glsp-examples/workflow-server-bundled@next":
-  version "1.1.0-next.f692ea4.55"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled/-/workflow-server-bundled-1.1.0-next.f692ea4.55.tgz#aeea1284bc0b4f5fadbac93be015006c3e4a35c1"
-  integrity sha512-sxC1rkdSuMfr2DUDNMAvWEEeIU3RQ0Bp+vPc8Y9YEveJSyn0vePyooK0ynshAOgGrIc2pAviCUxtQu+GDpZysQ==
-
 "@eclipse-glsp/cli@1.1.0-next.73d6685.138+73d6685":
   version "1.1.0-next.73d6685.138"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-1.1.0-next.73d6685.138.tgz#51ba9fa0837fac8d5ce17faf4f6d47becf55dc50"
@@ -929,6 +924,14 @@
   resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.5.tgz#9ee342a5d1314bb0928375424a2f162f97c310c7"
   integrity sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==
 
+"@types/glob@~7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types%2fjson-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
@@ -943,6 +946,11 @@
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -979,6 +987,14 @@
   resolved "https://registry.yarnpkg.com/@types%2fsemver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
   integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
+"@types/shelljs@0.8.12":
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.12.tgz#79dc9632af7d5ca1b5afb65a6bfc1422d79b5fa0"
+  integrity sha512-ZA8U81/gldY+rR5zl/7HSHrG2KDfEb3lzG6uCUDhW1DTQE9yC/VBQ45fXnXq8f3CgInfhZmjtdu/WOUlrXRQUg==
+  dependencies:
+    "@types/glob" "~7.2.0"
+    "@types/node" "*"
+
 "@types/sinon@^10.0.13":
   version "10.0.15"
   resolved "https://registry.yarnpkg.com/@types%2fsinon/-/sinon-10.0.15.tgz#513fded9c3cf85e589bbfefbf02b2a0541186b48"
@@ -990,6 +1006,14 @@
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@types%2fsinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
+
+"@types/tar@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.5.tgz#90ccb3b6a35430e7427410d50eed564e85feaaff"
+  integrity sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==
+  dependencies:
+    "@types/node" "*"
+    minipass "^4.0.0"
 
 "@types/uuid@3.4.5":
   version "3.4.5"
@@ -4605,7 +4629,7 @@ minipass@^3.0.0, minipass@^3.1.1, minipass@^3.1.6:
   dependencies:
     yallist "^4.0.0"
 
-minipass@^4.2.4:
+minipass@^4.0.0, minipass@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
   integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==


### PR DESCRIPTION
Remove direct dependency in `@eclipse-glsp/client` and add dedicated download & start script instead. This resolves the circular dependency issues between glsp-client and server-node and unblocks us for releases.

Fixes https://github.com/eclipse-glsp/glsp/issues/1026