### PR TITLE
Keyboard move and resize improvements

### DIFF
--- a/packages/client/src/features/accessibility/resize-key-tool/resize-key-handler.ts
+++ b/packages/client/src/features/accessibility/resize-key-tool/resize-key-handler.ts
@@ -14,23 +14,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable, optional } from 'inversify';
 import {
     Action,
     ChangeBoundsOperation,
     Dimension,
+    DisposableCollection,
+    ElementAndBounds,
+    GModelElement,
+    GParentElement,
     IActionDispatcher,
     IActionHandler,
     ICommand,
     ISnapper,
     Point,
-    GModelElement,
-    GParentElement,
+    SetBoundsAction,
     TYPES
 } from '@eclipse-glsp/sprotty';
+import { inject, injectable, optional } from 'inversify';
+import { DebouncedFunc, debounce } from 'lodash';
 import { EditorContextService } from '../../../base/editor-context-service';
-import { isValidMove, isValidSize, minHeight, minWidth } from '../../../utils/layout-utils';
+import { IFeedbackActionDispatcher } from '../../../base/feedback/feedback-action-dispatcher';
 import { SelectableBoundsAware, getElements, isSelectableAndBoundsAware, toElementAndBounds } from '../../../utils/gmodel-util';
+import { isValidMove, isValidSize, minHeight, minWidth } from '../../../utils/layout-utils';
 import { Resizable } from '../../change-bounds/model';
 import { GridSnapper } from '../../change-bounds/snap';
 
@@ -67,7 +72,14 @@ export class ResizeElementHandler implements IActionHandler {
     @inject(EditorContextService)
     protected editorContextService: EditorContextService;
 
-    @inject(TYPES.IActionDispatcher) protected dispatcher: IActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected dispatcher: IActionDispatcher;
+
+    @inject(TYPES.IFeedbackActionDispatcher)
+    protected feedbackDispatcher: IFeedbackActionDispatcher;
+
+    protected debouncedChangeBounds?: DebouncedFunc<() => void>;
+    protected disposableFeedback = new DisposableCollection();
 
     // Default x resize used if GridSnapper is not provided
     static readonly defaultResizeX = 20;
@@ -92,11 +104,21 @@ export class ResizeElementHandler implements IActionHandler {
 
     handleResizeElement(action: ResizeElementAction): void {
         const elements = getElements(this.editorContextService.modelRoot.index, action.elementIds, isSelectableAndBoundsAware);
-        this.dispatcher.dispatchAll(this.resize(elements, action));
+        const elementAndBounds = this.computeElementAndBounds(elements, action);
+
+        this.disposableFeedback.push(this.feedbackDispatcher.registerFeedback(this, [SetBoundsAction.create(elementAndBounds)]));
+
+        this.debouncedChangeBounds?.cancel();
+        this.debouncedChangeBounds = debounce(() => {
+            this.disposableFeedback.dispose();
+            this.dispatcher.dispatchAll([ChangeBoundsOperation.create(elementAndBounds)]);
+            this.debouncedChangeBounds = undefined;
+        }, 300);
+        this.debouncedChangeBounds();
     }
 
-    protected resize(elements: SelectableBoundsAware[], action: ResizeElementAction): Action[] {
-        const actions: Action[] = [];
+    protected computeElementAndBounds(elements: SelectableBoundsAware[], action: ResizeElementAction): ElementAndBounds[] {
+        const elementAndBounds: ElementAndBounds[] = [];
 
         elements.forEach(element => {
             const { x, y, width: oldWidth, height: oldHeight } = element.bounds;
@@ -116,11 +138,11 @@ export class ResizeElementHandler implements IActionHandler {
 
             if (this.isValidBoundChange(element, { x, y }, { width, height })) {
                 const resizeElement = { id: element.id, bounds: { x, y, width, height } } as GModelElement & GParentElement & Resizable;
-                actions.push(ChangeBoundsOperation.create([toElementAndBounds(resizeElement)]));
+                elementAndBounds.push(toElementAndBounds(resizeElement));
             }
         });
 
-        return actions;
+        return elementAndBounds;
     }
 
     protected isValidBoundChange(element: SelectableBoundsAware, newPosition: Point, newSize: Dimension): boolean {

--- a/packages/client/src/features/accessibility/search/search-palette.ts
+++ b/packages/client/src/features/accessibility/search/search-palette.ts
@@ -14,27 +14,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable } from 'inversify';
-import { isEqual } from 'lodash';
-import { toArray } from 'sprotty/lib/utils/iterable';
 import {
     Action,
     CenterAction,
-    LabeledAction,
     GModelElement,
     GModelRoot,
     GNode,
+    LabeledAction,
     SelectAction,
     SelectAllAction,
     codiconCSSString,
     isNameable,
     name
 } from '@eclipse-glsp/sprotty';
+import { injectable } from 'inversify';
+import { isEqual } from 'lodash';
+import { toArray } from 'sprotty/lib/utils/iterable';
 import { BaseAutocompletePalette } from '../../../base/auto-complete/base-autocomplete-palette';
 
+import { AutocompleteSuggestion, IAutocompleteSuggestionProvider } from '../../../base/auto-complete/autocomplete-suggestion-providers';
 import { applyCssClasses, deleteCssClasses } from '../../../base/feedback/css-feedback';
 import { RepositionAction } from '../../../features/viewport/reposition';
-import { AutocompleteSuggestion, IAutocompleteSuggestionProvider } from '../../../base/auto-complete/autocomplete-suggestion-providers';
 import { GEdge } from '../../../model';
 
 const CSS_SEARCH_HIDDEN = 'search-hidden';

--- a/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Action, GModelElement, ISnapper, KeyListener, KeyTool, Point, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { Action, ISnapper, KeyListener, KeyTool, GModelElement, TYPES } from '@eclipse-glsp/sprotty';
 import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { SelectionService } from '../../../base/selection-service';
 import { Tool } from '../../../base/tool-manager/tool';
@@ -63,14 +63,18 @@ export class MoveKeyListener extends KeyListener implements AccessibleKeyShortcu
 
     protected readonly token = MoveKeyListener.name;
 
-    protected grid = { x: MoveKeyListener.defaultMoveX, y: MoveKeyListener.defaultMoveY };
-
     constructor(protected readonly tool: MovementKeyTool) {
         super();
+    }
 
+    protected get grid(): Point {
         if (this.tool.snapper instanceof GridSnapper) {
-            this.grid = this.tool.snapper.grid;
+            return this.tool.snapper.grid;
         }
+        return {
+            x: MoveKeyListener.defaultMoveX,
+            y: MoveKeyListener.defaultMoveY
+        };
     }
 
     registerShortcutKey(): void {
@@ -84,22 +88,25 @@ export class MoveKeyListener extends KeyListener implements AccessibleKeyShortcu
 
     override keyDown(element: GModelElement, event: KeyboardEvent): Action[] {
         const selectedElementIds = this.tool.selectionService.getSelectedElementIDs();
+        const snap = !event.altKey;
+        const offsetX = snap ? this.grid.x : 1;
+        const offsetY = snap ? this.grid.y : 1;
 
         if (selectedElementIds.length > 0) {
             if (this.matchesMoveUpKeystroke(event)) {
-                return [MoveElementAction.create(selectedElementIds, 0, -this.grid.x)];
+                return [MoveElementAction.create(selectedElementIds, 0, -offsetY, snap)];
             } else if (this.matchesMoveDownKeystroke(event)) {
-                return [MoveElementAction.create(selectedElementIds, 0, this.grid.x)];
+                return [MoveElementAction.create(selectedElementIds, 0, offsetY, snap)];
             } else if (this.matchesMoveRightKeystroke(event)) {
-                return [MoveElementAction.create(selectedElementIds, this.grid.x, 0)];
+                return [MoveElementAction.create(selectedElementIds, offsetX, 0, snap)];
             } else if (this.matchesMoveLeftKeystroke(event)) {
-                return [MoveElementAction.create(selectedElementIds, -this.grid.x, 0)];
+                return [MoveElementAction.create(selectedElementIds, -offsetX, 0, snap)];
             }
         } else {
             if (this.matchesMoveUpKeystroke(event)) {
-                return [MoveViewportAction.create(0, -this.grid.x)];
+                return [MoveViewportAction.create(0, -this.grid.y)];
             } else if (this.matchesMoveDownKeystroke(event)) {
-                return [MoveViewportAction.create(0, this.grid.x)];
+                return [MoveViewportAction.create(0, this.grid.y)];
             } else if (this.matchesMoveRightKeystroke(event)) {
                 return [MoveViewportAction.create(this.grid.x, 0)];
             } else if (this.matchesMoveLeftKeystroke(event)) {
@@ -110,18 +117,18 @@ export class MoveKeyListener extends KeyListener implements AccessibleKeyShortcu
     }
 
     protected matchesMoveUpKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowUp');
+        return matchesKeystroke(event, 'ArrowUp') || matchesKeystroke(event, 'ArrowUp', 'alt');
     }
 
     protected matchesMoveDownKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowDown');
+        return matchesKeystroke(event, 'ArrowDown') || matchesKeystroke(event, 'ArrowDown', 'alt');
     }
 
     protected matchesMoveRightKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowRight');
+        return matchesKeystroke(event, 'ArrowRight') || matchesKeystroke(event, 'ArrowRight', 'alt');
     }
 
     protected matchesMoveLeftKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowLeft');
+        return matchesKeystroke(event, 'ArrowLeft') || matchesKeystroke(event, 'ArrowLeft', 'alt');
     }
 }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-feedback.ts
@@ -13,8 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from 'inversify';
-import { VNode } from 'snabbdom';
 import {
     Action,
     CommandExecutionContext,
@@ -22,11 +20,11 @@ import {
     Disposable,
     ElementMove,
     GChildElement,
+    GModelElement,
+    GModelRoot,
     MouseListener,
     MoveAction,
     Point,
-    GModelElement,
-    GModelRoot,
     TYPES,
     findParentByFeature,
     hasStringProp,
@@ -34,6 +32,8 @@ import {
     isSelectable,
     isViewport
 } from '@eclipse-glsp/sprotty';
+import { inject, injectable } from 'inversify';
+import { VNode } from 'snabbdom';
 
 import { CursorCSS, cursorFeedbackAction } from '../../../base/feedback/css-feedback';
 import { FeedbackCommand } from '../../../base/feedback/feedback-command';
@@ -197,7 +197,7 @@ export class FeedbackMoveMouseListener extends MouseListener implements Disposab
             y: (event.pageY - this.startDragPosition.y) / zoom
         };
 
-        const elementMoves: ElementMove[] = this.getElementMovesForDelta(target, delta, !event.shiftKey, finished);
+        const elementMoves: ElementMove[] = this.getElementMovesForDelta(target, delta, !event.altKey, finished);
         if (elementMoves.length > 0) {
             return MoveAction.create(elementMoves, { animate: false, finished });
         } else {

--- a/packages/client/src/utils/viewpoint-util.ts
+++ b/packages/client/src/utils/viewpoint-util.ts
@@ -19,8 +19,9 @@ import {
     BoundsAware,
     Dimension,
     GChildElement,
-    Point,
     GModelElement,
+    GModelRoot,
+    Point,
     Viewport,
     findParentByFeature,
     isAlignable,
@@ -132,4 +133,19 @@ export function absoluteToParent(element: BoundsAwareModelElement & GChildElemen
 export function absoluteToLocal(element: BoundsAwareModelElement, absolutePoint: Point): Point {
     const absoluteElementBounds = toAbsoluteBounds(element);
     return { x: absolutePoint.x - absoluteElementBounds.x, y: absolutePoint.y - absoluteElementBounds.y };
+}
+
+/**
+ * Returns `true` if `point` is outside of the `viewport`.
+ * @param point The point to check.
+ * @param viewport The viewport.
+ * @returns `true` if `point` is outside, `false` otherwise.
+ */
+export function outsideOfViewport(point: Point, viewport: GModelRoot & Viewport): boolean {
+    return (
+        point.x < viewport.scroll.x ||
+        point.x > viewport.scroll.x + viewport.canvasBounds.width ||
+        point.y < viewport.scroll.y ||
+        point.y > viewport.scroll.y + viewport.canvasBounds.height
+    );
 }


### PR DESCRIPTION
* Show client-side feedback without animation
* Trigger server operation with a debounce delay
* Respect snap modifier (ALT) for move
* Respect movement restrictor for move

Can only be tested with the standalone workflow example!

Fixes https://github.com/eclipse-glsp/glsp/issues/1156