### PR TITLE
GLSP-1166 Fix dependency injection cycle in selection service

### DIFF
--- a/packages/client/src/base/default.module.ts
+++ b/packages/client/src/base/default.module.ts
@@ -96,7 +96,6 @@ export const defaultModule = new FeatureModule((bind, unbind, isBound, rebind, .
     bindOrRebind(context, TYPES.ViewRegistry).to(GViewRegistry).inSingletonScope();
 
     bind(SelectionService).toSelf().inSingletonScope();
-    bind(TYPES.IGModelRootListener).toService(SelectionService);
 
     // Feedback Support ------------------------------------
     // Generic re-usable feedback modifying css classes


### PR DESCRIPTION
Avoid binding of SelectionService as `IModelRootListner`. Instead directly inject the`CommandStack` into `SelectionService` and manually register itself as `IGModelRootListener`. This avoids a circular dependency injection if any of the `SelectionListner`s wants to inject the `ActionDispatcher`.

Can be tested e.g. by creating a `SelectionListener` that injects the action dispatcher:

```ts
@injectable()
export class MySelectionListener implements ISelectionListener {
    @inject(TYPES.IActionDispatcher)
    protected actionDispatcher: ActionDispatcher;

    selectionChanged(root: Readonly<GModelRoot>, selectedElements: string[], deselectedElements?: string[] | undefined): void {
        console.log('Selection changed: ' + selectedElements);
    }
}

// bind it in the workflow diagram module

bindAsService(context, TYPES.ISelectionListener, MySelectionListener);
```

This fails on master with a circular dependency error but works with this change.

Fixes eclipse-glsp/glsp/issues/1166