### PR TITLE
Fix download example-server script

### DIFF
--- a/examples/workflow-standalone/scripts/config.json
+++ b/examples/workflow-standalone/scripts/config.json
@@ -1,4 +1,4 @@
 {
   "fileName": "workflow-server",
-  "version": "2.0.0"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
Ensure that the server download script downloads the latest version of the bundled workflow-server.
(The 2.0.0 version was bundled incorrectly and this was hotfixed with 2.0.1)