### PR TITLE
Improve UI Extension mechanism for easier re-use of HTML elements

### DIFF
--- a/packages/client/src/default-modules.ts
+++ b/packages/client/src/default-modules.ts
@@ -26,7 +26,6 @@ import {
     edgeLayoutModule,
     expandModule,
     fadeModule,
-    labelEditUiModule,
     modelSourceModule,
     resolveContainerConfiguration,
     zorderModule
@@ -61,6 +60,7 @@ import { nodeCreationToolModule } from './features/tools/node-creation/node-crea
 import { toolFocusLossModule } from './features/tools/tool-focus-loss-module';
 import { markerNavigatorModule, validationModule } from './features/validation/validation-modules';
 import { viewportModule } from './features/viewport/viewport-modules';
+import { labelEditUiModule } from './features/label-edit-ui/label-edit-ui-module';
 
 export const DEFAULT_MODULES = [
     defaultModule,

--- a/packages/client/src/features/command-palette/command-palette-module.ts
+++ b/packages/client/src/features/command-palette/command-palette-module.ts
@@ -13,13 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { CommandPalette, CommandPaletteActionProviderRegistry, FeatureModule, TYPES, bindAsService } from '@eclipse-glsp/sprotty';
+import { CommandPaletteActionProviderRegistry, FeatureModule, TYPES, bindAsService } from '@eclipse-glsp/sprotty';
 import '../../../css/command-palette.css';
+import { GlspCommandPalette } from './command-palette';
 import { CommandPaletteTool } from './command-palette-tool';
 import { ServerCommandPaletteActionProvider } from './server-command-palette-provider';
 
 export const commandPaletteModule = new FeatureModule(bind => {
-    bindAsService(bind, TYPES.IUIExtension, CommandPalette);
+    bindAsService(bind, TYPES.IUIExtension, GlspCommandPalette);
     bind(TYPES.ICommandPaletteActionProviderRegistry).to(CommandPaletteActionProviderRegistry).inSingletonScope();
     bindAsService(bind, TYPES.ICommandPaletteActionProvider, ServerCommandPaletteActionProvider);
     bindAsService(bind, TYPES.IDefaultTool, CommandPaletteTool);

--- a/packages/client/src/features/command-palette/command-palette.ts
+++ b/packages/client/src/features/command-palette/command-palette.ts
@@ -14,7 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.ui-extension.hidden {
-    display: none;
-    opacity: 0;
+import { CSS_HIDDEN_EXTENSION_CLASS, CSS_UI_EXTENSION_CLASS, CommandPalette } from '@eclipse-glsp/sprotty';
+import { injectable } from 'inversify';
+
+@injectable()
+export class GlspCommandPalette extends CommandPalette {
+    protected override initializeContents(containerElement: HTMLElement): void {
+        super.initializeContents(containerElement);
+        containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
+    }
+
+    protected override setContainerVisible(visible: boolean): void {
+        if (visible) {
+            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
+        } else {
+            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
+        }
+    }
 }

--- a/packages/client/src/features/command-palette/index.ts
+++ b/packages/client/src/features/command-palette/index.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+export * from './command-palette';
 export * from './command-palette-module';
 export * from './command-palette-tool';
 export * from './server-command-palette-provider';

--- a/packages/client/src/features/label-edit-ui/label-edit-ui-module.ts
+++ b/packages/client/src/features/label-edit-ui/label-edit-ui-module.ts
@@ -13,8 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { EditLabelAction, EditLabelActionHandler, FeatureModule, TYPES, configureActionHandler } from '@eclipse-glsp/sprotty';
+import { GlspEditLabelUI } from './label-edit-ui';
 
-.ui-extension.hidden {
-    display: none;
-    opacity: 0;
-}
+export const labelEditUiModule = new FeatureModule((bind, unbind, isBound, rebind, ...rest) => {
+    const context = { bind, unbind, isBound, rebind };
+    configureActionHandler(context, EditLabelAction.KIND, EditLabelActionHandler);
+    bind(GlspEditLabelUI).toSelf().inSingletonScope();
+    bind(TYPES.IUIExtension).toService(GlspEditLabelUI);
+});

--- a/packages/client/src/features/label-edit-ui/label-edit-ui.ts
+++ b/packages/client/src/features/label-edit-ui/label-edit-ui.ts
@@ -13,8 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { CSS_HIDDEN_EXTENSION_CLASS, CSS_UI_EXTENSION_CLASS, EditLabelUI } from '@eclipse-glsp/sprotty';
+import { injectable } from 'inversify';
 
-.ui-extension.hidden {
-    display: none;
-    opacity: 0;
+@injectable()
+export class GlspEditLabelUI extends EditLabelUI {
+    protected override initializeContents(containerElement: HTMLElement): void {
+        super.initializeContents(containerElement);
+        containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
+    }
+
+    protected override setContainerVisible(visible: boolean): void {
+        if (visible) {
+            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
+        } else {
+            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
+        }
+    }
 }

--- a/packages/glsp-sprotty/css/ui-extension.css
+++ b/packages/glsp-sprotty/css/ui-extension.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,9 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './action-override';
-export * from './feature-modules';
-export * from './re-exports';
-export * from './routing-override';
-export * from './types';
-export * from './ui-extension-override';
+
+.ui-extension.hidden {
+    display: none;
+    visibility: hidden;
+    opacity: 0;
+}

--- a/packages/glsp-sprotty/src/feature-modules.ts
+++ b/packages/glsp-sprotty/src/feature-modules.ts
@@ -15,16 +15,12 @@
  ********************************************************************************/
 /* eslint-disable no-restricted-imports */
 
-import { FeatureModule, bindOrRebind } from '@eclipse-glsp/protocol';
-import { EditLabelUI as SprottyEditLabelUI } from 'sprotty';
+import { FeatureModule } from '@eclipse-glsp/protocol';
 import sprottyDefaultModule from 'sprotty/lib/base/di.config';
 import sprottyButtonModule from 'sprotty/lib/features/button/di.config';
 import sprottyEdgeIntersectionModule from 'sprotty/lib/features/edge-intersection/di.config';
 import sprottyEdgeLayoutModule from 'sprotty/lib/features/edge-layout/di.config';
-import {
-    edgeEditModule as sprottyEdgeEditModule,
-    labelEditUiModule as sprottyLabelEditUiModule
-} from 'sprotty/lib/features/edit/di.config';
+import { edgeEditModule as sprottyEdgeEditModule } from 'sprotty/lib/features/edit/di.config';
 import sprottyExpandModule from 'sprotty/lib/features/expand/di.config';
 import sprottyFadeModule from 'sprotty/lib/features/fade/di.config';
 import sprottyMoveModule from 'sprotty/lib/features/move/di.config';
@@ -32,7 +28,6 @@ import sprottyOpenModule from 'sprotty/lib/features/open/di.config';
 import sprottyUpdateModule from 'sprotty/lib/features/update/di.config';
 import sprottyZorderModule from 'sprotty/lib/features/zorder/di.config';
 import sprottyModelSourceModule from 'sprotty/lib/model-source/di.config';
-import { EditLabelUI } from './ui-extension-override';
 
 export const buttonModule = new FeatureModule(sprottyButtonModule.registry);
 export const edgeEditModule = new FeatureModule(sprottyEdgeEditModule.registry);
@@ -45,12 +40,5 @@ export const moveModule = new FeatureModule(sprottyMoveModule.registry);
 export const openModule = new FeatureModule(sprottyOpenModule.registry);
 export const updateModule = new FeatureModule(sprottyUpdateModule.registry);
 export const zorderModule = new FeatureModule(sprottyZorderModule.registry);
-
-export const labelEditUiModule = new FeatureModule((bind, unbind, isBound, rebind, ...rest) => {
-    const context = { bind, unbind, isBound, rebind };
-    sprottyLabelEditUiModule.registry(bind, unbind, isBound, rebind, ...rest);
-    bind(EditLabelUI).toSelf().inSingletonScope();
-    bindOrRebind(context, SprottyEditLabelUI).toService(EditLabelUI);
-});
 
 export { sprottyDefaultModule };

--- a/packages/glsp-sprotty/src/feature-modules.ts
+++ b/packages/glsp-sprotty/src/feature-modules.ts
@@ -15,7 +15,9 @@
  ********************************************************************************/
 /* eslint-disable no-restricted-imports */
 
-import { FeatureModule } from '@eclipse-glsp/protocol';
+import { FeatureModule, bindOrRebind } from '@eclipse-glsp/protocol';
+import { EditLabelUI as SprottyEditLabelUI } from 'sprotty';
+import sprottyDefaultModule from 'sprotty/lib/base/di.config';
 import sprottyButtonModule from 'sprotty/lib/features/button/di.config';
 import sprottyEdgeIntersectionModule from 'sprotty/lib/features/edge-intersection/di.config';
 import sprottyEdgeLayoutModule from 'sprotty/lib/features/edge-layout/di.config';
@@ -26,11 +28,11 @@ import {
 import sprottyExpandModule from 'sprotty/lib/features/expand/di.config';
 import sprottyFadeModule from 'sprotty/lib/features/fade/di.config';
 import sprottyMoveModule from 'sprotty/lib/features/move/di.config';
+import sprottyOpenModule from 'sprotty/lib/features/open/di.config';
 import sprottyUpdateModule from 'sprotty/lib/features/update/di.config';
 import sprottyZorderModule from 'sprotty/lib/features/zorder/di.config';
 import sprottyModelSourceModule from 'sprotty/lib/model-source/di.config';
-import sprottyDefaultModule from 'sprotty/lib/base/di.config';
-import sprottyOpenModule from 'sprotty/lib/features/open/di.config';
+import { EditLabelUI } from './ui-extension-override';
 
 export const buttonModule = new FeatureModule(sprottyButtonModule.registry);
 export const edgeEditModule = new FeatureModule(sprottyEdgeEditModule.registry);
@@ -38,11 +40,17 @@ export const edgeIntersectionModule = new FeatureModule(sprottyEdgeIntersectionM
 export const edgeLayoutModule = new FeatureModule(sprottyEdgeLayoutModule.registry);
 export const expandModule = new FeatureModule(sprottyExpandModule.registry);
 export const fadeModule = new FeatureModule(sprottyFadeModule.registry);
-export const labelEditUiModule = new FeatureModule(sprottyLabelEditUiModule.registry);
 export const modelSourceModule = new FeatureModule(sprottyModelSourceModule.registry);
 export const moveModule = new FeatureModule(sprottyMoveModule.registry);
 export const openModule = new FeatureModule(sprottyOpenModule.registry);
 export const updateModule = new FeatureModule(sprottyUpdateModule.registry);
 export const zorderModule = new FeatureModule(sprottyZorderModule.registry);
+
+export const labelEditUiModule = new FeatureModule((bind, unbind, isBound, rebind, ...rest) => {
+    const context = { bind, unbind, isBound, rebind };
+    sprottyLabelEditUiModule.registry(bind, unbind, isBound, rebind, ...rest);
+    bind(EditLabelUI).toSelf().inSingletonScope();
+    bindOrRebind(context, SprottyEditLabelUI).toService(EditLabelUI);
+});
 
 export { sprottyDefaultModule };

--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -128,7 +128,7 @@ export {
     CommandPaletteActionProviderRegistry,
     RevealNamedElementActionProvider
 } from 'sprotty/lib/features/command-palette/action-providers';
-export { CommandPaletteKeyListener } from 'sprotty/lib/features/command-palette/command-palette';
+export * from 'sprotty/lib/features/command-palette/command-palette';
 
 // Exclude menu item. Aready provided by glsp-protocol
 export { Anchor, IContextMenuService, IContextMenuServiceProvider } from 'sprotty/lib/features/context-menu/context-menu-service';
@@ -143,7 +143,7 @@ export * from 'sprotty/lib/features/edge-layout/model';
 // export * from 'sprotty/lib/features/edit/create-on-drag';
 export * from 'sprotty/lib/features/edit/delete';
 export * from 'sprotty/lib/features/edit/edit-label';
-export { EditLabelActionHandler, IEditLabelValidationDecorator } from 'sprotty/lib/features/edit/edit-label-ui';
+export * from 'sprotty/lib/features/edit/edit-label-ui';
 export * from 'sprotty/lib/features/edit/edit-routing';
 export * from 'sprotty/lib/features/edit/model';
 // export * from 'sprotty/lib/features/edit/reconnect';

--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -73,7 +73,7 @@ export {
 } from 'sprotty/lib/base/model/smodel-factory';
 export * from 'sprotty/lib/base/model/smodel-utils';
 
-export * from 'sprotty/lib/base/ui-extensions/ui-extension';
+export { IUIExtension, isUIExtension } from 'sprotty/lib/base/ui-extensions/ui-extension';
 export * from 'sprotty/lib/base/ui-extensions/ui-extension-registry';
 
 export * from 'sprotty/lib/base/views/dom-helper';
@@ -128,7 +128,7 @@ export {
     CommandPaletteActionProviderRegistry,
     RevealNamedElementActionProvider
 } from 'sprotty/lib/features/command-palette/action-providers';
-export * from 'sprotty/lib/features/command-palette/command-palette';
+export { CommandPaletteKeyListener } from 'sprotty/lib/features/command-palette/command-palette';
 
 // Exclude menu item. Aready provided by glsp-protocol
 export { Anchor, IContextMenuService, IContextMenuServiceProvider } from 'sprotty/lib/features/context-menu/context-menu-service';
@@ -143,7 +143,7 @@ export * from 'sprotty/lib/features/edge-layout/model';
 // export * from 'sprotty/lib/features/edit/create-on-drag';
 export * from 'sprotty/lib/features/edit/delete';
 export * from 'sprotty/lib/features/edit/edit-label';
-export * from 'sprotty/lib/features/edit/edit-label-ui';
+export { EditLabelActionHandler, IEditLabelValidationDecorator } from 'sprotty/lib/features/edit/edit-label-ui';
 export * from 'sprotty/lib/features/edit/edit-routing';
 export * from 'sprotty/lib/features/edit/model';
 // export * from 'sprotty/lib/features/edit/reconnect';

--- a/packages/glsp-sprotty/src/ui-extension-override.ts
+++ b/packages/glsp-sprotty/src/ui-extension-override.ts
@@ -16,11 +16,7 @@
 import '../css/ui-extension.css';
 
 import { injectable } from 'inversify';
-import {
-    AbstractUIExtension as SprottyAbstractUIExtension,
-    CommandPalette as SprottyCommandPalette,
-    EditLabelUI as SprottyEditLabelUI
-} from 'sprotty';
+import { AbstractUIExtension as SprottyAbstractUIExtension } from 'sprotty';
 
 export const CSS_UI_EXTENSION_CLASS = 'ui-extension';
 export const CSS_HIDDEN_EXTENSION_CLASS = 'hidden';
@@ -73,7 +69,7 @@ export abstract class AbstractUIExtension extends SprottyAbstractUIExtension {
         }
         // to create a container the parent container
         const parent = this.getParentContainer();
-        if (!parent || !parent.isConnected) {
+        if (!parent?.isConnected) {
             throw new Error(`Could not obtain attached parent for initializing UI extension ${this.id}`);
         }
         const container = this.createContainer(parent);
@@ -95,7 +91,7 @@ export abstract class AbstractUIExtension extends SprottyAbstractUIExtension {
         container.classList.add(CSS_UI_EXTENSION_CLASS, this.containerClass());
     }
 
-    protected getParentContainer(): HTMLElement {
+    protected getParentContainer(): HTMLElement | null {
         return document.querySelector<HTMLElement>(this.parentContainerSelector)!;
     }
 
@@ -113,42 +109,10 @@ export abstract class AbstractUIExtension extends SprottyAbstractUIExtension {
     }
 
     protected isContainerVisible(): boolean {
-        return this.containerElement && !this.containerElement.classList.contains(CSS_HIDDEN_EXTENSION_CLASS);
+        return !this.containerElement?.classList.contains(CSS_HIDDEN_EXTENSION_CLASS);
     }
 
     protected toggleContainerVisible(): void {
         this.setContainerVisible(!this.isContainerVisible());
-    }
-}
-
-@injectable()
-export class EditLabelUI extends SprottyEditLabelUI {
-    protected override initializeContents(containerElement: HTMLElement): void {
-        super.initializeContents(containerElement);
-        containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
-    }
-
-    protected override setContainerVisible(visible: boolean): void {
-        if (visible) {
-            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
-        } else {
-            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
-        }
-    }
-}
-
-@injectable()
-export class CommandPalette extends SprottyCommandPalette {
-    protected override initializeContents(containerElement: HTMLElement): void {
-        super.initializeContents(containerElement);
-        containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
-    }
-
-    protected override setContainerVisible(visible: boolean): void {
-        if (visible) {
-            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
-        } else {
-            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
-        }
     }
 }

--- a/packages/glsp-sprotty/src/ui-extension-override.ts
+++ b/packages/glsp-sprotty/src/ui-extension-override.ts
@@ -1,0 +1,154 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import '../css/ui-extension.css';
+
+import { injectable } from 'inversify';
+import {
+    AbstractUIExtension as SprottyAbstractUIExtension,
+    CommandPalette as SprottyCommandPalette,
+    EditLabelUI as SprottyEditLabelUI
+} from 'sprotty';
+
+export const CSS_UI_EXTENSION_CLASS = 'ui-extension';
+export const CSS_HIDDEN_EXTENSION_CLASS = 'hidden';
+
+// An override to enables more fine-grained control of the container structure for the UI extension.
+
+@injectable()
+export abstract class AbstractUIExtension extends SprottyAbstractUIExtension {
+    protected get diagramContainerId(): string {
+        return this.options.baseDiv;
+    }
+
+    protected get parentContainerSelector(): string {
+        return '#' + this.diagramContainerId;
+    }
+
+    protected get containerSelector(): string {
+        return '#' + this.id();
+    }
+
+    protected get initialized(): boolean {
+        return !!this.containerElement;
+    }
+
+    protected override initialize(): boolean {
+        if (this.initialized) {
+            return true;
+        }
+        try {
+            this.containerElement = this.getOrCreateContainer();
+            this.initializeContainer(this.containerElement);
+            this.initializeContents(this.containerElement);
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : `Could not retrieve container element for UI extension ${this.id}`;
+            this.logger.error(this, msg);
+            return false;
+        }
+        return true;
+    }
+
+    protected override getOrCreateContainer(): HTMLElement {
+        if (this.containerElement) {
+            return this.containerElement;
+        }
+        // check if the container already exists, independent from any potential parent container
+        // this allows us to use existing elements defined anywhere in the document
+        const existingContainer = this.getContainer();
+        if (existingContainer) {
+            return existingContainer;
+        }
+        // to create a container the parent container
+        const parent = this.getParentContainer();
+        if (!parent || !parent.isConnected) {
+            throw new Error(`Could not obtain attached parent for initializing UI extension ${this.id}`);
+        }
+        const container = this.createContainer(parent);
+        this.insertContainerIntoParent(container, parent);
+        return container;
+    }
+
+    protected getContainer(): HTMLElement | null {
+        return document.querySelector<HTMLElement>(this.containerSelector);
+    }
+
+    protected createContainer(parent: HTMLElement): HTMLElement {
+        const container = document.createElement('div');
+        container.id = parent.id + '_' + this.id();
+        return container;
+    }
+
+    protected initializeContainer(container: HTMLElement): void {
+        container.classList.add(CSS_UI_EXTENSION_CLASS, this.containerClass());
+    }
+
+    protected getParentContainer(): HTMLElement {
+        return document.querySelector<HTMLElement>(this.parentContainerSelector)!;
+    }
+
+    protected insertContainerIntoParent(container: HTMLElement, parent: HTMLElement): void {
+        parent.insertBefore(container, parent.firstChild);
+    }
+
+    protected override setContainerVisible(visible: boolean): void {
+        // the parent class simply sets the style directly, however classes provide more fine-grained control
+        if (visible) {
+            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
+        } else {
+            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
+        }
+    }
+
+    protected isContainerVisible(): boolean {
+        return this.containerElement && !this.containerElement.classList.contains(CSS_HIDDEN_EXTENSION_CLASS);
+    }
+
+    protected toggleContainerVisible(): void {
+        this.setContainerVisible(!this.isContainerVisible());
+    }
+}
+
+@injectable()
+export class EditLabelUI extends SprottyEditLabelUI {
+    protected override initializeContents(containerElement: HTMLElement): void {
+        super.initializeContents(containerElement);
+        containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
+    }
+
+    protected override setContainerVisible(visible: boolean): void {
+        if (visible) {
+            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
+        } else {
+            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
+        }
+    }
+}
+
+@injectable()
+export class CommandPalette extends SprottyCommandPalette {
+    protected override initializeContents(containerElement: HTMLElement): void {
+        super.initializeContents(containerElement);
+        containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
+    }
+
+    protected override setContainerVisible(visible: boolean): void {
+        if (visible) {
+            this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
+        } else {
+            this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
+        }
+    }
+}


### PR DESCRIPTION
#### What it does

- Allow more fine-grained definition of container and parent
- Allow more fine-grained definition of container within parent
- Replace hard-coded styles with 'hidden' class

Fixes https://github.com/eclipse-glsp/glsp/issues/1246
Fixes https://github.com/eclipse-glsp/glsp/issues/1318

#### How to test
- Check whether the known UI extensions (command palette, label edit, tool palette) still work as expected
- Check whether the fade animation is no longer visible in the Theia integration (for https://github.com/eclipse-glsp/glsp/issues/1246)

#### Follow-ups
None.

#### Changelog
- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
