### PR TITLE
Bugfixes for 2.0.0

### DIFF
--- a/packages/client/src/features/copy-paste/copy-paste-modules.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-modules.ts
@@ -13,9 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { configureActionHandler, FeatureModule, TYPES } from '@eclipse-glsp/sprotty';
-import { CopyPasteContextMenuItemProvider, InvokeCopyPasteAction, InvokeCopyPasteActionHandler } from './copy-paste-context-menu';
+import { bindAsService, FeatureModule, TYPES } from '@eclipse-glsp/sprotty';
 import { LocalClipboardService, ServerCopyPasteHandler } from './copy-paste-handler';
+import { CopyPasteStartup } from './copy-paste-standalone';
 
 export const copyPasteModule = new FeatureModule((bind, _unbind, isBound) => {
     bind(TYPES.ICopyPasteHandler).to(ServerCopyPasteHandler);
@@ -29,9 +29,7 @@ export const copyPasteModule = new FeatureModule((bind, _unbind, isBound) => {
  */
 export const standaloneCopyPasteModule = new FeatureModule(
     (bind, _unbind, isBound) => {
-        bind(TYPES.IContextMenuProvider).to(CopyPasteContextMenuItemProvider).inSingletonScope();
-        bind(InvokeCopyPasteActionHandler).toSelf().inSingletonScope();
-        configureActionHandler({ bind, isBound }, InvokeCopyPasteAction.KIND, InvokeCopyPasteActionHandler);
+        bindAsService(bind, TYPES.IDiagramStartup, CopyPasteStartup);
     },
     { requires: copyPasteModule }
 );

--- a/packages/client/src/features/copy-paste/copy-paste-standalone.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-standalone.ts
@@ -1,0 +1,96 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    Action,
+    Disposable,
+    DisposableCollection,
+    GModelElement,
+    KeyListener,
+    TYPES,
+    ViewerOptions,
+    matchesKeystroke
+} from '@eclipse-glsp/sprotty';
+import { inject, injectable, optional, preDestroy } from 'inversify';
+import { IDiagramStartup } from '../../base/model/diagram-loader';
+import { InvokeCopyPasteAction } from './copy-paste-context-menu';
+import { ICopyPasteHandler } from './copy-paste-handler';
+/**
+ * Startup service to hook up the copy&paste event handler
+ */
+@injectable()
+export class CopyPasteStartup implements IDiagramStartup, Disposable {
+    @inject(TYPES.ICopyPasteHandler)
+    @optional()
+    protected copyPasteHandler?: ICopyPasteHandler;
+
+    @inject(TYPES.ViewerOptions)
+    protected options: ViewerOptions;
+
+    protected toDispose = new DisposableCollection();
+
+    postModelInitialization(): void {
+        const baseDiv = document.getElementById(this.options.baseDiv);
+
+        if (!this.copyPasteHandler || !baseDiv) {
+            return;
+        }
+        const copyListener = (e: ClipboardEvent): void => {
+            this.copyPasteHandler?.handleCopy(e);
+            e.preventDefault();
+        };
+        const cutListener = (e: ClipboardEvent): void => {
+            this.copyPasteHandler?.handleCut(e);
+            e.preventDefault();
+        };
+        const pasteListener = (e: ClipboardEvent): void => {
+            this.copyPasteHandler?.handlePaste(e);
+            e.preventDefault();
+        };
+        baseDiv.addEventListener('copy', copyListener);
+        baseDiv.addEventListener('cut', cutListener);
+        baseDiv.addEventListener('paste', pasteListener);
+
+        this.toDispose.push(
+            Disposable.create(() => {
+                baseDiv.removeEventListener('copy', copyListener);
+                baseDiv.removeEventListener('cut', cutListener);
+                baseDiv.removeEventListener('paste', pasteListener);
+            })
+        );
+    }
+
+    @preDestroy()
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+}
+
+@injectable()
+export class CopyPasteKeyListener extends KeyListener {
+    override keyDown(_element: GModelElement, event: KeyboardEvent): Action[] {
+        if (matchesKeystroke(event, 'KeyC', 'ctrlCmd')) {
+            return [InvokeCopyPasteAction.create('copy')];
+        }
+        if (matchesKeystroke(event, 'KeyV', 'ctrlCmd')) {
+            return [InvokeCopyPasteAction.create('paste')];
+        }
+        if (matchesKeystroke(event, 'KeyX', 'ctrlCmd')) {
+            return [InvokeCopyPasteAction.create('cut')];
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
- Add copy-paste support for standalone via keyboard short cuts
- Trigger auto layout operation via keyboard short cut (Shift+ctrl+L)
- Ensure that the viewport handler does not steal focus when integrated in an application frame (i.e. Theia)

- Make context menu listener selection aware. If the context menu was triggered for a selectable target (or parent):
 do nothing if the element is already selected, otherwise set the selection to the selectable element
Remove the current selection if the context menu element is not selectable. This behavior is consistent with other graphical tools like DrawIO, Google drawings, Papyrus etc.