### PR TITLE
Only enable a11y module in standalone example

### DIFF
--- a/examples/workflow-glsp/src/workflow-diagram-module.ts
+++ b/examples/workflow-glsp/src/workflow-diagram-module.ts
@@ -33,7 +33,6 @@ import {
     SLabelView,
     StructureCompartmentView,
     TYPES,
-    accessibilityModule,
     bindAsService,
     bindOrRebind,
     configureDefaultModelElements,
@@ -82,5 +81,5 @@ export function createWorkflowDiagramContainer(...containerConfiguration: Contai
 }
 
 export function initializeWorkflowDiagramContainer(container: Container, ...containerConfiguration: ContainerConfiguration): Container {
-    return initializeDiagramContainer(container, workflowDiagramModule, directTaskEditor, accessibilityModule, ...containerConfiguration);
+    return initializeDiagramContainer(container, workflowDiagramModule, directTaskEditor, ...containerConfiguration);
 }

--- a/examples/workflow-standalone/src/di.config.ts
+++ b/examples/workflow-standalone/src/di.config.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 import { createWorkflowDiagramContainer } from '@eclipse-glsp-examples/workflow-glsp';
 import {
+    accessibilityModule,
     bindOrRebind,
     ConsoleLogger,
     createDiagramOptionsModule,
@@ -26,7 +27,7 @@ import {
 import { Container } from 'inversify';
 import '../css/diagram.css';
 export default function createContainer(options: IDiagramOptions): Container {
-    const container = createWorkflowDiagramContainer(createDiagramOptionsModule(options), STANDALONE_MODULE_CONFIG);
+    const container = createWorkflowDiagramContainer(createDiagramOptionsModule(options), accessibilityModule, STANDALONE_MODULE_CONFIG);
     bindOrRebind(container, TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
     bindOrRebind(container, TYPES.LogLevel).toConstantValue(LogLevel.warn);
     container.bind(TYPES.IMarqueeBehavior).toConstantValue({ entireEdge: true, entireElement: true });


### PR DESCRIPTION
The a11y module is currently only tested for the standalone example but is configured per default in the global workflow glsp config. 
=> Remove module from global config and only enable it in the standalone example