### PR TITLE
Use `next` preid for nightly publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:ci": "lerna run lint:ci",
     "prepare": "lerna run prepare",
     "publish:latest": "lerna publish from-git --no-git-reset --no-git-tag-version --no-push",
-    "publish:next": "lerna publish preminor --exact --canary --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes",
+    "publish:next": "lerna publish preminor --exact --canary --preid next --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes",
     "publish:prepare": "lerna version --ignore-scripts --yes --no-push",
     "start:exampleServer": "yarn --cwd ./examples/workflow-standalone start:exampleServer",
     "test": "lerna run test",


### PR DESCRIPTION
The `--preid` flag was omitted on accident in a previous commit. As a consequence nightly versions are now published as "alpha".
Readd correct preid.
(https://www.npmjs.com/package/@eclipse-glsp/client/v/2.1.0-alpha.290)
