### PR TITLE
Allow setting `ViewerOptions` and set default zoom limits

### DIFF
--- a/packages/client/src/base/model/diagram-loader.ts
+++ b/packages/client/src/base/model/diagram-loader.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable, multiInject, optional, postConstruct } from 'inversify';
 import {
     AnyObject,
     ApplicationIdProvider,
@@ -29,6 +28,7 @@ import {
     TYPES,
     hasNumberProp
 } from '@eclipse-glsp/sprotty';
+import { inject, injectable, multiInject, optional, postConstruct } from 'inversify';
 import { GLSPActionDispatcher } from '../action-dispatcher';
 import { Ranked } from '../ranked';
 import { GLSPModelSource } from './glsp-model-source';

--- a/packages/client/src/default-modules.ts
+++ b/packages/client/src/default-modules.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Container } from 'inversify';
 import {
     BindingContext,
     ContainerConfiguration,
@@ -32,6 +31,7 @@ import {
     resolveContainerConfiguration,
     zorderModule
 } from '@eclipse-glsp/sprotty';
+import { Container } from 'inversify';
 import { defaultModule } from './base/default.module';
 import { IDiagramOptions } from './base/model/diagram-loader';
 import { boundsModule } from './features/bounds/bounds-module';
@@ -116,16 +116,21 @@ export function createDiagramOptionsModule(options: IDiagramOptions): FeatureMod
  * In addition to binding the {@link IDiagramOptions} this function also overrides the
  * {@link ViewerOptions} to match the given client id.
  * @param context The binding context
- * @param options The {@link IDiagramOptions} that should be bound
+ * @param diagramOptions The {@link IDiagramOptions} that should be bound
+ * @param viewerOptions Optional {@link ViewerOptions} that should be configured
  */
-export function configureDiagramOptions(context: BindingContext, options: IDiagramOptions): void {
-    const viewerOptions: Partial<ViewerOptions> = {
-        baseDiv: options.clientId,
-        hiddenDiv: options.clientId + '_hidden'
-    };
-    configureViewerOptions(context, viewerOptions);
-
-    context.bind(TYPES.IDiagramOptions).toConstantValue(options);
+export function configureDiagramOptions(
+    context: BindingContext,
+    diagramOptions: IDiagramOptions,
+    viewerOptions?: Partial<ViewerOptions>
+): void {
+    configureViewerOptions(context, {
+        baseDiv: diagramOptions.clientId,
+        hiddenDiv: diagramOptions.clientId + '_hidden',
+        zoomLimits: { min: 0.1, max: 20 },
+        ...viewerOptions
+    });
+    context.bind(TYPES.IDiagramOptions).toConstantValue(diagramOptions);
 }
 
 /**


### PR DESCRIPTION
Sprotty introduced zoom limits, so we should allow setting them.
This change allows to optionally specify all `ViewerOptions` in `configureDiagramOptions` and sets very generous `zoomLimits` by default. This should also mitigate the bug when you zoom beyond `Number.maxValue`.