### PR TITLE
Fix hover support for issue markers

### DIFF
--- a/packages/client/src/features/hover/hover.ts
+++ b/packages/client/src/features/hover/hover.ts
@@ -74,7 +74,7 @@ export class GlspHoverMouseListener extends HoverMouseListener implements IActio
             this.state.mouseOverTimer = window.setTimeout(() => {
                 const popupBounds = this.computePopupBounds(target, { x: event.pageX, y: event.pageY });
                 if (target instanceof GIssueMarker) {
-                    resolve(SetPopupModelAction.create(this.createPopupModel(target as GIssueMarker, popupBounds)));
+                    resolve(SetPopupModelAction.create(this.createPopupModel(target, popupBounds)));
                 } else {
                     resolve(RequestPopupModelAction.create({ elementId: target.id, bounds: popupBounds }));
                 }

--- a/packages/client/src/views/base-view-module.ts
+++ b/packages/client/src/views/base-view-module.ts
@@ -35,7 +35,6 @@ import {
     SCompartmentView,
     SEdge,
     SGraphView,
-    SIssueMarker,
     SLabel,
     SLabelView,
     SNode,
@@ -49,6 +48,7 @@ import {
     moveFeature,
     selectFeature
 } from '~glsp-sprotty';
+import { GIssueMarker } from '../features/validation/issue-marker';
 import { GLSPGraph } from '../lib/model';
 import { GEdgeView } from './glsp-edge-view';
 import { GIssueMarkerView } from './issue-marker-view';
@@ -86,7 +86,7 @@ export function configureDefaultModelElements(context: Pick<BindingContext, 'bin
 
     // UI elements
     configureModelElement(context, DefaultTypes.BUTTON_EXPAND, SButton, ExpandButtonView);
-    configureModelElement(context, DefaultTypes.ISSUE_MARKER, SIssueMarker, GIssueMarkerView);
+    configureModelElement(context, DefaultTypes.ISSUE_MARKER, GIssueMarker, GIssueMarkerView);
 
     // shapes
     configureModelElement(context, DefaultTypes.NODE_CIRCLE, CircularNode, CircularNodeView);


### PR DESCRIPTION
Ensure that hover support for manually constructed issue markers works as expected.
The hover mouse listener checks for `GIssueMarkers` but we configure issue markers as `SIssueMarkers` per default