### PR TITLE
GLSP-1082: Fix edge edit

### DIFF
--- a/packages/client/src/features/select/select-mouse-listener.ts
+++ b/packages/client/src/features/select/select-mouse-listener.ts
@@ -13,22 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import {
-    Action,
-    BringToFrontAction,
-    SButton,
-    SModelElement,
-    SModelRoot,
-    SRoutableElement,
-    SRoutingHandle,
-    SelectAction,
-    SelectMouseListener,
-    SwitchEditModeAction,
-    findParentByFeature,
-    isCtrlOrCmd,
-    isSelectable,
-    toArray
-} from '~glsp-sprotty';
+import { Action, BringToFrontAction, SModelElement, SelectAction, SelectMouseListener, Selectable } from '~glsp-sprotty';
 import { Ranked } from '../../base/ranked';
 
 /**
@@ -36,71 +21,34 @@ import { Ranked } from '../../base/ranked';
  * This ensures that default mouse listeners are working on a model that has selection changes already applied.
  */
 export class RankedSelectMouseListener extends SelectMouseListener implements Ranked {
-    rank: number = Ranked.DEFAULT_RANK - 1; /* we want to be executed before all default mouse listeners */
+    rank: number = Ranked.DEFAULT_RANK - 100; /* we want to be executed before all default mouse listeners */
 
-    override mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    protected override handleSelectTarget(
+        selectableTarget: SModelElement & Selectable,
+        deselectedElements: SModelElement[],
+        event: MouseEvent
+    ): (Action | Promise<Action>)[] {
         const result: Action[] = [];
-        if (this.buttonHandlerRegistry !== undefined && target instanceof SButton && target.enabled) {
-            const buttonHandler = this.buttonHandlerRegistry.get(target.type);
-            if (buttonHandler !== undefined) {
-                return buttonHandler.buttonPressed(target);
-            }
-        }
-        const selectableTarget = findParentByFeature(target, isSelectable);
-        if (selectableTarget !== undefined || target instanceof SModelRoot) {
-            this.hasDragged = false;
-            let deselect: SModelElement[] = [];
-            // multi-selection?
-            if (!isCtrlOrCmd(event)) {
-                deselect = toArray(
-                    target.root.index
-                        .all()
-                        .filter(
-                            element =>
-                                isSelectable(element) &&
-                                element.selected &&
-                                !(selectableTarget instanceof SRoutingHandle && element === (selectableTarget.parent as SModelElement))
-                        )
-                );
-            }
-            if (selectableTarget !== undefined) {
-                if (!selectableTarget.selected) {
-                    this.wasSelected = false;
-                    result.push(
-                        SelectAction.create({
-                            selectedElementsIDs: [selectableTarget.id],
-                            deselectedElementsIDs: deselect.map(e => e.id)
-                        })
-                    );
-                    result.push(BringToFrontAction.create([selectableTarget.id]));
-                    const routableDeselect = deselect.filter(e => e instanceof SRoutableElement).map(e => e.id);
-                    if (selectableTarget instanceof SRoutableElement) {
-                        result.push(
-                            SwitchEditModeAction.create({
-                                elementsToActivate: [selectableTarget.id],
-                                elementsToDeactivate: routableDeselect
-                            })
-                        );
-                    } else if (routableDeselect.length > 0) {
-                        result.push(SwitchEditModeAction.create({ elementsToDeactivate: routableDeselect }));
-                    }
-                } else if (isCtrlOrCmd(event)) {
-                    this.wasSelected = false;
-                    result.push(SelectAction.create({ deselectedElementsIDs: [selectableTarget.id] }));
-                    if (selectableTarget instanceof SRoutableElement) {
-                        result.push(SwitchEditModeAction.create({ elementsToDeactivate: [selectableTarget.id] }));
-                    }
-                } else {
-                    this.wasSelected = true;
-                }
-            } else {
-                result.push(SelectAction.create({ deselectedElementsIDs: deselect.map(e => e.id) }));
-                const routableDeselect = deselect.filter(e => e instanceof SRoutableElement).map(e => e.id);
-                if (routableDeselect.length > 0) {
-                    result.push(SwitchEditModeAction.create({ elementsToDeactivate: routableDeselect }));
-                }
-            }
-        }
+        result.push(
+            SelectAction.create({
+                selectedElementsIDs: [selectableTarget.id],
+                deselectedElementsIDs: deselectedElements.map(e => e.id)
+            })
+        );
+        result.push(BringToFrontAction.create([selectableTarget.id]));
+
+        return result;
+    }
+
+    protected override handleDeselectTarget(selectableTarget: SModelElement & Selectable, event: MouseEvent): (Action | Promise<Action>)[] {
+        const result: Action[] = [];
+        result.push(SelectAction.create({ selectedElementsIDs: [], deselectedElementsIDs: [selectableTarget.id] }));
+        return result;
+    }
+
+    protected override handleDeselectAll(deselectedElements: SModelElement[], event: MouseEvent): (Action | Promise<Action>)[] {
+        const result: Action[] = [];
+        result.push(SelectAction.create({ selectedElementsIDs: [], deselectedElementsIDs: deselectedElements.map(e => e.id) }));
         return result;
     }
 }


### PR DESCRIPTION
Update selection-mouse listener. The base mouse listener in sprotty has been reworked. This change adjusts the `RankedSelectMouseListener` to the new basae implementation and overrides it where necessary to avoid disposal of `SetEditModeActions`

Fixes https://github.com/eclipse-glsp/glsp/issues/1082