### PR TITLE
GLSP-1088: Ensure we restore focus to the diagram

### DIFF
--- a/packages/client/src/base/focus/focus-tracker.ts
+++ b/packages/client/src/base/focus/focus-tracker.ts
@@ -21,6 +21,8 @@ import { FocusStateChangedAction } from './focus-state-change-action';
 export class FocusTracker implements IActionHandler {
     protected inActiveCssClass = 'inactive';
     protected _hasFocus = true;
+    protected _focusElement: HTMLOrSVGElement | null;
+    protected _diagramElement: HTMLElement | null;
 
     @inject(TYPES.ViewerOptions) protected options: ViewerOptions;
 
@@ -28,19 +30,28 @@ export class FocusTracker implements IActionHandler {
         return this._hasFocus;
     }
 
+    get focusElement(): HTMLOrSVGElement | null {
+        return this._focusElement;
+    }
+
+    get diagramElement(): HTMLElement | null {
+        return this._diagramElement;
+    }
+
     handle(action: Action): void | Action | ICommand {
         if (FocusStateChangedAction.is(action)) {
             this._hasFocus = action.hasFocus;
-            const placeholder = document.getElementById(this.options.baseDiv);
-            if (!placeholder) {
+            this._focusElement = document.activeElement as HTMLOrSVGElement | null;
+            this._diagramElement = document.getElementById(this.options.baseDiv);
+            if (!this._diagramElement) {
                 return;
             }
             if (this.hasFocus) {
-                if (placeholder.classList.contains(this.inActiveCssClass)) {
-                    placeholder.classList.remove(this.inActiveCssClass);
+                if (this._diagramElement.classList.contains(this.inActiveCssClass)) {
+                    this._diagramElement.classList.remove(this.inActiveCssClass);
                 }
             } else {
-                placeholder.classList.add(this.inActiveCssClass);
+                this._diagramElement.classList.add(this.inActiveCssClass);
             }
         }
     }

--- a/packages/client/src/features/tool-palette/tool-palette.ts
+++ b/packages/client/src/features/tool-palette/tool-palette.ts
@@ -337,7 +337,7 @@ export class ToolPalette extends AbstractUIExtension implements IActionHandler, 
         this.changeActiveButton();
         if (this.focusTracker.hasFocus) {
             // if focus was deliberately taken do not restore focus to the palette
-            this.restoreFocus();
+            this.focusTracker.diagramElement?.focus();
         }
     }
 


### PR DESCRIPTION
- UI extensions only track the active element before they are shown
- Enhance the focus tracker to provide more info on the active element
-- In Theia the tool palette stored the file explorer as active element

Requires https://github.com/eclipse-glsp/glsp-theia-integration/pull/174
Fixes https://github.com/eclipse-glsp/glsp/issues/1088