### PR TITLE
Avoid dependency on 'chai' through exported index

### DIFF
--- a/packages/protocol/src/utils/index.ts
+++ b/packages/protocol/src/utils/index.ts
@@ -17,5 +17,7 @@ export * from './array-util';
 export * from './di-util';
 export * from './disposable';
 export * from './event';
-export * from './test-util';
+// we do not export test-util to avoid a dependency on test frameworks such as chai
+// however, adopters can still access the file by accessing it through the complete path
+// export * from './test-util';
 export * from './type-util';


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-glsp/glsp/issues/1269

#### How to test

Verify through another package that does not have chai but still imports types and functions from the main package that it properly works.

#### Follow-ups

#### Changelog
- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
