### PR TITLE
Fix helper line feedback matching

### DIFF
--- a/packages/client/src/features/helper-lines/helper-line-feedback.ts
+++ b/packages/client/src/features/helper-lines/helper-line-feedback.ts
@@ -64,6 +64,7 @@ import {
     isVisibleOnCanvas
 } from '../../utils/gmodel-util';
 import { getViewportBounds, toAbsoluteBounds } from '../../utils/viewpoint-util';
+import { feedbackEdgeEndId, feedbackEdgeId } from '../tools';
 import { HelperLine, HelperLineType, SelectionBounds, isHelperLine, isSelectionBounds } from './model';
 
 export type ViewportLineType = typeof HelperLineType.Center | typeof HelperLineType.Middle | string;
@@ -90,7 +91,12 @@ export const DEFAULT_ELEMENT_LINES = ALL_ELEMENT_LINE_TYPES;
 export const DEFAULT_VIEWPORT_LINES = ALL_VIEWPORT_LINE_TYPES;
 export const DEFAULT_EPSILON = 1;
 export const DEFAULT_ALIGNABLE_ELEMENT_FILTER = (element: BoundsAwareModelElement): boolean =>
-    isVisibleOnCanvas(element) && !isRoutable(element) && !(element instanceof GLabel) && !isDecoration(element);
+    isVisibleOnCanvas(element) &&
+    !isRoutable(element) &&
+    !(element instanceof GLabel) &&
+    !(element.id === feedbackEdgeId(element.root)) &&
+    !(element.id === feedbackEdgeEndId(element.root)) &&
+    !isDecoration(element);
 export const DEFAULT_DEBUG = false;
 
 export namespace DrawHelperLinesFeedbackAction {
@@ -294,7 +300,7 @@ export class DrawHelperLinesFeedbackCommand extends FeedbackCommand {
     }
 
     protected isMatch(leftCoordinate: number, rightCoordinate: number, epsilon: number): boolean {
-        return Math.abs(leftCoordinate - rightCoordinate) < epsilon;
+        return Math.abs(leftCoordinate - rightCoordinate) <= epsilon;
     }
 
     protected log(message: string, ...params: any[]): void {


### PR DESCRIPTION
#### What it does

- Use <= as comparison operator
- Do not match for feedback edge

Fixes https://github.com/eclipse-glsp/glsp/issues/1257

#### How to test

When binding the `IHelperLineOptions` in `workflow-diagram-module`, set the `alignmentEpsilon` to zero and observe that now we properly match the zero-epsilon condition.

#### Follow-ups

#### Changelog

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
