### PR TITLE
Ensure hidden bounds calculation works in all browser

### DIFF
--- a/packages/client/css/ghost-element.css
+++ b/packages/client/css/ghost-element.css
@@ -21,5 +21,7 @@
 }
 
 .ghost-element.hidden {
-    display: none;
+    width: 0;
+    height: 0;
+    visibility: hidden;
 }

--- a/packages/client/css/glsp-sprotty.css
+++ b/packages/client/css/glsp-sprotty.css
@@ -73,11 +73,6 @@
     fill: #1d80d1;
 }
 
-.sprotty-hidden .sprotty-resize-handle {
-    /** resize handles should not be considered as part of the elements bounds */
-    display: none;
-}
-
 .sprotty-edge {
     fill: none;
     stroke-width: 1.5px;

--- a/packages/client/src/features/bounds/set-bounds-feedback-command.ts
+++ b/packages/client/src/features/bounds/set-bounds-feedback-command.ts
@@ -65,6 +65,7 @@ export class SetBoundsFeedbackCommand extends SetBoundsCommand implements Feedba
                 element.layoutOptions = options;
             }
         });
-        return LocalRequestBoundsAction.fromCommand(context, this.actionDispatcher, this.action);
+        const elementIDs = this.action.bounds.map(bounds => bounds.elementId);
+        return LocalRequestBoundsAction.fromCommand(context, this.actionDispatcher, this.action, elementIDs);
     }
 }

--- a/packages/client/src/features/element-template/add-template-element.ts
+++ b/packages/client/src/features/element-template/add-template-element.ts
@@ -64,13 +64,14 @@ export class AddTemplateElementsFeedbackCommand extends FeedbackCommand {
     }
 
     override execute(context: CommandExecutionContext): CommandResult {
-        this.action.templates
+        const templateElements = this.action.templates
             .map(template => templateToSchema(template, context))
             .filter(isNotUndefined)
             .map(schema => context.modelFactory.createElement(schema))
-            .map(element => this.applyRootCssClasses(element, this.action.addClasses, this.action.removeClasses))
-            .forEach(templateElement => context.root.add(templateElement));
-        return LocalRequestBoundsAction.fromCommand(context, this.actionDispatcher, this.action);
+            .map(element => this.applyRootCssClasses(element, this.action.addClasses, this.action.removeClasses));
+        templateElements.forEach(templateElement => context.root.add(templateElement));
+        const templateElementIDs = templateElements.map(element => element.id);
+        return LocalRequestBoundsAction.fromCommand(context, this.actionDispatcher, this.action, templateElementIDs);
     }
 
     protected applyRootCssClasses(element: GChildElement, addClasses?: string[], removeClasses?: string[]): GChildElement {

--- a/packages/client/src/utils/gmodel-util.ts
+++ b/packages/client/src/utils/gmodel-util.ts
@@ -22,6 +22,7 @@ import {
     GChildElement,
     GModelElement,
     GModelElementSchema,
+    GParentElement,
     GRoutableElement,
     GRoutingHandle,
     ModelIndexImpl,
@@ -30,13 +31,12 @@ import {
     Selectable,
     TypeGuard,
     distinctAdd,
-    findParentByFeature,
     getAbsoluteBounds,
+    getZoom,
     isBoundsAware,
     isMoveable,
     isSelectable,
     isSelected,
-    isViewport,
     remove
 } from '@eclipse-glsp/sprotty';
 
@@ -346,8 +346,7 @@ export function findTopLevelElementByFeature<T>(
 
 export function calculateDeltaBetweenPoints(target: Point, source: Point, element: GModelElement): Point {
     const delta = Point.subtract(target, source);
-    const viewport = findParentByFeature(element, isViewport);
-    const zoom = viewport?.zoom ?? 1;
+    const zoom = getZoom(element);
     const adaptedDelta = { x: delta.x / zoom, y: delta.y / zoom };
     return adaptedDelta;
 }
@@ -361,4 +360,16 @@ export function isVisibleOnCanvas(model: BoundsAwareModelElement): boolean {
         modelBounds.y <= canvasBounds.height &&
         modelBounds.y + modelBounds.height >= 0
     );
+}
+
+export function getDescendantIds(element?: GModelElement, skip?: (t: GModelElement) => boolean): string[] {
+    if (!element || skip?.(element)) {
+        return [];
+    }
+    const parent = element;
+    const ids = [parent.id];
+    if (parent instanceof GParentElement) {
+        ids.push(...parent.children.flatMap(child => getDescendantIds(child, skip)));
+    }
+    return ids;
 }

--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -173,6 +173,7 @@ export {
     SIssueSeverity as GIssueSeverity,
     // Export as is, we extend it glsp-client to `GIssueMarker`
     SIssueMarker,
+    decorationFeature,
     isDecoration
 } from 'sprotty/lib/features/decoration/model';
 export * from 'sprotty/lib/features/decoration/views';


### PR DESCRIPTION
#### What it does

- Do not use 'display: none' for hidden getBBox() calculation

- Only re-calculate the bounds for certain elements -- Extend LocalRequestBoundsAction with element IDs -- Restrict calculation to given set of elements if IDs are present

- Minor: Fix re-export for decorationModule

Fixes https://github.com/eclipse-glsp/glsp/issues/1258

#### How to test

- Resize elements or create new elements in the workflow example using the ghost elements (default).
- Check that we have the same visual feedback in both Chrome, Firefox or any other browser you are using

#### Follow-ups

#### Changelog

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
