### PR TITLE
GLSP-960 Improve Diagram container configuration

### DIFF
--- a/examples/workflow-glsp/src/workflow-diagram-module.ts
+++ b/examples/workflow-glsp/src/workflow-diagram-module.ts
@@ -39,8 +39,7 @@ import {
     configureDefaultModelElements,
     configureModelElement,
     editLabelFeature,
-    initializeDiagramContainer,
-    overrideViewerOptions
+    initializeDiagramContainer
 } from '@eclipse-glsp/client';
 import 'balloon-css/balloon.min.css';
 import { Container, ContainerModule } from 'inversify';
@@ -78,19 +77,10 @@ export const workflowDiagramModule = new ContainerModule((bind, unbind, isBound,
     configureModelElement(context, 'struct', SCompartment, StructureCompartmentView);
 });
 
-export function createWorkflowDiagramContainer(widgetId: string, ...containerConfiguration: ContainerConfiguration): Container {
-    return initializeWorkflowDiagramContainer(new Container(), widgetId, ...containerConfiguration);
+export function createWorkflowDiagramContainer(...containerConfiguration: ContainerConfiguration): Container {
+    return initializeWorkflowDiagramContainer(new Container(), ...containerConfiguration);
 }
 
-export function initializeWorkflowDiagramContainer(
-    container: Container,
-    widgetId: string,
-    ...containerConfiguration: ContainerConfiguration
-): Container {
-    initializeDiagramContainer(container, workflowDiagramModule, directTaskEditor, accessibilityModule, ...containerConfiguration);
-    overrideViewerOptions(container, {
-        baseDiv: widgetId,
-        hiddenDiv: widgetId + '_hidden'
-    });
-    return container;
+export function initializeWorkflowDiagramContainer(container: Container, ...containerConfiguration: ContainerConfiguration): Container {
+    return initializeDiagramContainer(container, workflowDiagramModule, directTaskEditor, accessibilityModule, ...containerConfiguration);
 }

--- a/examples/workflow-standalone/src/di.config.ts
+++ b/examples/workflow-standalone/src/di.config.ts
@@ -14,11 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { createWorkflowDiagramContainer } from '@eclipse-glsp-examples/workflow-glsp';
-import { bindOrRebind, ConsoleLogger, LogLevel, STANDALONE_MODULE_CONFIG, TYPES } from '@eclipse-glsp/client';
+import {
+    bindOrRebind,
+    ConsoleLogger,
+    createDiagramOptionsModule,
+    IDiagramOptions,
+    LogLevel,
+    STANDALONE_MODULE_CONFIG,
+    TYPES
+} from '@eclipse-glsp/client';
 import { Container } from 'inversify';
 import '../css/diagram.css';
-export default function createContainer(): Container {
-    const container = createWorkflowDiagramContainer('sprotty', STANDALONE_MODULE_CONFIG);
+export default function createContainer(options: IDiagramOptions): Container {
+    const container = createWorkflowDiagramContainer(createDiagramOptionsModule(options), STANDALONE_MODULE_CONFIG);
     bindOrRebind(container, TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
     bindOrRebind(container, TYPES.LogLevel).toConstantValue(LogLevel.warn);
     container.bind(TYPES.IMarqueeBehavior).toConstantValue({ entireEdge: true, entireElement: true });

--- a/packages/client/src/base/editor-context-service.ts
+++ b/packages/client/src/base/editor-context-service.ts
@@ -23,8 +23,9 @@ import {
     EditorContext,
     Emitter,
     Event,
+    GLSPClient,
     IActionHandler,
-    ModelSource,
+    MaybePromise,
     MousePositionTracker,
     SModelElement,
     SModelRoot,
@@ -33,7 +34,8 @@ import {
     TYPES,
     ValueChange
 } from '~glsp-sprotty';
-import { GLSPModelSource } from './model/glsp-model-source';
+import { GLSPActionDispatcher } from './action-dispatcher';
+import { IDiagramOptions, IDiagramStartup } from './model/diagram-loader';
 import { SelectionService } from './selection-service';
 
 export interface IEditModeListener {
@@ -54,19 +56,22 @@ export type DirtyStateChange = Pick<SetDirtyStateAction, 'isDirty' | 'reason'>;
  *    position, etc.).
  */
 @injectable()
-export class EditorContextService implements IActionHandler, Disposable {
+export class EditorContextService implements IActionHandler, Disposable, IDiagramStartup {
     @inject(SelectionService)
     protected selectionService: SelectionService;
 
     @inject(MousePositionTracker)
     protected mousePositionTracker: MousePositionTracker;
 
+    @inject(TYPES.IDiagramOptions)
+    protected diagramOptions: IDiagramOptions;
+
     @multiInject(TYPES.IEditModeListener)
     @optional()
     protected editModeListeners: IEditModeListener[] = [];
 
-    @inject(TYPES.ModelSourceProvider)
-    protected modelSourceProvider: () => Promise<ModelSource>;
+    @inject(GLSPActionDispatcher)
+    protected actionDispatcher: GLSPActionDispatcher;
 
     protected _editMode: string;
     protected onEditModeChangedEmitter = new Emitter<ValueChange<string>>();
@@ -84,6 +89,7 @@ export class EditorContextService implements IActionHandler, Disposable {
 
     @postConstruct()
     protected initialize(): void {
+        this._editMode = this.diagramOptions.editMode ?? EditMode.EDITABLE;
         this.toDispose.push(this.onEditModeChangedEmitter, this.onDirtyStateChangedEmitter);
         this.editModeListeners.forEach(listener =>
             this.onEditModeChanged(change => listener.editModeChanged(change.newValue, change.oldValue))
@@ -132,16 +138,24 @@ export class EditorContextService implements IActionHandler, Disposable {
         }
     }
 
-    async getSourceUri(): Promise<string | undefined> {
-        const modelSource = await this.modelSourceProvider();
-        if (modelSource instanceof GLSPModelSource) {
-            return modelSource.sourceUri;
-        }
-        return undefined;
+    get sourceUri(): string | undefined {
+        return this.diagramOptions.sourceUri;
     }
 
     get editMode(): string {
         return this._editMode;
+    }
+
+    get diagramType(): string {
+        return this.diagramOptions.diagramType;
+    }
+
+    get clientId(): string {
+        return this.diagramOptions.clientId;
+    }
+
+    get glspClient(): GLSPClient {
+        return this.diagramOptions.glspClient;
     }
 
     get modelRoot(): Readonly<SModelRoot> {
@@ -158,6 +172,10 @@ export class EditorContextService implements IActionHandler, Disposable {
 
     get isDirty(): boolean {
         return this._isDirty;
+    }
+
+    postModelLoading(): MaybePromise<void> {
+        this.actionDispatcher.dispatch(SetEditModeAction.create(this.editMode));
     }
 }
 

--- a/packages/client/src/base/editor-context-service.ts
+++ b/packages/client/src/base/editor-context-service.ts
@@ -174,7 +174,7 @@ export class EditorContextService implements IActionHandler, Disposable, IDiagra
         return this._isDirty;
     }
 
-    postModelLoading(): MaybePromise<void> {
+    postRequestModel(): MaybePromise<void> {
         this.actionDispatcher.dispatch(SetEditModeAction.create(this.editMode));
     }
 }

--- a/packages/client/src/base/model/diagram-loader.ts
+++ b/packages/client/src/base/model/diagram-loader.ts
@@ -1,0 +1,161 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, multiInject, optional, postConstruct } from 'inversify';
+import {
+    ApplicationIdProvider,
+    Args,
+    EMPTY_ROOT,
+    EndProgressAction,
+    GLSPClient,
+    MaybePromise,
+    RequestModelAction,
+    ServerStatusAction,
+    SetModelAction,
+    StartProgressAction,
+    TYPES
+} from '~glsp-sprotty';
+import { GLSPActionDispatcher } from '../action-dispatcher';
+import { Ranked } from '../ranked';
+
+/**
+ * Instance specific configuration options for a GLSP diagram
+ */
+export interface IDiagramOptions {
+    /**
+     * Unique id associated with this diagram. Used on the server side to identify the
+     * corresponding client session.
+     */
+    clientId: string;
+    /**
+     * The diagram type i.e. diagram language this diagram is associated with.
+     */
+    diagramType: string;
+    /**
+     * The GLSP client used by this diagram to communicate with the server.
+     */
+    glspClient: GLSPClient;
+    /**
+     * The file source URI associated with this diagram.
+     */
+    sourceUri?: string;
+
+    /**
+     * The initial edit mode of diagram. If no defined the default `editable` edit mode will be used
+     */
+    editMode?: string;
+}
+
+/**
+ * Services that implement startup hooks which are invoked during the {@link DiagramLoader.load} process.
+ * Typically used to dispatch additional initial actions and/or activate UI extensions on startup.
+ * Execution order is derived by the `rank` property of the service. If not present, the {@link Ranked.DEFAULT_RANK} will be assumed.
+ *
+ */
+export interface IDiagramStartup extends Partial<Ranked> {
+    /**
+     * Hook for services that should be executed before the underlying GLSP client is configured and the server is initialized.
+     */
+    preInitialize?(): MaybePromise<void>;
+    /**
+     * Hook for services that should be executed before the initial model loading request (i.e. `RequestModelAction`) but
+     * after the underlying GLSP client has been configured and the server is initialized.
+     */
+    preModelLoading?(): MaybePromise<void>;
+    /**
+     * Hook for services that should be executed after the initial model loading request (i.e. `RequestModelAction`).
+     * Note that this hook is invoked directly after the `RequestModelAction` has been dispatched. It does not necessarily wait
+     * until the client-server update roundtrip is completed. If you need to wait until the diagram is fully initialized use the
+     * {@link GLSPActionDispatcher.onceModelInitialized} constraint.
+     */
+    postModelLoading?(): MaybePromise<void>;
+}
+
+export namespace IDiagramStartup {
+    export function is(object: unknown): object is IDiagramStartup {
+        return Ranked.is(object) && ('preInitialize' in object || 'preModelLoading' in object || 'postModelLoading' in object);
+    }
+}
+
+/**
+ * The central component responsible for initializing the diagram and loading the graphical model
+ * from the GLSP server.
+ * Invoking the {@link DiagramLoader.load} method is typically the first operation that is executed after
+ * a diagram DI container has been created
+ */
+@injectable()
+export class DiagramLoader {
+    @inject(TYPES.IDiagramOptions)
+    protected options: IDiagramOptions;
+
+    @inject(GLSPActionDispatcher)
+    protected actionDispatcher: GLSPActionDispatcher;
+
+    @multiInject(TYPES.IDiagramStartup)
+    @optional()
+    protected diagramStartups: IDiagramStartup[] = [];
+
+    protected enableLoadingNotifications = true;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        this.diagramStartups.sort((a, b) => Ranked.getRank(a) - Ranked.getRank(b));
+    }
+
+    async load(requestModelOptions: Args = {}): Promise<void> {
+        // Set placeholder model until real model from server is available
+        await this.actionDispatcher.dispatch(SetModelAction.create(EMPTY_ROOT));
+        await this.invokeStartupHook('preInitialize');
+        await this.configureGLSPClient();
+        await this.invokeStartupHook('preModelLoading');
+        await this.requestModel(requestModelOptions);
+        await this.invokeStartupHook('postModelLoading');
+    }
+
+    protected async invokeStartupHook(hook: keyof Omit<IDiagramStartup, 'rank'>): Promise<void> {
+        for (const startup of this.diagramStartups) {
+            await startup[hook]?.();
+        }
+    }
+
+    protected requestModel(requestModelOptions: Args = {}): Promise<void> {
+        const options = { sourceUri: this.options.sourceUri, diagramType: this.options.diagramType, ...requestModelOptions } as Args;
+        const result = this.actionDispatcher.dispatch(RequestModelAction.create({ options }));
+        if (this.enableLoadingNotifications) {
+            this.actionDispatcher.dispatch(ServerStatusAction.create('', { severity: 'NONE' }));
+            this.actionDispatcher.dispatch(EndProgressAction.create('initializeClient'));
+        }
+        return result;
+    }
+
+    protected async configureGLSPClient(): Promise<void> {
+        const glspClient = this.options.glspClient;
+
+        if (this.enableLoadingNotifications) {
+            this.actionDispatcher.dispatch(ServerStatusAction.create('Initializing...', { severity: 'INFO' }));
+            this.actionDispatcher.dispatch(StartProgressAction.create({ progressId: 'initializeClient', title: 'Initializing' }));
+        }
+
+        await glspClient.start();
+
+        if (!glspClient.initializeResult) {
+            await glspClient.initializeServer({
+                applicationId: ApplicationIdProvider.get(),
+                protocolVersion: GLSPClient.protocolVersion
+            });
+        }
+    }
+}

--- a/packages/client/src/default-modules.ts
+++ b/packages/client/src/default-modules.ts
@@ -103,7 +103,7 @@ export const DEFAULT_MODULES = [
 /**
  * Wraps the {@link configureDiagramOptions} utility function in a module. Adopters can either include this
  * module into the container {@link ModuleConfiguration} or configure the container after its creation
- * (e.g. using the {@link configureDiagramOptions} utility function)
+ * (e.g. using the {@link configureDiagramOptions} utility function).
  * @param options The diagram instance specific configuration options
  * @returns The corresponding {@link FeatureModule}
  */

--- a/packages/client/src/default-modules.ts
+++ b/packages/client/src/default-modules.ts
@@ -16,9 +16,13 @@
 
 import { Container, ContainerModule } from 'inversify';
 import {
+    BindingContext,
     ContainerConfiguration,
     FeatureModule,
+    TYPES,
+    ViewerOptions,
     buttonModule,
+    configureViewerOptions,
     edgeIntersectionModule,
     edgeLayoutModule,
     expandModule,
@@ -29,6 +33,7 @@ import {
     zorderModule
 } from '~glsp-sprotty';
 import { defaultModule } from './base/default.module';
+import { IDiagramOptions } from './base/model/diagram-loader';
 import { boundsModule } from './features/bounds/bounds-module';
 import { commandPaletteModule } from './features/command-palette/command-palette-module';
 import { contextMenuModule } from './features/context-menu/context-menu-module';
@@ -94,6 +99,34 @@ export const DEFAULT_MODULES = [
     svgMetadataModule,
     statusModule
 ] as const;
+
+/**
+ * Wraps the {@link configureDiagramOptions} utility function in a module. Adopters can either include this
+ * module into the container {@link ModuleConfiguration} or configure the container after its creation
+ * (e.g. using the {@link configureDiagramOptions} utility function)
+ * @param options The diagram instance specific configuration options
+ * @returns The corresponding {@link FeatureModule}
+ */
+export function createDiagramOptionsModule(options: IDiagramOptions): FeatureModule {
+    return new FeatureModule((bind, unbind, isBound, rebind) => configureDiagramOptions({ bind, unbind, isBound, rebind }, options));
+}
+
+/**
+ * Utility function to bind the diagram instance specific configuration options.
+ * In addition to binding the {@link IDiagramOptions} this function also overrides the
+ * {@link ViewerOptions} to match the given client id.
+ * @param context The binding context
+ * @param options The {@link IDiagramOptions} that should be bound
+ */
+export function configureDiagramOptions(context: BindingContext, options: IDiagramOptions): void {
+    const viewerOptions: Partial<ViewerOptions> = {
+        baseDiv: options.clientId,
+        hiddenDiv: options.clientId + '_hidden'
+    };
+    configureViewerOptions(context, viewerOptions);
+
+    context.bind(TYPES.IDiagramOptions).toConstantValue(options);
+}
 
 /**
  *  Initializes a GLSP Diagram container with the GLSP default modules and the specified custom `modules`.

--- a/packages/client/src/features/hints/type-hints-module.ts
+++ b/packages/client/src/features/hints/type-hints-module.ts
@@ -13,12 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { FeatureModule, SetTypeHintsAction, TYPES, configureActionHandler, configureCommand } from '~glsp-sprotty';
+import { FeatureModule, SetTypeHintsAction, TYPES, bindAsService, configureActionHandler, configureCommand } from '~glsp-sprotty';
 import { ApplyTypeHintsCommand, TypeHintProvider } from './type-hints';
 
-export const typeHintsModule = new FeatureModule((bind, _unbind, isBound) => {
-    bind(TypeHintProvider).toSelf().inSingletonScope();
-    bind(TYPES.ITypeHintProvider).toService(TypeHintProvider);
-    configureActionHandler({ bind, isBound }, SetTypeHintsAction.KIND, TypeHintProvider);
-    configureCommand({ bind, isBound }, ApplyTypeHintsCommand);
+export const typeHintsModule = new FeatureModule((bind, unbind, isBound) => {
+    const context = { bind, unbind, isBound };
+    bindAsService(context, TYPES.ITypeHintProvider, TypeHintProvider);
+    bind(TYPES.IDiagramStartup).toService(TypeHintProvider);
+    configureActionHandler(context, SetTypeHintsAction.KIND, TypeHintProvider);
+    configureCommand(context, ApplyTypeHintsCommand);
 });

--- a/packages/client/src/features/hints/type-hints.ts
+++ b/packages/client/src/features/hints/type-hints.ts
@@ -23,6 +23,8 @@ import {
     FeatureSet,
     IActionHandler,
     ICommand,
+    MaybePromise,
+    RequestTypeHintsAction,
     SEdge,
     SModelElement,
     SModelRoot,
@@ -36,8 +38,10 @@ import {
     editFeature,
     moveFeature
 } from '~glsp-sprotty';
+import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { IFeedbackActionDispatcher } from '../../base/feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../base/feedback/feedback-command';
+import { IDiagramStartup } from '../../base/model/diagram-loader';
 import { getElementTypeId, hasCompatibleType } from '../../utils/smodel-util';
 import { resizeFeature } from '../change-bounds/model';
 import { reconnectFeature } from '../reconnect/model';
@@ -149,9 +153,12 @@ export interface ITypeHintProvider {
 }
 
 @injectable()
-export class TypeHintProvider implements IActionHandler, ITypeHintProvider {
+export class TypeHintProvider implements IActionHandler, ITypeHintProvider, IDiagramStartup {
     @inject(TYPES.IFeedbackActionDispatcher)
     protected feedbackActionDispatcher: IFeedbackActionDispatcher;
+
+    @inject(GLSPActionDispatcher)
+    protected actionDispatcher: GLSPActionDispatcher;
 
     protected shapeHints: Map<string, ShapeTypeHint> = new Map();
     protected edgeHints: Map<string, EdgeTypeHint> = new Map();
@@ -191,6 +198,10 @@ export class TypeHintProvider implements IActionHandler, ITypeHintProvider {
 
     getEdgeTypeHint(input: SModelElement | SModelElement | string): EdgeTypeHint | undefined {
         return getTypeHint(input, this.edgeHints);
+    }
+
+    preModelLoading(): MaybePromise<void> {
+        this.actionDispatcher.dispatch(RequestTypeHintsAction.create());
     }
 }
 

--- a/packages/client/src/features/hints/type-hints.ts
+++ b/packages/client/src/features/hints/type-hints.ts
@@ -200,7 +200,7 @@ export class TypeHintProvider implements IActionHandler, ITypeHintProvider, IDia
         return getTypeHint(input, this.edgeHints);
     }
 
-    preModelLoading(): MaybePromise<void> {
+    preRequestModel(): MaybePromise<void> {
         this.actionDispatcher.dispatch(RequestTypeHintsAction.create());
     }
 }

--- a/packages/client/src/features/navigation/navigation-target-resolver.ts
+++ b/packages/client/src/features/navigation/navigation-target-resolver.ts
@@ -23,7 +23,7 @@ import {
     SetResolvedNavigationTargetAction,
     TYPES
 } from '~glsp-sprotty';
-import { EditorContextServiceProvider } from '../../base/editor-context-service';
+import { IDiagramOptions } from '../../base/model/diagram-loader';
 
 /**
  * Resolves `NavigationTargets` to element ids.
@@ -33,14 +33,17 @@ import { EditorContextServiceProvider } from '../../base/editor-context-service'
  */
 @injectable()
 export class NavigationTargetResolver {
-    @inject(TYPES.IEditorContextServiceProvider) protected editorContextService: EditorContextServiceProvider;
-    @inject(TYPES.IActionDispatcher) protected dispatcher: IActionDispatcher;
-    @inject(TYPES.ILogger) protected readonly logger: ILogger;
+    @inject(TYPES.IActionDispatcher)
+    protected dispatcher: IActionDispatcher;
+
+    @inject(TYPES.ILogger)
+    protected logger: ILogger;
+
+    @inject(TYPES.IDiagramOptions)
+    protected diagramOptions: IDiagramOptions;
 
     async resolve(navigationTarget: NavigationTarget): Promise<SetResolvedNavigationTargetAction | undefined> {
-        const contextService = await this.editorContextService();
-        const sourceUri = await contextService.getSourceUri();
-        return this.resolveWithSourceUri(sourceUri, navigationTarget);
+        return this.resolveWithSourceUri(this.diagramOptions.sourceUri, navigationTarget);
     }
 
     async resolveWithSourceUri(

--- a/packages/client/src/features/status/status-module.ts
+++ b/packages/client/src/features/status/status-module.ts
@@ -21,5 +21,6 @@ import { StatusOverlay } from './status-overlay';
 export const statusModule = new FeatureModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
     bindAsService(context, TYPES.IUIExtension, StatusOverlay);
+    bind(TYPES.IDiagramStartup).toService(StatusOverlay);
     configureActionHandler(context, ServerStatusAction.KIND, StatusOverlay);
 });

--- a/packages/client/src/features/status/status-overlay.ts
+++ b/packages/client/src/features/status/status-overlay.ts
@@ -13,15 +13,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { AbstractUIExtension, IActionHandler, ServerStatusAction, codiconCSSClasses } from '~glsp-sprotty';
+import { GLSPActionDispatcher } from '../../base/action-dispatcher';
+import { EditorContextService } from '../../base/editor-context-service';
+import { IDiagramStartup } from '../../base/model/diagram-loader';
 
 /**
  * A reusable status overlay for rendering (icon + message) and handling of {@link ServerStatusAction}'s.
  */
 @injectable()
-export class StatusOverlay extends AbstractUIExtension implements IActionHandler {
+export class StatusOverlay extends AbstractUIExtension implements IActionHandler, IDiagramStartup {
     static readonly ID = 'glsp.server.status.overlay';
+
+    @inject(GLSPActionDispatcher)
+    protected actionDispatcher: GLSPActionDispatcher;
+
+    @inject(EditorContextService)
+    protected editorContext: EditorContextService;
 
     protected statusIconDiv?: HTMLDivElement;
     protected statusMessageDiv?: HTMLDivElement;
@@ -104,5 +113,9 @@ export class StatusOverlay extends AbstractUIExtension implements IActionHandler
         if (statusTimeout > 0) {
             this.pendingTimeout = window.setTimeout(() => this.clearStatus(), statusTimeout);
         }
+    }
+
+    preInitialize(): void {
+        this.show(this.editorContext.modelRoot);
     }
 }

--- a/packages/client/src/features/tool-palette/tool-palette-module.ts
+++ b/packages/client/src/features/tool-palette/tool-palette-module.ts
@@ -15,10 +15,10 @@
  ********************************************************************************/
 import { bindAsService, configureActionHandler, EnableDefaultToolsAction, FeatureModule, TYPES } from '~glsp-sprotty';
 import '../../../css/tool-palette.css';
-import { EnableToolPaletteAction, ToolPalette } from './tool-palette';
+import { ToolPalette } from './tool-palette';
 
 export const toolPaletteModule = new FeatureModule((bind, _unbind, isBound, _rebind) => {
     bindAsService(bind, TYPES.IUIExtension, ToolPalette);
-    configureActionHandler({ bind, isBound }, EnableToolPaletteAction.KIND, ToolPalette);
+    bind(TYPES.IDiagramStartup).toService(ToolPalette);
     configureActionHandler({ bind, isBound }, EnableDefaultToolsAction.KIND, ToolPalette);
 });

--- a/packages/client/src/features/tool-palette/tool-palette.ts
+++ b/packages/client/src/features/tool-palette/tool-palette.ts
@@ -381,7 +381,7 @@ export class ToolPalette extends AbstractUIExtension implements IActionHandler, 
         this.createBody();
     }
 
-    async preModelLoading(): Promise<void> {
+    async preRequestModel(): Promise<void> {
         const requestAction = RequestContextActions.create({
             contextId: ToolPalette.ID,
             editorContext: {

--- a/packages/client/src/features/validation/validate.ts
+++ b/packages/client/src/features/validation/validate.ts
@@ -110,7 +110,7 @@ export class SetMarkersActionHandler implements IActionHandler {
     }
 
     async setMarkers(markers: Marker[], reason: string | undefined): Promise<void> {
-        const uri = await this.editorContextService.getSourceUri();
+        const uri = this.editorContextService.sourceUri;
         this.externalMarkerManager?.setMarkers(markers, reason, uri);
         const applyMarkersAction = ApplyMarkersAction.create(markers);
         this.validationFeedbackEmitter.registerValidationFeedbackAction(applyMarkersAction, reason);

--- a/packages/client/src/glsp-sprotty/types.ts
+++ b/packages/client/src/glsp-sprotty/types.ts
@@ -34,7 +34,9 @@ export const TYPES = {
     ITool: Symbol('ITool'),
     IDefaultTool: Symbol('IDefaultTool'),
     IEditModeListener: Symbol('IEditModeListener'),
-    IMarqueeBehavior: Symbol('IMarqueeBehavior')
+    IMarqueeBehavior: Symbol('IMarqueeBehavior'),
+    IDiagramOptions: Symbol('IDiagramOptions'),
+    IDiagramStartup: Symbol('IDiagramStartup')
 };
 
 /**

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,6 +29,7 @@ export * from './base/feedback/update-model-command';
 export * from './base/focus/focus-state-change-action';
 export * from './base/focus/focus-tracker';
 export * from './base/model-initialization-constraint';
+export * from './base/model/diagram-loader';
 export * from './base/model/glsp-model-source';
 export * from './base/model/model-registry';
 export * from './base/ranked';

--- a/packages/protocol/src/client-server-protocol/base-glsp-client.spec.ts
+++ b/packages/protocol/src/client-server-protocol/base-glsp-client.spec.ts
@@ -131,6 +131,19 @@ describe('Node GLSP Client', () => {
             expect(result).to.be.deep.equal(client.initializeResult);
             expect(server.initialize.called).to.be.false;
         });
+        it('should fire event on first invocation', async () => {
+            await resetClient();
+            const expectedResult = { protocolVersion: '1.0.0', serverActions: {} };
+            const params = { applicationId: 'id', protocolVersion: '1.0.0' };
+            server.initialize.returns(Promise.resolve(expectedResult));
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            const eventHandler = (result: InitializeResult): void => {};
+            const eventHandlerSpy = sinon.spy(eventHandler);
+            client.onServerInitialized(eventHandlerSpy);
+            await client.initializeServer(params);
+            await client.initializeServer(params);
+            expect(eventHandlerSpy.calledOnceWith(expectedResult)).to.be.true;
+        });
     });
 
     describe('initializeClientSession', () => {

--- a/packages/protocol/src/client-server-protocol/glsp-client.ts
+++ b/packages/protocol/src/client-server-protocol/glsp-client.ts
@@ -17,6 +17,7 @@ import * as uuid from 'uuid';
 
 import { ActionMessage } from '../action-protocol';
 import { Disposable } from '../utils/disposable';
+import { Event } from '../utils/event';
 import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from './types';
 
 export class ApplicationIdProvider {
@@ -99,6 +100,11 @@ export interface GLSPClient {
      * the {@link GLSPClient.initializeServer} method.
      */
     readonly initializeResult: InitializeResult | undefined;
+
+    /**
+     * Event that is fired once the first invocation of {@link GLSPClient.initializeServer} has been completed.
+     */
+    readonly onServerInitialized: Event<InitializeResult>;
 
     /**
      * Send an `initializeClientSession` request to the server. One client application may open several session.


### PR DESCRIPTION
- Make import configuration constants available in DI container via `IDiagramOptions`. This includes diagramType, clientId, sourceUri and glspClient.
- Introduce `DiagramLoader` as new central component responsible for configuring the glsp client and dispatching the intial model loading request
- Introduce `IDiagramStartup` services that can hook into the diagram loader lifecycle (GLSP-587)
- This means that feature modules are now self containted and can dispatch their initial actions, activate UI extensions on startup etc. without having to modifiy the `GLSPDiagram` (or similiar) componenent.

- Add `onServerInitialized` event + tests to `GLSPClient`

Part of https://github.com/eclipse-glsp/glsp/issues/960 
Part of https://github.com/eclipse-glsp/glsp/issues/587