### PR TITLE
Improve handling of change bounds in several areas

### DIFF
--- a/packages/client/css/change-bounds.css
+++ b/packages/client/css/change-bounds.css
@@ -2,14 +2,39 @@
     cursor: nw-resize;
 }
 
+.sprotty-resize-handle[data-kind='top'] {
+    cursor: n-resize;
+}
+
 .sprotty-resize-handle[data-kind='top-right'] {
     cursor: ne-resize;
+}
+
+.sprotty-resize-handle[data-kind='right'] {
+    cursor: e-resize;
+}
+
+.sprotty-resize-handle[data-kind='bottom-right'] {
+    cursor: se-resize;
+}
+
+.sprotty-resize-handle[data-kind='bottom'] {
+    cursor: s-resize;
 }
 
 .sprotty-resize-handle[data-kind='bottom-left'] {
     cursor: sw-resize;
 }
 
-.sprotty-resize-handle[data-kind='bottom-right'] {
-    cursor: se-resize;
+.sprotty-resize-handle[data-kind='left'] {
+    cursor: w-resize;
+}
+
+.sprotty-resize-handle.resize-not-allowed {
+    fill: var(--glsp-error-foreground) !important;
+}
+
+.sprotty g .resize-not-allowed > .sprotty-node {
+    stroke: var(--glsp-error-foreground) !important;
+    stroke-width: 1.5px;
 }

--- a/packages/client/css/change-bounds.css
+++ b/packages/client/css/change-bounds.css
@@ -31,10 +31,19 @@
 }
 
 .sprotty-resize-handle.resize-not-allowed {
-    fill: var(--glsp-error-foreground) !important;
+    fill: var(--glsp-error-foreground);
 }
 
 .sprotty g .resize-not-allowed > .sprotty-node {
-    stroke: var(--glsp-error-foreground) !important;
+    stroke: var(--glsp-error-foreground);
     stroke-width: 1.5px;
+}
+
+.move-mode .sprotty-projection-bar,
+.resize-mode .sprotty-projection-bar {
+    /**
+     * We are using mouse events (offsetX, offsetY) in the GLSPMousePositionTracker to calculate the diagram position relative to the parent.
+     * Other elements result in relative coordinates different from the graph and will therefore interfere with the correct position calculation.
+     */
+    pointer-events: none;
 }

--- a/packages/client/css/glsp-sprotty.css
+++ b/packages/client/css/glsp-sprotty.css
@@ -152,16 +152,32 @@
     cursor: nw-resize;
 }
 
+.sprotty .resize-w-mode {
+    cursor: n-resize;
+}
+
 .sprotty .resize-ne-mode {
     cursor: ne-resize;
+}
+
+.sprotty .resize-e-mode {
+    cursor: e-resize;
+}
+
+.sprotty .resize-se-mode {
+    cursor: se-resize;
+}
+
+.sprotty .resize-s-mode {
+    cursor: s-resize;
 }
 
 .sprotty .resize-sw-mode {
     cursor: sw-resize;
 }
 
-.sprotty .resize-se-mode {
-    cursor: se-resize;
+.sprotty .resize-w-mode {
+    cursor: w-resize;
 }
 
 .sprotty .element-deletion-mode {

--- a/packages/client/css/helper-lines.css
+++ b/packages/client/css/helper-lines.css
@@ -16,8 +16,8 @@
 
 .helper-line {
     pointer-events: none;
-    stroke: #f7086c;
-    stroke-width: 0.5;
+    stroke: #1d80d1;
+    stroke-width: 1;
     opacity: 1;
 }
 

--- a/packages/client/src/base/default.module.ts
+++ b/packages/client/src/base/default.module.ts
@@ -18,6 +18,7 @@ import {
     FeatureModule,
     KeyTool,
     LocationPostprocessor,
+    MousePositionTracker,
     MouseTool,
     MoveCommand,
     SetDirtyStateAction,
@@ -47,6 +48,7 @@ import { DiagramLoader } from './model/diagram-loader';
 import { GLSPModelSource } from './model/glsp-model-source';
 import { DefaultModelInitializationConstraint, ModelInitializationConstraint } from './model/model-initialization-constraint';
 import { GModelRegistry } from './model/model-registry';
+import { GLSPMousePositionTracker } from './mouse-position-tracker';
 import { SelectionClearingMouseListener } from './selection-clearing-mouse-listener';
 import { SelectionService } from './selection-service';
 import { EnableDefaultToolsAction, EnableToolsAction } from './tool-manager/tool';
@@ -85,7 +87,8 @@ export const defaultModule = new FeatureModule((bind, unbind, isBound, rebind, .
     bind(GLSPMouseTool).toSelf().inSingletonScope();
     bindOrRebind(context, MouseTool).toService(GLSPMouseTool);
     bind(TYPES.IDiagramStartup).toService(GLSPMouseTool);
-
+    bind(GLSPMousePositionTracker).toSelf().inSingletonScope();
+    bindOrRebind(context, MousePositionTracker).toService(GLSPMousePositionTracker);
     bind(GLSPKeyTool).toSelf().inSingletonScope();
     bindOrRebind(context, KeyTool).toService(GLSPKeyTool);
     bind(TYPES.IDiagramStartup).toService(GLSPKeyTool);

--- a/packages/client/src/base/feedback/css-feedback.ts
+++ b/packages/client/src/base/feedback/css-feedback.ts
@@ -85,14 +85,18 @@ export enum CursorCSS {
     RESIZE_NESW = 'resize-nesw-mode',
     RESIZE_NWSE = 'resize-nwse-mode',
     RESIZE_NW = 'resize-nw-mode',
+    RESIZE_N = 'resize-n-mode',
     RESIZE_NE = 'resize-ne-mode',
-    RESIZE_SW = 'resize-sw-mode',
+    RESIZE_E = 'resize-e-mode',
     RESIZE_SE = 'resize-se-mode',
+    RESIZE_S = 'resize-s-mode',
+    RESIZE_SW = 'resize-sw-mode',
+    RESIZE_W = 'resize-w-mode',
     MOVE = 'move-mode',
     MARQUEE = 'marquee-mode'
 }
 
-export function cursorFeedbackAction(cursorCss?: CursorCSS): ModifyCSSFeedbackAction {
+export function cursorFeedbackAction(cursorCss?: string): ModifyCSSFeedbackAction {
     const add = [];
     if (cursorCss) {
         add.push(cursorCss);
@@ -106,4 +110,8 @@ export function applyCssClasses(element: GModelElement, ...add: string[]): Modif
 
 export function deleteCssClasses(element: GModelElement, ...remove: string[]): ModifyCSSFeedbackAction {
     return ModifyCSSFeedbackAction.create({ elements: [element], remove });
+}
+
+export function toggleCssClasses(element: GModelElement, add: boolean, ...cssClasses: string[]): ModifyCSSFeedbackAction {
+    return add ? applyCssClasses(element, ...cssClasses) : deleteCssClasses(element, ...cssClasses);
 }

--- a/packages/client/src/base/feedback/feeback-emitter.ts
+++ b/packages/client/src/base/feedback/feeback-emitter.ts
@@ -32,9 +32,12 @@ export class FeedbackEmitter implements IFeedbackEmitter, Disposable {
      * once the {@link submit} method is called.
      *
      * @param action feedback action
-     * @param cleanupAction action that undoes the feedback action. This is only triggered when {@link revert} is called.
+     * @param cleanupAction action that undoes the feedback action. This is only triggered when {@link revert} or {@link dispose} is called.
      */
-    add(action: Action, cleanupAction?: MaybeActions): this {
+    add(action?: Action, cleanupAction?: MaybeActions): this {
+        if (!action && !cleanupAction) {
+            return this;
+        }
         const idx = this.feedbackActions.length;
         this.feedbackActions[idx] = action;
         if (cleanupAction) {
@@ -73,7 +76,7 @@ export class FeedbackEmitter implements IFeedbackEmitter, Disposable {
      * Registers any pending actions as feedback. Any previously submitted feedback becomes invalid.
      */
     submit(): this {
-        // with 'arrayOf' we skip undefined entries that are created for non-cleanup actions
+        // with 'arrayOf' we skip undefined entries that are created for non-cleanup actions or cleanup-only actions
         const actions = arrayOf(...this.feedbackActions);
         const cleanupActions = arrayOf(...this.cleanupActions);
         this.deregistration = this.feedbackDispatcher.registerFeedback(this, actions, () => cleanupActions.flatMap(MaybeActions.asArray));

--- a/packages/client/src/base/index.ts
+++ b/packages/client/src/base/index.ts
@@ -24,6 +24,7 @@ export * from './editor-context-service';
 export * from './feedback';
 export * from './focus';
 export * from './model';
+export * from './mouse-position-tracker';
 export * from './ranked';
 export * from './selection-clearing-mouse-listener';
 export * from './selection-service';

--- a/packages/client/src/base/mouse-position-tracker.ts
+++ b/packages/client/src/base/mouse-position-tracker.ts
@@ -1,8 +1,9 @@
 /********************************************************************************
- * Copyright (c) 2023 EclipseSource and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
+    rank: number;
  * http://www.eclipse.org/legal/epl-2.0.
  *
  * This Source Code may also be made available under the following Secondary
@@ -13,12 +14,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './bounds-module';
-export * from './freeform-layout';
-export * from './glsp-hidden-bounds-updater';
-export * from './hbox-layout';
-export * from './layout-data';
-export * from './layouter';
-export * from './local-bounds';
-export * from './set-bounds-feedback-command';
-export * from './vbox-layout';
+import { MousePositionTracker } from '@eclipse-glsp/sprotty';
+import { injectable } from 'inversify';
+import { Ranked } from './ranked';
+
+@injectable()
+export class GLSPMousePositionTracker extends MousePositionTracker implements Ranked {
+    /* we want to be executed before all default mouse listeners since we are just tracking the position and others may need it */
+    rank = Ranked.DEFAULT_RANK - 200;
+}

--- a/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
@@ -20,8 +20,8 @@ import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { SelectionService } from '../../../base/selection-service';
 import { Tool } from '../../../base/tool-manager/tool';
-import { unsnapModifier, useSnap } from '../../change-bounds/snap';
 import { Grid } from '../../grid';
+import { ChangeBoundsManager } from '../../tools';
 import { AccessibleKeyShortcutProvider, SetAccessibleKeyShortcutAction } from '../key-shortcut/accessible-key-shortcut';
 import { MoveElementAction, MoveViewportAction } from '../move-zoom/move-handler';
 
@@ -41,6 +41,7 @@ export class MovementKeyTool implements Tool {
     @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
     @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
     @optional() @inject(TYPES.Grid) protected grid: Grid;
+    @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
 
     get id(): string {
         return MovementKeyTool.ID;
@@ -86,7 +87,7 @@ export class MoveKeyListener extends KeyListener implements AccessibleKeyShortcu
 
     override keyDown(_element: GModelElement, event: KeyboardEvent): Action[] {
         const selectedElementIds = this.tool.selectionService.getSelectedElementIDs();
-        const snap = useSnap(event);
+        const snap = this.tool.changeBoundsManager.usePositionSnap(event);
         const offsetX = snap ? this.grid.x : 1;
         const offsetY = snap ? this.grid.y : 1;
 
@@ -115,18 +116,20 @@ export class MoveKeyListener extends KeyListener implements AccessibleKeyShortcu
     }
 
     protected matchesMoveUpKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowUp') || matchesKeystroke(event, 'ArrowUp', unsnapModifier());
+        return matchesKeystroke(event, 'ArrowUp') || matchesKeystroke(event, 'ArrowUp', this.tool.changeBoundsManager.unsnapModifier());
     }
 
     protected matchesMoveDownKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowDown') || matchesKeystroke(event, 'ArrowDown', unsnapModifier());
+        return matchesKeystroke(event, 'ArrowDown') || matchesKeystroke(event, 'ArrowDown', this.tool.changeBoundsManager.unsnapModifier());
     }
 
     protected matchesMoveRightKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowRight') || matchesKeystroke(event, 'ArrowRight', unsnapModifier());
+        return (
+            matchesKeystroke(event, 'ArrowRight') || matchesKeystroke(event, 'ArrowRight', this.tool.changeBoundsManager.unsnapModifier())
+        );
     }
 
     protected matchesMoveLeftKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowLeft') || matchesKeystroke(event, 'ArrowLeft', unsnapModifier());
+        return matchesKeystroke(event, 'ArrowLeft') || matchesKeystroke(event, 'ArrowLeft', this.tool.changeBoundsManager.unsnapModifier());
     }
 }

--- a/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
@@ -40,7 +40,7 @@ export class MovementKeyTool implements Tool {
     @inject(SelectionService) selectionService: SelectionService;
     @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
     @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
-    @optional() @inject(TYPES.Grid) protected grid: Grid;
+    @inject(TYPES.Grid) @optional() protected grid: Grid;
     @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
 
     get id(): string {
@@ -116,20 +116,22 @@ export class MoveKeyListener extends KeyListener implements AccessibleKeyShortcu
     }
 
     protected matchesMoveUpKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowUp') || matchesKeystroke(event, 'ArrowUp', this.tool.changeBoundsManager.unsnapModifier());
+        const unsnap = this.tool.changeBoundsManager.unsnapModifier();
+        return matchesKeystroke(event, 'ArrowUp') || (!!unsnap && matchesKeystroke(event, 'ArrowUp', unsnap));
     }
 
     protected matchesMoveDownKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowDown') || matchesKeystroke(event, 'ArrowDown', this.tool.changeBoundsManager.unsnapModifier());
+        const unsnap = this.tool.changeBoundsManager.unsnapModifier();
+        return matchesKeystroke(event, 'ArrowDown') || (!!unsnap && matchesKeystroke(event, 'ArrowDown', unsnap));
     }
 
     protected matchesMoveRightKeystroke(event: KeyboardEvent): boolean {
-        return (
-            matchesKeystroke(event, 'ArrowRight') || matchesKeystroke(event, 'ArrowRight', this.tool.changeBoundsManager.unsnapModifier())
-        );
+        const unsnap = this.tool.changeBoundsManager.unsnapModifier();
+        return matchesKeystroke(event, 'ArrowRight') || (!!unsnap && matchesKeystroke(event, 'ArrowRight', unsnap));
     }
 
     protected matchesMoveLeftKeystroke(event: KeyboardEvent): boolean {
-        return matchesKeystroke(event, 'ArrowLeft') || matchesKeystroke(event, 'ArrowLeft', this.tool.changeBoundsManager.unsnapModifier());
+        const unsnap = this.tool.changeBoundsManager.unsnapModifier();
+        return matchesKeystroke(event, 'ArrowLeft') || (!!unsnap && matchesKeystroke(event, 'ArrowLeft', unsnap));
     }
 }

--- a/packages/client/src/features/bounds/bounds-module.ts
+++ b/packages/client/src/features/bounds/bounds-module.ts
@@ -52,5 +52,7 @@ export const boundsModule = new FeatureModule((bind, _unbind, isBound, _rebind) 
     configureLayout(context, HBoxLayouter.KIND, HBoxLayouterExt);
     configureLayout(context, FreeFormLayouter.KIND, FreeFormLayouter);
 
+    // backwards compatibility
+    // eslint-disable-next-line deprecation/deprecation
     bind(PositionSnapper).toSelf();
 });

--- a/packages/client/src/features/bounds/hbox-layout.ts
+++ b/packages/client/src/features/bounds/hbox-layout.ts
@@ -13,22 +13,23 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable } from 'inversify';
 import {
     Bounds,
     BoundsData,
     Dimension,
     GChildElement,
+    GModelElement,
+    GParentElement,
     HBoxLayoutOptions,
     HBoxLayouter,
     LayoutContainer,
     Point,
-    GModelElement,
-    GParentElement,
     StatefulLayouter,
     isBoundsAware,
     isLayoutableChild
 } from '@eclipse-glsp/sprotty';
+import { injectable } from 'inversify';
+import { LayoutAware } from './layout-data';
 
 export interface HBoxLayoutOptionsExt extends HBoxLayoutOptions {
     hGrab: boolean;
@@ -79,7 +80,9 @@ export class HBoxLayouterExt extends HBoxLayouter {
 
         if (width > 0 && height > 0) {
             const offset = this.layoutChildren(container, layouter, options, width, height, grabWidth, grabbingChildren);
-            boundsData.bounds = this.getFinalContainerBounds(container, offset, options, childrenSize.width, childrenSize.height);
+            const computed = this.getComputedContainerDimensions(options, childrenSize.width, childrenSize.height);
+            LayoutAware.setComputedDimensions(boundsData, computed);
+            boundsData.bounds = this.getFinalContainerBounds(container, offset, options, computed.width, computed.height);
             boundsData.boundsChanged = true;
         }
     }
@@ -223,22 +226,28 @@ export class HBoxLayouterExt extends HBoxLayouter {
         return (element as any).layoutOptions;
     }
 
+    protected getComputedContainerDimensions(options: HBoxLayoutOptionsExt, maxWidth: number, maxHeight: number): Dimension {
+        return {
+            width: maxWidth + options.paddingLeft + options.paddingRight,
+            height: maxHeight + options.paddingTop + options.paddingBottom
+        };
+    }
+
     protected override getFinalContainerBounds(
         container: GParentElement & LayoutContainer,
         lastOffset: Point,
         options: HBoxLayoutOptionsExt,
-        maxWidth: number,
-        maxHeight: number
+        computedWidth: number,
+        computedHeight: number
     ): Bounds {
         const elementOptions = this.getElementLayoutOptions(container);
         const width = elementOptions?.prefWidth ?? options.minWidth;
         const height = elementOptions?.prefHeight ?? options.minHeight;
-
         const result = {
             x: container.bounds.x,
             y: container.bounds.y,
-            width: Math.max(width, maxWidth + options.paddingLeft + options.paddingRight),
-            height: Math.max(height, maxHeight + options.paddingTop + options.paddingBottom)
+            width: Math.max(width, computedWidth),
+            height: Math.max(height, computedHeight)
         };
 
         return result;

--- a/packages/client/src/features/bounds/layout-data.ts
+++ b/packages/client/src/features/bounds/layout-data.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Dimension, LayoutData } from '@eclipse-glsp/sprotty';
+
+export interface LayoutAware {
+    layoutData: LayoutData;
+}
+
+export namespace LayoutAware {
+    export function is<T extends object>(element: T): element is T & LayoutAware {
+        return 'layoutData' in element;
+    }
+
+    export function getLayoutData<T extends object>(element: T): LayoutData | undefined {
+        return is(element) ? element.layoutData : undefined;
+    }
+
+    export function setLayoutData<T extends object>(element: T, data: LayoutData): void {
+        (element as LayoutAware).layoutData = data;
+    }
+
+    export function setComputedDimensions<T extends object>(element: T, computedDimensions: Dimension): void {
+        ensureLayoutAware(element).layoutData.computedDimensions = computedDimensions;
+    }
+
+    export function getComputedDimensions<T extends object>(element: T): Dimension | undefined {
+        return getLayoutData(element)?.computedDimensions;
+    }
+
+    function ensureLayoutAware<T extends object>(element: T): T & LayoutAware {
+        (element as LayoutAware).layoutData = (element as LayoutAware).layoutData ?? {};
+        return element as T & LayoutAware;
+    }
+}

--- a/packages/client/src/features/bounds/layout-data.ts
+++ b/packages/client/src/features/bounds/layout-data.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 EclipseSource and others.
+ * Copyright (c) 2024 Axon Ivy AG and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/change-bounds/index.ts
+++ b/packages/client/src/features/change-bounds/index.ts
@@ -18,3 +18,4 @@ export * from './movement-restrictor';
 export * from './point-position-updater';
 export * from './position-snapper';
 export * from './snap';
+export * from './tracker';

--- a/packages/client/src/features/change-bounds/movement-restrictor.ts
+++ b/packages/client/src/features/change-bounds/movement-restrictor.ts
@@ -108,3 +108,13 @@ export function removeMovementRestrictionFeedback(
 
     return ModifyCSSFeedbackAction.create({ elements, remove: movementRestrictor.cssClasses });
 }
+
+export function movementRestrictionFeedback(
+    element: GModelElement,
+    movementRestrictor: IMovementRestrictor,
+    valid: boolean
+): ModifyCSSFeedbackAction {
+    return valid
+        ? removeMovementRestrictionFeedback(element, movementRestrictor)
+        : createMovementRestrictionFeedback(element, movementRestrictor);
+}

--- a/packages/client/src/features/change-bounds/point-position-updater.spec.ts
+++ b/packages/client/src/features/change-bounds/point-position-updater.spec.ts
@@ -13,6 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable import/no-deprecated */
+/* eslint-disable deprecation/deprecation */
 
 import { GModelElement } from '@eclipse-glsp/sprotty';
 import { expect } from 'chai';

--- a/packages/client/src/features/change-bounds/point-position-updater.ts
+++ b/packages/client/src/features/change-bounds/point-position-updater.ts
@@ -14,6 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 /* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable import/no-deprecated */
+/* eslint-disable deprecation/deprecation */
+
 import { GModelElement, ISnapper, Point, Writable } from '@eclipse-glsp/sprotty';
 import { calculateDeltaBetweenPoints } from '../../utils/gmodel-util';
 import { isMouseEvent } from '../../utils/html-utils';

--- a/packages/client/src/features/change-bounds/point-position-updater.ts
+++ b/packages/client/src/features/change-bounds/point-position-updater.ts
@@ -29,6 +29,9 @@ import { useSnap } from './snap';
  *
  * You can initialize a this class with a optional {@link ISnapper}. If a
  * snapper is present, the positions will be snapped to the defined grid.
+ *
+ * @deprecated The use of this class is discouraged. Use the {@link ChangeBoundsManager.createTracker}
+ * instead which centralized a few aspects of the tracking.
  */
 export class PointPositionUpdater {
     protected positionSnapper: PositionSnapper;

--- a/packages/client/src/features/change-bounds/position-snapper.ts
+++ b/packages/client/src/features/change-bounds/position-snapper.ts
@@ -18,6 +18,10 @@ import { inject, injectable, optional } from 'inversify';
 import { IHelperLineManager } from '../helper-lines/helper-line-manager';
 import { Direction, HelperLine, isHelperLine } from '../helper-lines/model';
 
+/**
+ * @deprecated The use of this class is discouraged. Use the {@link ChangeBoundsManager.createTracker}
+ * instead which centralized a few aspects of the tracking.
+ */
 @injectable()
 export class PositionSnapper {
     constructor(

--- a/packages/client/src/features/change-bounds/snap.ts
+++ b/packages/client/src/features/change-bounds/snap.ts
@@ -16,10 +16,16 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { KeyboardModifier } from '@eclipse-glsp/sprotty';
 
+/**
+ * @deprecated Use {@link ChangeBoundsManager.useSnap} instead which may be customized.
+ */
 export function useSnap(event: MouseEvent | KeyboardEvent): boolean {
     return !event.shiftKey;
 }
 
+/**
+ * @deprecated Use {@link ChangeBoundsManager.unsnapModifier} instead which may be customized.
+ */
 export function unsnapModifier(): KeyboardModifier {
     return 'shift';
 }

--- a/packages/client/src/features/change-bounds/tracker.ts
+++ b/packages/client/src/features/change-bounds/tracker.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Disposable, MousePositionTracker, Movement, Point, Vector } from '@eclipse-glsp/sprotty';
+
+export class MovementCalculator implements Disposable {
+    protected position?: Point;
+
+    setPosition(position: Point): void {
+        this.position = { ...position };
+    }
+
+    updatePosition(param: Vector | Movement): void {
+        const vector = Vector.is(param) ? param : param.vector;
+        this.setPosition(Point.add(this.position ?? Point.ORIGIN, vector));
+    }
+
+    get hasPosition(): boolean {
+        return this.position !== undefined;
+    }
+
+    calculateMoveTo(targetPosition: Point): Movement {
+        return !this.position ? Movement.ZERO : Point.move(this.position, targetPosition);
+    }
+
+    dispose(): void {
+        this.position = undefined;
+    }
+}
+
+export class DiagramMovementCalculator extends MovementCalculator {
+    constructor(readonly positionTracker: MousePositionTracker) {
+        super();
+    }
+
+    init(): void {
+        const position = this.positionTracker.lastPositionOnDiagram;
+        if (position) {
+            this.setPosition(position);
+        }
+    }
+
+    calculateMoveToCurrent(): Movement {
+        const targetPosition = this.positionTracker.lastPositionOnDiagram;
+        return targetPosition ? this.calculateMoveTo(targetPosition) : Movement.ZERO;
+    }
+
+    reset(): void {
+        this.dispose();
+    }
+}

--- a/packages/client/src/features/change-bounds/tracker.ts
+++ b/packages/client/src/features/change-bounds/tracker.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 EclipseSource and others.
+ * Copyright (c) 2024 Axon Ivy AG and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/debug/debug-bounds-decorator.tsx
+++ b/packages/client/src/features/debug/debug-bounds-decorator.tsx
@@ -15,7 +15,7 @@
  ********************************************************************************/
 /* eslint-disable max-len */
 
-import { Bounds, GModelElement, IVNodePostprocessor, Point, TYPES, isBoundsAware, setClass, svg } from '@eclipse-glsp/sprotty';
+import { Bounds, GModelElement, IVNodePostprocessor, Point, TYPES, isSizeable, setClass, svg } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
 import { GGraph } from '../../model';
@@ -33,8 +33,8 @@ export class DebugBoundsDecorator implements IVNodePostprocessor {
         if (!this.debugManager?.isDebugEnabled) {
             return vnode;
         }
-        if (isBoundsAware(element)) {
-            this.decorateBoundsAware(vnode, element);
+        if (isSizeable(element)) {
+            this.decorateSizeable(vnode, element);
         }
         if (element instanceof GGraph) {
             this.decorateGraph(vnode, element);
@@ -67,7 +67,7 @@ export class DebugBoundsDecorator implements IVNodePostprocessor {
         );
     }
 
-    protected decorateBoundsAware(vnode: VNode, element: BoundsAwareModelElement): void {
+    protected decorateSizeable(vnode: VNode, element: BoundsAwareModelElement): void {
         setClass(vnode, 'debug-bounds', true);
         vnode.children?.push(this.renderTopLeftCorner(element));
         vnode.children?.push(this.renderTopRightCorner(element));

--- a/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
+++ b/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
@@ -14,55 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import {
-    Action,
-    Dimension,
-    Disposable,
-    ElementMove,
-    GModelElement,
-    MoveAction,
-    Point,
-    isBoundsAware,
-    isMoveable
-} from '@eclipse-glsp/sprotty';
-import { injectable } from 'inversify';
+import { Action, Dimension, GModelElement, MoveAction, Point, isBoundsAware, isMoveable } from '@eclipse-glsp/sprotty';
 import { DragAwareMouseListener } from '../../base/drag-aware-mouse-listener';
 import { CSS_HIDDEN, ModifyCSSFeedbackAction } from '../../base/feedback/css-feedback';
 import { FeedbackEmitter } from '../../base/feedback/feeback-emitter';
-import { IFeedbackEmitter } from '../../base/feedback/feedback-action-dispatcher';
-import { Tool } from '../../base/tool-manager/tool';
-import { MoveableElement } from '../../utils';
-import { getAbsolutePosition } from '../../utils/viewpoint-util';
-import {
-    IMovementRestrictor,
-    createMovementRestrictionFeedback,
-    removeMovementRestrictionFeedback
-} from '../change-bounds/movement-restrictor';
-import { PointPositionUpdater } from '../change-bounds/point-position-updater';
-import { PositionSnapper } from '../change-bounds/position-snapper';
-import { useSnap } from '../change-bounds/snap';
-import { MoveFinishedEventAction } from '../tools';
+import { getAbsolutePosition } from '../../utils';
+import { ChangeBoundsManager, ChangeBoundsTracker, FeedbackAwareTool, MoveFinishedEventAction, TrackedElementMove } from '../tools';
 
-export interface PositioningTool extends Tool {
-    readonly positionSnapper: PositionSnapper;
-    readonly movementRestrictor?: IMovementRestrictor;
-
-    createFeedbackEmitter(): FeedbackEmitter;
-    /**
-     * @deprecated It is recommended to create a {@link createFeedbackEmitter dedicated emitter} per feedback instead of using the tool.
-     */
-    registerFeedback(feedbackActions: Action[], feedbackEmitter?: IFeedbackEmitter, cleanupActions?: Action[]): Disposable;
-    /**
-     * @deprecated It is recommended to create a {@link createFeedbackEmitter dedicated emitter} per feedback and dispose it like that.
-     */
-    deregisterFeedback(feedbackEmitter?: IFeedbackEmitter, cleanupActions?: Action[]): void;
+export interface PositioningTool extends FeedbackAwareTool {
+    readonly changeBoundsManager: ChangeBoundsManager;
 }
 
-@injectable()
 export class MouseTrackingElementPositionListener extends DragAwareMouseListener {
-    protected positionUpdater: PointPositionUpdater;
     protected moveGhostFeedback: FeedbackEmitter;
-    protected currentPosition?: Point;
+    protected tracker: ChangeBoundsTracker;
 
     constructor(
         protected elementId: string,
@@ -70,7 +35,7 @@ export class MouseTrackingElementPositionListener extends DragAwareMouseListener
         protected cursorPosition: 'top-left' | 'middle' = 'top-left'
     ) {
         super();
-        this.positionUpdater = new PointPositionUpdater(this.tool.positionSnapper);
+        this.tracker = this.tool.changeBoundsManager.createTracker();
         this.moveGhostFeedback = this.tool.createFeedbackEmitter();
     }
 
@@ -80,44 +45,36 @@ export class MouseTrackingElementPositionListener extends DragAwareMouseListener
         if (!element || !isMoveable(element)) {
             return [];
         }
-        if (this.positionUpdater.isLastDragPositionUndefined()) {
-            this.positionUpdater.updateLastDragPosition(element.position);
+        if (!this.tracker.isTracking()) {
+            this.tracker.startTracking();
+            const mousePosition = getAbsolutePosition(target, event);
+            element.position =
+                this.cursorPosition === 'middle' && isBoundsAware(element)
+                    ? Point.subtract(mousePosition, Dimension.center(element.bounds))
+                    : mousePosition;
         }
-        const mousePosition = getAbsolutePosition(target, event);
-        const delta = this.positionUpdater.updatePosition(element, mousePosition, useSnap(event));
-        if (!delta) {
+        // we only validate if we use the position already as a target, otherwise we need to re-evaluate after moving to the center anyway
+        const move = this.tracker.moveElements([element], { snap: event, restrict: event, validate: true });
+        const elementMove = move.elementMoves[0];
+        if (!elementMove) {
             return [];
         }
-        const toPosition = this.getElementTargetPosition(mousePosition, element, event);
-        const elementMove = { elementId: element.id, toPosition: toPosition };
-        this.addMoveFeeback(element, elementMove);
-        this.currentPosition = toPosition;
+        this.addMoveFeeback(elementMove);
         // since we are moving a ghost element that is feedback-only and will be removed anyway,
         // we just send a MoveFinishedEventAction instead of reseting the position with a MoveAction and the finished flag set to true.
-        this.moveGhostFeedback.add(MoveAction.create([elementMove], { animate: false }), MoveFinishedEventAction.create()).submit();
+        this.moveGhostFeedback
+            .add(
+                MoveAction.create([{ elementId: this.elementId, toPosition: elementMove.toPosition }], { animate: false }),
+                MoveFinishedEventAction.create()
+            )
+            .submit();
+        this.tracker.updateTrackingPosition(elementMove.moveVector);
         return [];
     }
 
-    protected getElementTargetPosition(mousePosition: Point, element: MoveableElement, event: MouseEvent): Point {
-        const unsnappedPosition =
-            this.cursorPosition === 'middle' && isBoundsAware(element)
-                ? Point.subtract(mousePosition, Dimension.center(element.bounds))
-                : mousePosition;
-        return this.tool.positionSnapper.snapPosition(unsnappedPosition, element, useSnap(event));
-    }
-
-    protected addMoveFeeback(element: MoveableElement, elementMove: ElementMove): void {
-        if (this.tool.movementRestrictor) {
-            if (!this.tool.movementRestrictor.validate(element, elementMove.toPosition)) {
-                this.moveGhostFeedback.add(
-                    createMovementRestrictionFeedback(element, this.tool.movementRestrictor),
-                    removeMovementRestrictionFeedback(element, this.tool.movementRestrictor)
-                );
-            } else {
-                this.moveGhostFeedback.add(removeMovementRestrictionFeedback(element, this.tool.movementRestrictor));
-            }
-        }
-        this.moveGhostFeedback.add(ModifyCSSFeedbackAction.create({ elements: [element.id], remove: [CSS_HIDDEN] }));
+    protected addMoveFeeback(move: TrackedElementMove): void {
+        this.tool.changeBoundsManager.addRestrictionFeedback(this.moveGhostFeedback, move);
+        this.moveGhostFeedback.add(ModifyCSSFeedbackAction.create({ elements: [move.element.id], remove: [CSS_HIDDEN] }));
     }
 
     override dispose(): void {

--- a/packages/client/src/features/helper-lines/helper-line-feedback.ts
+++ b/packages/client/src/features/helper-lines/helper-line-feedback.ts
@@ -27,6 +27,7 @@ import {
     Point,
     TYPES,
     Viewport,
+    equalUpTo,
     findParentByFeature,
     isBoundsAware,
     isDecoration,
@@ -293,7 +294,7 @@ export class DrawHelperLinesFeedbackCommand extends FeedbackCommand {
     }
 
     protected isMatch(leftCoordinate: number, rightCoordinate: number, epsilon: number): boolean {
-        return Math.abs(leftCoordinate - rightCoordinate) <= epsilon;
+        return equalUpTo(leftCoordinate, rightCoordinate, epsilon);
     }
 
     protected log(message: string, ...params: any[]): void {

--- a/packages/client/src/features/helper-lines/helper-line-manager.ts
+++ b/packages/client/src/features/helper-lines/helper-line-manager.ts
@@ -13,16 +13,25 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { GModelElement } from '@eclipse-glsp/sprotty';
+import { GModelElement, Vector } from '@eclipse-glsp/sprotty';
 import { Direction } from './model';
 
 export interface IHelperLineManager {
     /**
-     * Calculates the minimum move delta that is necessary to break through a helper line.
+     * Calculates the minimum move delta on one axis that is necessary to break through a helper line.
      *
      * @param element element that is being moved
      * @param isSnap whether snapping is active or not
      * @param direction direction in which the target element is moving
      */
     getMinimumMoveDelta(element: GModelElement, isSnap: boolean, direction: Direction): number;
+
+    /**
+     * Calculates the minimum move vector that is necessary to break through a helper line.
+     *
+     * @param element element that is being moved
+     * @param isSnap whether snapping is active or not
+     * @param directions directions in which the target element is moving
+     */
+    getMinimumMoveVector(element: GModelElement, isSnap: boolean, directions: Direction[]): Vector | undefined;
 }

--- a/packages/client/src/features/routing/edge-router.ts
+++ b/packages/client/src/features/routing/edge-router.ts
@@ -41,6 +41,13 @@ export abstract class GLSPAbstractEdgeRouter extends AbstractEdgeRouter {
         const anchor = super.getTranslatedAnchor(connectable, refPoint, refContainer, edge, anchorCorrection);
         return Point.isValid(anchor) ? anchor : refPoint;
     }
+
+    override cleanupRoutingPoints(edge: GRoutableElement, routingPoints: Point[], updateHandles: boolean, addRoutingPoints: boolean): void {
+        // sometimes it might happen that the source or target has the bounds not properly set when using the feedback edge
+        if (ensureBounds(edge.source) && ensureBounds(edge.target)) {
+            super.cleanupRoutingPoints(edge, routingPoints, updateHandles, addRoutingPoints);
+        }
+    }
 }
 
 @injectable()
@@ -55,6 +62,13 @@ export class GLSPPolylineEdgeRouter extends PolylineEdgeRouter {
         // users may define all kinds of anchors and anchor computers, we want to make sure we return a valid one in any case
         const anchor = super.getTranslatedAnchor(connectable, refPoint, refContainer, edge, anchorCorrection);
         return Point.isValid(anchor) ? anchor : refPoint;
+    }
+
+    override cleanupRoutingPoints(edge: GRoutableElement, routingPoints: Point[], updateHandles: boolean, addRoutingPoints: boolean): void {
+        // sometimes it might happen that the source or target has the bounds not properly set when using the feedback edge
+        if (ensureBounds(edge.source) && ensureBounds(edge.target)) {
+            super.cleanupRoutingPoints(edge, routingPoints, updateHandles, addRoutingPoints);
+        }
     }
 }
 
@@ -111,6 +125,13 @@ export class GLSPManhattanEdgeRouter extends ManhattanEdgeRouter {
             }
         });
     }
+
+    override cleanupRoutingPoints(edge: GRoutableElement, routingPoints: Point[], updateHandles: boolean, addRoutingPoints: boolean): void {
+        // sometimes it might happen that the source or target has the bounds not properly set when using the feedback edge
+        if (ensureBounds(edge.source) && ensureBounds(edge.target)) {
+            super.cleanupRoutingPoints(edge, routingPoints, updateHandles, addRoutingPoints);
+        }
+    }
 }
 
 @injectable()
@@ -126,4 +147,25 @@ export class GLSPBezierEdgeRouter extends BezierEdgeRouter {
         const anchor = super.getTranslatedAnchor(connectable, refPoint, refContainer, edge, anchorCorrection);
         return Point.isValid(anchor) ? anchor : refPoint;
     }
+
+    override cleanupRoutingPoints(edge: GRoutableElement, routingPoints: Point[], updateHandles: boolean, addRoutingPoints: boolean): void {
+        // sometimes it might happen that the source or target has the bounds not properly set when using the feedback edge
+        if (ensureBounds(edge.source) && ensureBounds(edge.target)) {
+            super.cleanupRoutingPoints(edge, routingPoints, updateHandles, addRoutingPoints);
+        }
+    }
+}
+
+function ensureBounds(element?: GConnectableElement): boolean {
+    if (!element) {
+        return false;
+    }
+    if (element.bounds) {
+        return true;
+    }
+    if (element.position && element.size) {
+        element.bounds = { ...element.position, ...element.size };
+        return true;
+    }
+    return false;
 }

--- a/packages/client/src/features/tools/base-tools.ts
+++ b/packages/client/src/features/tools/base-tools.ts
@@ -23,11 +23,41 @@ import { EnableToolsAction, Tool } from '../../base/tool-manager/tool';
 import { GLSPKeyTool } from '../../base/view/key-tool';
 import { GLSPMouseTool } from '../../base/view/mouse-tool';
 
+export interface FeedbackAwareTool extends Tool {
+    /**
+     * Creates a new feedback emitter helper object. While anything can serve as a feedback emitter,
+     * this method ensures that the emitter is stable and does not change between model updates.
+     */
+    createFeedbackEmitter(): FeedbackEmitter;
+
+    /**
+     * Registers `actions` to be sent out as feedback, i.e., changes that are re-established whenever the `GModelRoot`
+     * has been set or updated.
+     *
+     * @param feedbackActions the actions to be sent out.
+     * @param feedbackEmitter the emitter sending out feedback actions (this tool by default).
+     * @param cleanupActions the actions to be sent out when the feedback is de-registered through the returned Disposable.
+     * @returns A 'Disposable' that de-registers the feedback and cleans up any pending feedback with the given `cleanupActions`.
+     * @deprecated It is recommended to create a {@link createFeedbackEmitter dedicated emitter} per feedback instead of using the tool.
+     */
+    registerFeedback(feedbackActions: Action[], feedbackEmitter?: IFeedbackEmitter, cleanupActions?: MaybeActions): Disposable;
+
+    /**
+     * De-registers all feedback from the given `feedbackEmitter` (this tool by default) and cleans up any pending feedback with the
+     * given `cleanupActions`.
+     *
+     * @param feedbackEmitter the emitter to be deregistered (this tool by default).
+     * @param cleanupActions the actions to be dispatched right after the deregistration to clean up any pending feedback.
+     * @deprecated It is recommended to create a {@link createFeedbackEmitter dedicated emitter} per feedback and dispose it like that.
+     */
+    deregisterFeedback(feedbackEmitter?: IFeedbackEmitter, cleanupActions?: MaybeActions): void;
+}
+
 /**
  *  A reusable base implementation for edit {@link Tool}s.
  */
 @injectable()
-export abstract class BaseEditTool implements Tool {
+export abstract class BaseEditTool implements FeedbackAwareTool {
     @inject(TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher;
     @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
     @inject(GLSPMouseTool) protected mouseTool: GLSPMouseTool;
@@ -56,28 +86,10 @@ export abstract class BaseEditTool implements Tool {
         return this.feedbackDispatcher.createEmitter();
     }
 
-    /**
-     * Registers `actions` to be sent out as feedback, i.e., changes that are re-established whenever the `GModelRoot`
-     * has been set or updated.
-     *
-     * @param feedbackActions the actions to be sent out.
-     * @param feedbackEmitter the emitter sending out feedback actions (this tool by default).
-     * @param cleanupActions the actions to be sent out when the feedback is de-registered through the returned Disposable.
-     * @returns A 'Disposable' that de-registers the feedback and cleans up any pending feedback with the given `cleanupActions`.
-     * @deprecated It is recommended to create a {@link createFeedbackEmitter dedicated emitter} per feedback instead of using the tool.
-     */
     registerFeedback(feedbackActions: Action[], feedbackEmitter: IFeedbackEmitter = this, cleanupActions?: MaybeActions): Disposable {
         return this.feedbackDispatcher.registerFeedback(feedbackEmitter, feedbackActions, cleanupActions);
     }
 
-    /**
-     * De-registers all feedback from the given `feedbackEmitter` (this tool by default) and cleans up any pending feedback with the
-     * given `cleanupActions`.
-     *
-     * @param feedbackEmitter the emitter to be deregistered (this tool by default).
-     * @param cleanupActions the actions to be dispatched right after the deregistration to clean up any pending feedback.
-     * @deprecated It is recommended to create a {@link createFeedbackEmitter dedicated emitter} per feedback and dispose it like that.
-     */
     deregisterFeedback(feedbackEmitter: IFeedbackEmitter = this, cleanupActions?: MaybeActions): void {
         this.feedbackDispatcher.deregisterFeedback(feedbackEmitter, cleanupActions);
     }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-manager.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-manager.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 EclipseSource and others.
+ * Copyright (c) 2024 Axon Ivy AG and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,6 +40,8 @@ import {
 import { IHelperLineManager } from '../../helper-lines';
 import { ChangeBoundsTracker, TrackedElementMove } from './change-bounds-tracker';
 
+export const CSS_RESIZE_MODE = 'resize-mode';
+
 @injectable()
 export class ChangeBoundsManager {
     constructor(
@@ -49,7 +51,7 @@ export class ChangeBoundsManager {
         @optional() @inject(TYPES.IHelperLineManager) readonly helperLineManager?: IHelperLineManager
     ) {}
 
-    unsnapModifier(): KeyboardModifier {
+    unsnapModifier(): KeyboardModifier | undefined {
         return 'shift';
     }
 

--- a/packages/client/src/features/tools/change-bounds/change-bounds-manager.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-manager.ts
@@ -1,0 +1,143 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    Dimension,
+    GModelElement,
+    ISnapper,
+    KeyboardModifier,
+    MousePositionTracker,
+    Movement,
+    Point,
+    TYPES,
+    Vector,
+    isBoundsAware,
+    isLocateable
+} from '@eclipse-glsp/sprotty';
+import { inject, injectable, optional } from 'inversify';
+import { FeedbackEmitter } from '../../../base';
+import { isValidMove, minDimensions } from '../../../utils';
+import { LayoutAware } from '../../bounds/layout-data';
+import {
+    IMovementRestrictor,
+    ResizeHandleLocation,
+    movementRestrictionFeedback,
+    removeMovementRestrictionFeedback
+} from '../../change-bounds';
+import { IHelperLineManager } from '../../helper-lines';
+import { ChangeBoundsTracker, TrackedElementMove } from './change-bounds-tracker';
+
+@injectable()
+export class ChangeBoundsManager {
+    constructor(
+        @inject(MousePositionTracker) readonly positionTracker: MousePositionTracker,
+        @optional() @inject(TYPES.IMovementRestrictor) readonly movementRestrictor?: IMovementRestrictor,
+        @optional() @inject(TYPES.ISnapper) readonly snapper?: ISnapper,
+        @optional() @inject(TYPES.IHelperLineManager) readonly helperLineManager?: IHelperLineManager
+    ) {}
+
+    unsnapModifier(): KeyboardModifier {
+        return 'shift';
+    }
+
+    usePositionSnap(arg: MouseEvent | KeyboardEvent | any): boolean {
+        return typeof arg === 'boolean' ? arg : !(arg as MouseEvent | KeyboardEvent).shiftKey;
+    }
+
+    snapPosition(element: GModelElement, position: Point): Point {
+        return this.snapper?.snap(position, element) ?? position;
+    }
+
+    isValid(element: GModelElement): boolean {
+        return this.hasValidPosition(element) && this.hasValidSize(element);
+    }
+
+    hasValidPosition(element: GModelElement, position?: Point): boolean {
+        return !isLocateable(element) || isValidMove(element, position ?? element.position, this.movementRestrictor);
+    }
+
+    hasValidSize(element: GModelElement, size?: Dimension): boolean {
+        if (!isBoundsAware(element)) {
+            return true;
+        }
+        const dimension: Dimension = size ?? element.bounds;
+        const minimum = this.getMinimumSize(element);
+        if (dimension.width < minimum.width || dimension.height < minimum.height) {
+            return false;
+        }
+        return true;
+    }
+
+    getMinimumSize(element: GModelElement): Dimension {
+        if (!isBoundsAware(element)) {
+            return Dimension.EMPTY;
+        }
+        const definedMinimum = minDimensions(element);
+        const computedMinimum = LayoutAware.getComputedDimensions(element);
+        return computedMinimum
+            ? {
+                  width: Math.max(definedMinimum.width, computedMinimum.width),
+                  height: Math.max(definedMinimum.height, computedMinimum.height)
+              }
+            : definedMinimum;
+    }
+
+    useMovementRestriction(arg: MouseEvent | KeyboardEvent | any): boolean {
+        return this.usePositionSnap(arg);
+    }
+
+    restrictMovement(element: GModelElement, movement: Movement): Movement {
+        const minimumMovement = this.helperLineManager?.getMinimumMoveVector(element, true, movement.direction);
+        if (!minimumMovement) {
+            return movement;
+        }
+        // minimum is given in absolute coordinates
+        // if minimum is not reached, reset to original position for that coordinate
+        const absVector = Vector.abs(movement.vector);
+        const targetPosition: Point = {
+            x: absVector.x < minimumMovement.x ? movement.from.x : movement.to.x,
+            y: absVector.y < minimumMovement.y ? movement.from.y : movement.to.y
+        };
+        return Point.move(movement.from, targetPosition);
+    }
+
+    addRestrictionFeedback(feedback: FeedbackEmitter, move: TrackedElementMove): FeedbackEmitter {
+        if (this.movementRestrictor) {
+            feedback.add(
+                movementRestrictionFeedback(move.element, this.movementRestrictor!, move.valid),
+                removeMovementRestrictionFeedback(move.element, this.movementRestrictor!)
+            );
+        }
+        return feedback;
+    }
+
+    defaultResizeLocations(): ResizeHandleLocation[] {
+        return [
+            ResizeHandleLocation.TopLeft,
+            ResizeHandleLocation.TopRight,
+            ResizeHandleLocation.BottomRight,
+            ResizeHandleLocation.BottomLeft
+        ];
+    }
+
+    useSymmetricResize(arg: MouseEvent | KeyboardEvent | any): boolean {
+        return typeof arg === 'boolean' ? arg : (arg as MouseEvent | KeyboardEvent).ctrlKey;
+    }
+
+    createTracker(): ChangeBoundsTracker {
+        return new ChangeBoundsTracker(this);
+    }
+}

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-module.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-module.ts
@@ -16,12 +16,14 @@
 import { FeatureModule, TYPES, bindAsService, configureCommand, configureView } from '@eclipse-glsp/sprotty';
 import '../../../../css/change-bounds.css';
 import { SResizeHandle } from '../../change-bounds/model';
+import { ChangeBoundsManager } from './change-bounds-manager';
 import { ChangeBoundsTool } from './change-bounds-tool';
 import { HideChangeBoundsToolResizeFeedbackCommand, ShowChangeBoundsToolResizeFeedbackCommand } from './change-bounds-tool-feedback';
 import { SResizeHandleView } from './view';
 
 export const changeBoundsToolModule = new FeatureModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
+    bindAsService(context, TYPES.IChangeBoundsManager, ChangeBoundsManager);
     bindAsService(context, TYPES.IDefaultTool, ChangeBoundsTool);
     configureCommand(context, ShowChangeBoundsToolResizeFeedbackCommand);
     configureCommand(context, HideChangeBoundsToolResizeFeedbackCommand);

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, Disposable, ElementMove, GModelElement, GModelRoot, MoveAction, Point, findParentByFeature } from '@eclipse-glsp/sprotty';
+import { Action, ElementMove, GModelElement, GModelRoot, MoveAction, Point, findParentByFeature } from '@eclipse-glsp/sprotty';
 
 import { DebouncedFunc, debounce } from 'lodash';
 import { ChangeBoundsTracker, TrackedMove } from '.';
@@ -32,7 +32,7 @@ import { MoveFinishedEventAction, MoveInitializedEventAction } from './change-bo
  * the visual feedback but also the basis for sending the change to the server
  * (see also `tools/MoveTool`).
  */
-export class FeedbackMoveMouseListener extends DragAwareMouseListener implements Disposable {
+export class FeedbackMoveMouseListener extends DragAwareMouseListener {
     protected rootElement?: GModelRoot;
     protected tracker: ChangeBoundsTracker;
     protected elementId2startPos = new Map<string, Point>();

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -16,25 +16,14 @@
 import { Action, Disposable, ElementMove, GModelElement, GModelRoot, MoveAction, Point, findParentByFeature } from '@eclipse-glsp/sprotty';
 
 import { DebouncedFunc, debounce } from 'lodash';
+import { ChangeBoundsTracker, TrackedMove } from '.';
 import { DragAwareMouseListener } from '../../../base/drag-aware-mouse-listener';
 import { CursorCSS, cursorFeedbackAction } from '../../../base/feedback/css-feedback';
 import { FeedbackEmitter } from '../../../base/feedback/feeback-emitter';
 import { MoveableElement, filter, getElements, isNonRoutableSelectedMovableBoundsAware, removeDescendants } from '../../../utils';
-import { PointPositionUpdater } from '../../change-bounds';
 import { SResizeHandle } from '../../change-bounds/model';
-import { createMovementRestrictionFeedback, removeMovementRestrictionFeedback } from '../../change-bounds/movement-restrictor';
 import { ChangeBoundsTool } from './change-bounds-tool';
 import { MoveFinishedEventAction, MoveInitializedEventAction } from './change-bounds-tool-feedback';
-
-export interface ValidatedElementMove extends ElementMove {
-    valid: boolean;
-}
-
-export namespace ValidatedElementMove {
-    export function isValid(move: ElementMove): boolean {
-        return (move as ValidatedElementMove).valid ?? true;
-    }
-}
 
 /**
  * This mouse listener provides visual feedback for moving by sending client-side
@@ -45,7 +34,7 @@ export namespace ValidatedElementMove {
  */
 export class FeedbackMoveMouseListener extends DragAwareMouseListener implements Disposable {
     protected rootElement?: GModelRoot;
-    protected positionUpdater;
+    protected tracker: ChangeBoundsTracker;
     protected elementId2startPos = new Map<string, Point>();
 
     protected pendingMoveInitialized?: DebouncedFunc<() => void>;
@@ -55,7 +44,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
 
     constructor(protected tool: ChangeBoundsTool) {
         super();
-        this.positionUpdater = new PointPositionUpdater(tool.positionSnapper);
+        this.tracker = tool.createChangeBoundsTracker();
         this.moveInitializedFeedback = tool.createFeedbackEmitter();
         this.moveFeedback = tool.createFeedbackEmitter();
     }
@@ -66,7 +55,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
             this.initializeMove(target, event);
             return [];
         }
-        this.positionUpdater.resetPosition();
+        this.tracker.stopTracking();
         return [];
     }
 
@@ -77,10 +66,10 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
         }
         const moveable = findParentByFeature(target, this.isValidMoveable);
         if (moveable !== undefined) {
-            this.positionUpdater.updateLastDragPosition(event);
+            this.tracker.startTracking();
             this.scheduleMoveInitialized();
         } else {
-            this.positionUpdater.resetPosition();
+            this.tracker.stopTracking();
         }
     }
 
@@ -113,7 +102,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
     override nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {
         // should reset everything that may have happend on mouse down
         this.moveInitializedFeedback.dispose();
-        this.positionUpdater.resetPosition();
+        this.tracker.stopTracking();
         return [];
     }
 
@@ -121,7 +110,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
         super.mouseMove(target, event);
         if (event.buttons === 0) {
             return this.mouseUp(target, event);
-        } else if (!this.positionUpdater.isLastDragPositionUndefined()) {
+        } else if (this.tracker.isTracking()) {
             return this.moveElements(target, event);
         }
         return [];
@@ -131,35 +120,34 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
         if (this.elementId2startPos.size === 0) {
             this.initializeElementsToMove(target.root);
         }
-        const moveAction = this.getElementMoves(target, event, false);
-        if (!moveAction) {
+        const elementsToMove = this.getElementsToMove(target);
+        const move = this.tracker.moveElements(elementsToMove, { snap: event, restrict: event });
+        if (move.elementMoves.length === 0) {
             return [];
         }
         // cancel any pending move
         this.pendingMoveInitialized?.cancel();
-        this.moveFeedback.add(moveAction, () => this.resetElementPositions(target));
-        this.addMovementFeedback(moveAction, target);
+        this.moveFeedback.add(this.createMoveAction(move), () => this.resetElementPositions(target));
+        this.addMovementFeedback(move, target, event);
+        this.tracker.updateTrackingPosition(move);
         this.moveFeedback.submit();
         return [];
     }
 
-    protected addMovementFeedback(movement: MoveAction, ctx: GModelElement): void {
+    protected createMoveAction(trackedMove: TrackedMove): Action {
+        // we never want to animate the move action as this interferes with the move feedback
+        return MoveAction.create(
+            trackedMove.elementMoves.map(move => ({ elementId: move.element.id, toPosition: move.toPosition })),
+            { animate: false }
+        );
+    }
+
+    protected addMovementFeedback(trackedMove: TrackedMove, ctx: GModelElement, event: MouseEvent): void {
         // cursor feedback
         this.moveFeedback.add(cursorFeedbackAction(CursorCSS.MOVE), cursorFeedbackAction(CursorCSS.DEFAULT));
 
         // restriction feedback
-        movement.moves.forEach(move => {
-            const element = ctx.root.index.getById(move.elementId);
-            if (element && this.tool.movementRestrictor) {
-                if (!ValidatedElementMove.isValid(move)) {
-                    this.moveFeedback.add(createMovementRestrictionFeedback(element, this.tool.movementRestrictor), () =>
-                        removeMovementRestrictionFeedback(element, this.tool.movementRestrictor!)
-                    );
-                } else {
-                    this.moveFeedback.add(removeMovementRestrictionFeedback(element, this.tool.movementRestrictor));
-                }
-            }
-        });
+        trackedMove.elementMoves.forEach(move => this.tool.changeBoundsManager.addRestrictionFeedback(this.moveFeedback, move));
     }
 
     protected initializeElementsToMove(root: GModelRoot): void {
@@ -175,45 +163,6 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
 
     protected getElementsToMove(context: GModelElement): MoveableElement[] {
         return getElements(context.root.index, Array.from(this.elementId2startPos.keys()), this.isValidMoveable);
-    }
-
-    protected getElementMoves(target: GModelElement, event: MouseEvent, finished: boolean): MoveAction | undefined {
-        const delta = this.positionUpdater.updatePosition(target, event);
-        if (!delta) {
-            return undefined;
-        }
-        const elementMoves: ElementMove[] = this.getElementMovesForDelta(target, delta, finished).filter(move =>
-            this.filterElementMove(move)
-        );
-        if (elementMoves.length > 0) {
-            // we never want to animate the move action as this interferes with the move feedback
-            return MoveAction.create(elementMoves, { animate: false, finished });
-        } else {
-            return undefined;
-        }
-    }
-
-    protected filterElementMove(elementMove: ValidatedElementMove): boolean {
-        return !!elementMove.fromPosition && !Point.equals(elementMove.fromPosition, elementMove.toPosition);
-    }
-
-    protected getElementMovesForDelta(target: GModelElement, delta: Point, finished: boolean): ValidatedElementMove[] {
-        return this.getElementsToMove(target).flatMap<ValidatedElementMove>(element => {
-            const startPosition = this.elementId2startPos.get(element.id);
-            if (!startPosition) {
-                return [];
-            }
-            const targetPosition = Point.add(element.position, delta);
-            const valid = this.tool.movementRestrictor?.validate(element, targetPosition) ?? true;
-            return [this.createElementMove(element, targetPosition, valid, finished)];
-        });
-    }
-
-    protected createElementMove(element: MoveableElement, toPosition: Point, valid: boolean, finished: boolean): ValidatedElementMove {
-        // if we are finished and have an invalid move, we want to move the element back to its start position
-        return !valid && finished
-            ? { elementId: element.id, fromPosition: element.position, toPosition: element.position, valid }
-            : { elementId: element.id, fromPosition: element.position, toPosition, valid };
     }
 
     protected resetElementPositions(context: GModelElement): MoveAction | undefined {
@@ -233,12 +182,13 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
     }
 
     override draggingMouseUp(target: GModelElement, event: MouseEvent): Action[] {
-        if (this.positionUpdater.isLastDragPositionUndefined()) {
+        if (!this.tracker.isTracking()) {
             return [];
         }
         // only reset the move of invalid elements, the others will be handled by the change bounds tool itself
-        const moves = this.getElementMovesForDelta(target, Point.ORIGIN, false);
-        moves.filter(move => move.valid).forEach(move => this.elementId2startPos.delete(move.elementId));
+        this.getElementsToMove(target)
+            .filter(element => this.tool.changeBoundsManager.isValid(element))
+            .forEach(element => this.elementId2startPos.delete(element.id));
         this.dispose();
         return [];
     }
@@ -247,7 +197,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
         this.pendingMoveInitialized?.cancel();
         this.moveInitializedFeedback.dispose();
         this.moveFeedback.dispose();
-        this.positionUpdater.resetPosition();
+        this.tracker.dispose();
         this.elementId2startPos.clear();
         super.dispose();
     }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tracker.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tracker.ts
@@ -1,0 +1,460 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    Bounds,
+    Dimension,
+    GModelElement,
+    GRoutingHandle,
+    Locateable,
+    Movement,
+    Point,
+    ResolvedElementMove,
+    TypeGuard,
+    Vector,
+    Writable,
+    hasBooleanProp,
+    isMoveable
+} from '@eclipse-glsp/sprotty';
+import { ChangeBoundsManager } from '..';
+import { BoundsAwareModelElement, MoveableElement, ResizableModelElement, getElements } from '../../../utils';
+import { DiagramMovementCalculator, ResizeHandleLocation, SResizeHandle } from '../../change-bounds';
+
+export interface ElementTrackingOptions {
+    /** Snap position. Default: true. */
+    snap: boolean | MouseEvent | KeyboardEvent | any;
+    /** Restrict position. Default: true */
+    restrict: boolean | MouseEvent | KeyboardEvent | any;
+    /** Validate operation. Default: true */
+    validate: boolean;
+
+    /** Skip operations that do not trigger change. Default: true */
+    skipStatic: boolean;
+}
+
+export interface MoveOptions extends ElementTrackingOptions {
+    /** Skip operations are invalid. Default: false */
+    skipInvalid: boolean;
+}
+
+export const DEFAULT_MOVE_OPTIONS: MoveOptions = {
+    snap: true,
+    restrict: true,
+    validate: true,
+
+    skipStatic: true,
+    skipInvalid: false
+};
+
+export type MoveableElements =
+    | MoveableElement[]
+    | {
+          ctx: GModelElement;
+          elementIDs: string[];
+          guard?: TypeGuard<MoveableElement>;
+      };
+
+export interface TrackedElementMove extends ResolvedElementMove {
+    moveVector: Vector;
+    valid: boolean;
+}
+
+export type TypedElementMove<T extends MoveableElement> = TrackedElementMove & { element: T };
+
+export namespace ElementMovement {
+    export function empty<T extends MoveableElement>(element: T, point = Point.ORIGIN): TypedElementMove<T> {
+        return {
+            element,
+            fromPosition: point,
+            toPosition: point,
+            moveVector: Vector.ZERO,
+            valid: true
+        };
+    }
+}
+
+export interface TrackedMove extends Movement {
+    elementMoves: TrackedElementMove[];
+    valid: boolean;
+    options: MoveOptions;
+}
+
+export namespace TrackedMove {
+    export function is(obj: any): obj is TrackedMove {
+        return Movement.is(obj) && hasBooleanProp(obj, 'valid');
+    }
+}
+
+export interface ResizeOptions extends ElementTrackingOptions {
+    /** Skip resizes that do not actually change the dimension of the element. Default: true. */
+    skipStatic: boolean;
+
+    /** Perform symmetric resize on the opposite side. Default: false. */
+    symmetric: boolean | MouseEvent | KeyboardEvent | any;
+
+    /**
+     * Avoids resizes smaller than the minimum size which will yield invalid sizes.
+     * The minimum size takes precedence over the snapped (grid) position.
+     *
+     * Default: true.
+     */
+    capAtMinimumSize: boolean;
+
+    /** Skip resizes that produce an invalid size. Default: false. */
+    skipInvalidSize: boolean;
+
+    /** Skip resizes that produce an invalid move. Default: false. */
+    skipInvalidMove: boolean;
+}
+
+export const DEFAULT_RESIZE_OPTIONS: ResizeOptions = {
+    snap: true,
+    restrict: true,
+    validate: true,
+    symmetric: true,
+
+    capAtMinimumSize: true,
+
+    skipStatic: true,
+    skipInvalidSize: false,
+    skipInvalidMove: false
+};
+
+export interface TrackedHandleMove extends TypedElementMove<MoveableResizeHandle> {}
+
+export interface TrackedElementResize {
+    element: BoundsAwareModelElement;
+    fromBounds: Bounds;
+    toBounds: Bounds;
+    valid: {
+        size: boolean;
+        move: boolean;
+    };
+}
+
+export interface TrackedResize extends Movement {
+    handleMove: TrackedHandleMove;
+    elementResizes: TrackedElementResize[];
+    valid: {
+        size: boolean;
+        move: boolean;
+    };
+    options: ResizeOptions;
+}
+
+export class ChangeBoundsTracker {
+    protected diagramMovement: DiagramMovementCalculator;
+
+    constructor(readonly manager: ChangeBoundsManager) {
+        this.diagramMovement = new DiagramMovementCalculator(manager.positionTracker);
+    }
+
+    startTracking(): this {
+        this.diagramMovement.init();
+        return this;
+    }
+
+    updateTrackingPosition(param: Vector | Movement | TrackedMove): void {
+        const update = TrackedMove.is(param) ? Vector.max(...param.elementMoves.map(move => move.moveVector)) : param;
+        this.diagramMovement.updatePosition(update);
+    }
+
+    isTracking(): boolean {
+        return this.diagramMovement.hasPosition;
+    }
+
+    stopTracking(): this {
+        this.diagramMovement.dispose();
+        return this;
+    }
+
+    //
+    // MOVE
+    //
+
+    moveElements(elements: MoveableElements, opts?: Partial<MoveOptions>): TrackedMove {
+        const options = this.resolveMoveOptions(opts);
+        const update = this.calculateDiagramMovement();
+        const move: TrackedMove = { ...update, elementMoves: [], valid: true, options };
+
+        if (Vector.isZero(update.vector)) {
+            // no movement detected so elements won't be moved, exit early
+            return move;
+        }
+
+        // calculate move for each element
+        const elementsToMove = this.getMoveableElements(elements, options);
+        for (const element of elementsToMove) {
+            const elementMove = this.calculateElementMove(element, update.vector, options);
+            if (!this.skipElementMove(elementMove, options)) {
+                move.elementMoves.push(elementMove);
+                move.valid &&= elementMove.valid;
+            }
+        }
+        return move;
+    }
+
+    protected resolveMoveOptions(opts?: Partial<MoveOptions>): MoveOptions {
+        return {
+            ...DEFAULT_MOVE_OPTIONS,
+            ...opts,
+            snap: this.manager.usePositionSnap(opts?.snap ?? DEFAULT_MOVE_OPTIONS.snap),
+            restrict: this.manager.useMovementRestriction(opts?.restrict ?? DEFAULT_MOVE_OPTIONS.restrict)
+        };
+    }
+
+    protected calculateDiagramMovement(): Movement {
+        return this.diagramMovement.calculateMoveToCurrent();
+    }
+
+    protected getMoveableElements(elements: MoveableElements, options: MoveOptions): MoveableElement[] {
+        return Array.isArray(elements) ? elements : getElements(elements.ctx.index, elements.elementIDs, elements.guard ?? isMoveable);
+    }
+
+    protected skipElementMove(elementMove: TrackedElementMove, options: MoveOptions): boolean {
+        return (options.skipInvalid && !elementMove.valid) || (options.skipStatic && Vector.isZero(elementMove.moveVector));
+    }
+
+    protected calculateElementMove<T extends MoveableElement>(element: T, vector: Vector, options: MoveOptions): TypedElementMove<T> {
+        const fromPosition = element.position;
+        const toPosition = Point.add(fromPosition, vector);
+        const move: TypedElementMove<T> = { element, fromPosition, toPosition, valid: true, moveVector: Vector.ZERO };
+
+        if (options.snap) {
+            move.toPosition = this.snapPosition(move, options);
+        }
+
+        if (options.restrict) {
+            move.toPosition = this.restrictMovement(move, options);
+        }
+
+        if (options.validate) {
+            move.valid = this.validateElementMove(move, options);
+        }
+
+        move.moveVector = Point.vector(move.fromPosition, move.toPosition);
+        return move;
+    }
+
+    protected snapPosition(elementMove: TrackedElementMove, opts: MoveOptions): Point {
+        return this.manager.snapPosition(elementMove.element, elementMove.toPosition);
+    }
+
+    protected restrictMovement(elementMove: TrackedElementMove, opts: MoveOptions): Point {
+        const movement = Point.move(elementMove.fromPosition, elementMove.toPosition);
+        return this.manager.restrictMovement(elementMove.element, movement).to;
+    }
+
+    protected validateElementMove(elementMove: TrackedElementMove, opts: MoveOptions): boolean {
+        return this.manager.hasValidPosition(elementMove.element, elementMove.toPosition);
+    }
+
+    //
+    // RESIZE
+    //
+
+    resizeElements(handle: SResizeHandle, opts?: Partial<ResizeOptions>): TrackedResize {
+        const options = this.resolveResizeOptions(opts);
+        const update = this.calculateDiagramMovement();
+        const handleMove = this.calculateHandleMove(new MoveableResizeHandle(handle), update.vector, options);
+        const resize: TrackedResize = { ...update, valid: { move: true, size: true }, options, handleMove, elementResizes: [] };
+        if (Vector.isZero(handleMove.moveVector)) {
+            // no movement detected so elements won't be moved, exit early
+            return resize;
+        }
+
+        // symmetic handle move applies the diagram movement to the opposite handle
+        const symmetricHandleMove = options.symmetric
+            ? this.calculateHandleMove(handleMove.element.opposite(), Vector.reverse(update.vector), options)
+            : undefined;
+
+        // calculate resize for each element (typically only one element is resized at a time but customizations are possible)
+        const elementsToResize = this.getResizeableElements(handle, options);
+        for (const element of elementsToResize) {
+            const elementResize = this.calculateElementResize(element, handleMove, options, symmetricHandleMove);
+            if (!this.skipElementResize(elementResize, options)) {
+                resize.elementResizes.push(elementResize);
+                resize.valid.move = resize.valid.move && elementResize.valid.move;
+                resize.valid.size = resize.valid.size && elementResize.valid.size;
+                // handleMove.toPosition = SResizeHandle.getHandlePosition(elementResize.toBounds, handle.location);
+                // handleMove.moveVector = Point.vector(handleMove.fromPosition, handleMove.toPosition);
+            }
+        }
+        return resize;
+    }
+
+    protected resolveResizeOptions(opts?: Partial<ResizeOptions>): ResizeOptions {
+        return {
+            ...DEFAULT_RESIZE_OPTIONS,
+            ...opts,
+            snap: this.manager.usePositionSnap(opts?.snap ?? DEFAULT_RESIZE_OPTIONS.snap),
+            restrict: this.manager.useMovementRestriction(opts?.restrict ?? DEFAULT_RESIZE_OPTIONS.restrict),
+            symmetric: this.manager.useSymmetricResize(opts?.symmetric ?? DEFAULT_RESIZE_OPTIONS.symmetric)
+        };
+    }
+
+    protected calculateHandleMove(handle: MoveableResizeHandle, diagramMovement: Vector, opts?: Partial<ResizeOptions>): TrackedHandleMove {
+        const moveOptions = this.resolveMoveOptions({ ...opts, validate: false });
+        return this.calculateElementMove(handle, diagramMovement, moveOptions);
+    }
+
+    protected getResizeableElements(handle: SResizeHandle, options: ResizeOptions): ResizableModelElement[] {
+        return [handle.parent];
+    }
+
+    protected skipElementResize(elementResize: TrackedElementResize, options: ResizeOptions): boolean {
+        return (
+            (options.skipInvalidMove && !elementResize.valid.move) ||
+            (options.skipInvalidSize && !elementResize.valid.size) ||
+            (options.skipStatic && Dimension.equals(elementResize.fromBounds, elementResize.toBounds))
+        );
+    }
+
+    protected calculateElementResize(
+        element: ResizableModelElement,
+        handleMove: TrackedHandleMove,
+        options: ResizeOptions,
+        symmetricHandleMove?: TrackedHandleMove
+    ): TrackedElementResize {
+        const fromBounds = element.bounds;
+        const toBounds = this.calculateElementBounds(element, handleMove, options, symmetricHandleMove);
+        const resize: TrackedElementResize = { element, fromBounds, toBounds, valid: { size: true, move: true } };
+
+        if (options.validate) {
+            resize.valid.size = this.manager.hasValidSize(resize.element, resize.toBounds);
+            resize.valid.move = handleMove.valid && this.manager.hasValidPosition(resize.element, resize.toBounds);
+        }
+
+        return resize;
+    }
+
+    private calculateElementBounds(
+        element: ResizableModelElement,
+        handleMove: TrackedHandleMove,
+        options: ResizeOptions,
+        symmetricHandleMove?: TrackedHandleMove
+    ): Bounds {
+        if (options.capAtMinimumSize) {
+            const minimum = this.manager.getMinimumSize(element);
+            const vector = this.capMoveVector(element.bounds, handleMove, minimum);
+            let toBounds = this.calculateBounds(element.bounds, handleMove.element.location, vector);
+            if (symmetricHandleMove) {
+                const symmetricVector = this.capMoveVector(toBounds, symmetricHandleMove, minimum);
+                toBounds = this.calculateBounds(toBounds, symmetricHandleMove.element.location, symmetricVector);
+            }
+            return toBounds;
+        } else {
+            const vector = handleMove.moveVector;
+            let toBounds = this.calculateBounds(element.bounds, handleMove.element.location, vector);
+            if (symmetricHandleMove) {
+                toBounds = this.calculateBounds(toBounds, symmetricHandleMove.element.location, symmetricHandleMove.moveVector);
+            }
+            return toBounds;
+        }
+    }
+
+    protected capMoveVector(src: Bounds, handleMove: TrackedHandleMove, minimum: Dimension): Vector {
+        const vector = handleMove.moveVector as Writable<Vector>;
+        switch (handleMove.element.location) {
+            case ResizeHandleLocation.TopLeft:
+                vector.x = src.width - vector.x < minimum.width ? src.width - minimum.width : vector.x;
+                vector.y = src.height - vector.y < minimum.height ? src.height - minimum.height : vector.y;
+                break;
+            case ResizeHandleLocation.Top:
+                vector.y = src.height - vector.y < minimum.height ? src.height - minimum.height : vector.y;
+                break;
+            case ResizeHandleLocation.TopRight:
+                vector.x = src.width + vector.x < minimum.width ? minimum.width - src.width : vector.x;
+                vector.y = src.height - vector.y < minimum.height ? src.height - minimum.height : vector.y;
+                break;
+            case ResizeHandleLocation.Right:
+                vector.x = src.width + vector.x < minimum.width ? minimum.width - src.width : vector.x;
+                break;
+            case ResizeHandleLocation.BottomRight:
+                vector.x = src.width + vector.x < minimum.width ? minimum.width - src.width : vector.x;
+                vector.y = src.height + vector.y < minimum.height ? minimum.height - src.height : vector.y;
+                break;
+            case ResizeHandleLocation.Bottom:
+                vector.y = src.height + vector.y < minimum.height ? minimum.height - src.height : vector.y;
+                break;
+            case ResizeHandleLocation.BottomLeft:
+                vector.x = src.width - vector.x < minimum.width ? src.width - minimum.width : vector.x;
+                vector.y = src.height + vector.y < minimum.height ? minimum.height - src.height : vector.y;
+                break;
+            case ResizeHandleLocation.Left:
+                vector.x = src.width - vector.x < minimum.width ? src.width - minimum.width : vector.x;
+                break;
+        }
+        return vector;
+    }
+
+    protected calculateBounds(src: Bounds, location: ResizeHandleLocation, vector: Vector): Writable<Bounds> {
+        if (Vector.isZero(vector)) {
+            return src;
+        }
+        switch (location) {
+            case ResizeHandleLocation.TopLeft:
+                return { x: src.x + vector.x, y: src.y + vector.y, width: src.width - vector.x, height: src.height - vector.y };
+            case ResizeHandleLocation.Top:
+                return { ...src, y: src.y + vector.y, height: src.height - vector.y };
+            case ResizeHandleLocation.TopRight:
+                return { ...src, y: src.y + vector.y, width: src.width + vector.x, height: src.height - vector.y };
+            case ResizeHandleLocation.Right:
+                return { ...src, width: src.width + vector.x };
+            case ResizeHandleLocation.BottomRight:
+                return { ...src, width: src.width + vector.x, height: src.height + vector.y };
+            case ResizeHandleLocation.Bottom:
+                return { ...src, height: src.height + vector.y };
+            case ResizeHandleLocation.BottomLeft:
+                return { ...src, x: src.x + vector.x, width: src.width - vector.x, height: src.height + vector.y };
+            case ResizeHandleLocation.Left:
+                return { ...src, x: src.x + vector.x, width: src.width - vector.x };
+        }
+    }
+
+    dispose(): void {
+        this.stopTracking();
+    }
+}
+
+export class MoveableResizeHandle extends SResizeHandle implements Locateable {
+    constructor(
+        protected handle: SResizeHandle,
+        override location: ResizeHandleLocation = handle.location,
+        readonly position = SResizeHandle.getHandlePosition(handle.parent, location)
+    ) {
+        super(location, handle.type, handle.hoverFeedback);
+        this.id = handle.id;
+        // this only acts as a wrapper so we do not actually add this to the parent but still want the parent reference
+        (this as any).parent = handle.parent;
+    }
+
+    opposite(): MoveableResizeHandle {
+        return new MoveableResizeHandle(this.handle, ResizeHandleLocation.opposite(this.location));
+    }
+}
+
+export class MoveableRoutingHandle extends GRoutingHandle implements Locateable {
+    constructor(
+        protected handle: GRoutingHandle,
+        readonly position: Point
+    ) {
+        super();
+        this.id = handle.id;
+        // this only acts as a wrapper so we do not actually add this to the parent but still want the parent reference
+        (this as any).parent = handle.parent;
+    }
+}

--- a/packages/client/src/features/tools/change-bounds/index.ts
+++ b/packages/client/src/features/tools/change-bounds/index.ts
@@ -13,8 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+export * from './change-bounds-manager';
 export * from './change-bounds-tool';
 export * from './change-bounds-tool-feedback';
 export * from './change-bounds-tool-module';
 export * from './change-bounds-tool-move-feedback';
+export * from './change-bounds-tracker';
 export * from './view';

--- a/packages/client/src/features/tools/change-bounds/view.tsx
+++ b/packages/client/src/features/tools/change-bounds/view.tsx
@@ -16,7 +16,7 @@
 import { IView, Point, RenderingContext, setAttr, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { ResizeHandleLocation, SResizeHandle, isResizable } from '../../change-bounds/model';
+import { SResizeHandle } from '../../change-bounds/model';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const JSX = { createElement: svg };
@@ -46,19 +46,7 @@ export class SResizeHandleView implements IView {
     }
 
     protected getPosition(handle: SResizeHandle): Point | undefined {
-        const parent = handle.parent;
-        if (isResizable(parent)) {
-            if (handle.location === ResizeHandleLocation.TopLeft) {
-                return { x: 0, y: 0 };
-            } else if (handle.location === ResizeHandleLocation.TopRight) {
-                return { x: parent.bounds.width, y: 0 };
-            } else if (handle.location === ResizeHandleLocation.BottomLeft) {
-                return { x: 0, y: parent.bounds.height };
-            } else if (handle.location === ResizeHandleLocation.BottomRight) {
-                return { x: parent.bounds.width, y: parent.bounds.height };
-            }
-        }
-        return undefined;
+        return Point.subtract(SResizeHandle.getHandlePosition(handle), handle.parent.bounds);
     }
 
     getRadius(): number {

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
@@ -24,18 +24,19 @@ import {
     GRoutableElement,
     GRoutingHandle,
     ReconnectEdgeOperation,
+    TYPES,
     canEditRouting,
     findParentByFeature,
     isConnectable,
     isSelected
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
+import { ChangeBoundsManager } from '..';
 import { FeedbackEmitter } from '../../../base';
 import { DragAwareMouseListener } from '../../../base/drag-aware-mouse-listener';
 import { CursorCSS, cursorFeedbackAction } from '../../../base/feedback/css-feedback';
 import { ISelectionListener, SelectionService } from '../../../base/selection-service';
 import { calcElementAndRoutingPoints, isRoutable, isRoutingHandle } from '../../../utils/gmodel-util';
-import { PositionSnapper } from '../../change-bounds/position-snapper';
 import { GReconnectHandle, isReconnectHandle, isReconnectable, isSourceRoutingHandle, isTargetRoutingHandle } from '../../reconnect/model';
 import { BaseEditTool } from '../base-tools';
 import { DrawFeedbackEdgeAction, RemoveFeedbackEdgeAction, feedbackEdgeId } from '../edge-creation/dangling-edge-feedback';
@@ -56,7 +57,7 @@ export class EdgeEditTool extends BaseEditTool {
     @inject(SelectionService) protected selectionService: SelectionService;
     @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry;
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
-    @inject(PositionSnapper) readonly positionSnapper: PositionSnapper;
+    @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
 
     protected feedbackEdgeSourceMovingListener: FeedbackEdgeSourceMovingMouseListener;
     protected feedbackEdgeTargetMovingListener: FeedbackEdgeTargetMovingMouseListener;
@@ -73,7 +74,7 @@ export class EdgeEditTool extends BaseEditTool {
         // install feedback move mouse listener for client-side move updates
         this.feedbackEdgeSourceMovingListener = new FeedbackEdgeSourceMovingMouseListener(this.anchorRegistry, this.feedbackDispatcher);
         this.feedbackEdgeTargetMovingListener = new FeedbackEdgeTargetMovingMouseListener(this.anchorRegistry, this.feedbackDispatcher);
-        this.feedbackMovingListener = new FeedbackEdgeRouteMovingMouseListener(this.positionSnapper, this.edgeRouterRegistry);
+        this.feedbackMovingListener = new FeedbackEdgeRouteMovingMouseListener(this.changeBoundsManager, this.edgeRouterRegistry);
 
         this.toDisposeOnDisable.push(
             this.edgeEditListener,

--- a/packages/client/src/features/tools/marquee-selection/marquee-mouse-tool.ts
+++ b/packages/client/src/features/tools/marquee-selection/marquee-mouse-tool.ts
@@ -56,6 +56,10 @@ export class MarqueeMouseTool extends BaseEditTool {
             this.createFeedbackEmitter().add(cursorFeedbackAction(CursorCSS.MARQUEE), cursorFeedbackAction()).submit()
         );
     }
+
+    override get isEditTool(): boolean {
+        return false;
+    }
 }
 
 export class MarqueeMouseListener extends DragAwareMouseListener {

--- a/packages/client/src/utils/layout-utils.ts
+++ b/packages/client/src/utils/layout-utils.ts
@@ -33,6 +33,10 @@ export function minHeight(element: BoundsAwareModelElement): number {
     return 1;
 }
 
+export function minDimensions(element: BoundsAwareModelElement): Dimension {
+    return { width: minWidth(element), height: minHeight(element) };
+}
+
 export function getLayoutOptions(element: GModelElement): ModelLayoutOptions | undefined {
     const layoutOptions = (element as any).layoutOptions;
     if (layoutOptions !== undefined) {

--- a/packages/glsp-sprotty/src/types.ts
+++ b/packages/glsp-sprotty/src/types.ts
@@ -50,5 +50,6 @@ export const TYPES = {
     IToolManager: Symbol('IToolManager'),
     IDebugManager: Symbol('IDebugManager'),
     Grid: Symbol('Grid'),
-    IGridManager: Symbol('IGridManager')
+    IGridManager: Symbol('IGridManager'),
+    IChangeBoundsManager: Symbol('IChangeBoundsManager')
 };

--- a/packages/protocol/src/action-protocol/model-layout.ts
+++ b/packages/protocol/src/action-protocol/model-layout.ts
@@ -17,7 +17,7 @@ import * as sprotty from 'sprotty-protocol/lib/actions';
 import { GModelRootSchema } from '..';
 import { hasArrayProp, hasObjectProp } from '../utils/type-util';
 import { Action, Operation, RequestAction, ResponseAction } from './base-protocol';
-import { Args, ElementAndAlignment, ElementAndBounds, ElementAndRoutingPoints } from './types';
+import { Args, ElementAndAlignment, ElementAndBounds, ElementAndLayoutData, ElementAndRoutingPoints } from './types';
 
 /**
  * Sent from the server to the client to request bounds for the given model. The model is rendered invisibly so the bounds can
@@ -79,6 +79,11 @@ export interface ComputedBoundsAction extends ResponseAction, sprotty.ComputedBo
      * The route of the model elements.
      */
     routes?: ElementAndRoutingPoints[];
+
+    /**
+     * The layout data of hte model elements.
+     */
+    layoutData?: ElementAndLayoutData[];
 }
 
 export namespace ComputedBoundsAction {
@@ -95,6 +100,7 @@ export namespace ComputedBoundsAction {
             responseId?: string;
             alignments?: ElementAndAlignment[];
             routes?: ElementAndRoutingPoints[];
+            layoutData?: ElementAndLayoutData[];
         } = {}
     ): ComputedBoundsAction {
         return {

--- a/packages/protocol/src/action-protocol/types.ts
+++ b/packages/protocol/src/action-protocol/types.ts
@@ -82,6 +82,30 @@ export interface ElementAndRoutingPoints {
 }
 
 /**
+ * Data provided by the layouter.
+ */
+export interface LayoutData {
+    /**
+     * The computed minimum size of the element.
+     */
+    computedDimensions?: Dimension;
+}
+
+/**
+ * The `ElementAndLayoutData` type is used to associate new layout data with a model element, which is referenced via its id.
+ */
+export interface ElementAndLayoutData {
+    /**
+     * The identifier of the element.
+     */
+    elementId: string;
+    /**
+     * The data provided by the layouter.
+     */
+    layoutData: LayoutData;
+}
+
+/**
  * The `EditorContext` may be used to represent the current state of the editor for particular actions.
  * It encompasses the last recorded mouse position, the list of selected elements, and may contain
  * custom arguments to encode additional state information.

--- a/packages/protocol/src/sprotty-geometry-bounds.spec.ts
+++ b/packages/protocol/src/sprotty-geometry-bounds.spec.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { expect } from 'chai';
-import { Point } from 'sprotty-protocol';
+import { Dimension, Point } from 'sprotty-protocol';
 import { Bounds } from './sprotty-geometry-bounds';
 
 describe('Bounds', () => {
@@ -282,6 +282,38 @@ describe('Bounds', () => {
             const rankFunc = (bounds: Bounds): number => bounds.x;
             const sortedBounds = Bounds.sortBy(rankFunc, bounds1, bounds2, bounds3);
             expect(sortedBounds).to.deep.equal([bounds1, bounds2, bounds3]);
+        });
+    });
+
+    describe('move', () => {
+        it('should move the bounds by the given delta', () => {
+            const bounds: Bounds = { x: 10, y: 20, width: 100, height: 200 };
+            const delta: Point = { x: 10, y: 20 };
+            const result = Bounds.move(bounds, delta);
+            expect(result).to.deep.equal({ x: 20, y: 40, width: 100, height: 200 });
+        });
+
+        it('should move the bounds by the given delta with negative values', () => {
+            const bounds: Bounds = { x: 10, y: 20, width: 100, height: 200 };
+            const delta: Point = { x: -10, y: -20 };
+            const result = Bounds.move(bounds, delta);
+            expect(result).to.deep.equal({ x: 0, y: 0, width: 100, height: 200 });
+        });
+    });
+
+    describe('resize', () => {
+        it('should resize the bounds by the given delta', () => {
+            const bounds: Bounds = { x: 10, y: 20, width: 100, height: 200 };
+            const delta: Dimension = { width: 10, height: 20 };
+            const result = Bounds.resize(bounds, delta);
+            expect(result).to.deep.equal({ x: 10, y: 20, width: 110, height: 220 });
+        });
+
+        it('should resize the bounds by the given delta with negative values', () => {
+            const bounds: Bounds = { x: 10, y: 20, width: 100, height: 200 };
+            const delta: Dimension = { width: -10, height: -20 };
+            const result = Bounds.resize(bounds, delta);
+            expect(result).to.deep.equal({ x: 10, y: 20, width: 90, height: 180 });
         });
     });
 });

--- a/packages/protocol/src/sprotty-geometry-bounds.ts
+++ b/packages/protocol/src/sprotty-geometry-bounds.ts
@@ -49,7 +49,7 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * @param right right bounds
          * @returns true if the two bounds are equal
          */
-        function equals(left: Bounds, right: Bounds): boolean;
+        function equals(left: Bounds, right: Bounds, eps?: number): boolean;
 
         /**
          * Returns the x-coordinate of the left edge of the bounds.
@@ -259,7 +259,8 @@ Bounds.overlap = (one: Bounds, other: Bounds, touch?: boolean): boolean => {
               otherBottomRight.y > oneTopLeft.y;
 };
 
-Bounds.equals = (left: Bounds, right: Bounds): boolean => Point.equals(left, right) && Dimension.equals(left, right);
+Bounds.equals = (left: Bounds, right: Bounds, eps?: number): boolean =>
+    Point.equals(left, right, eps) && Dimension.equals(left, right, eps);
 
 Bounds.left = (bounds: Bounds): number => bounds.x;
 

--- a/packages/protocol/src/sprotty-geometry-bounds.ts
+++ b/packages/protocol/src/sprotty-geometry-bounds.ts
@@ -47,6 +47,7 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * Checks whether the two bounds are equal.
          * @param left left bounds
          * @param right right bounds
+         * @param eps the epsilon for the comparison
          * @returns true if the two bounds are equal
          */
         function equals(left: Bounds, right: Bounds, eps?: number): boolean;

--- a/packages/protocol/src/sprotty-geometry-bounds.ts
+++ b/packages/protocol/src/sprotty-geometry-bounds.ts
@@ -20,6 +20,11 @@ import { Bounds, Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
 declare module 'sprotty-protocol/lib/utils/geometry' {
     namespace Bounds {
         /**
+         * The empty bounds with valid dimensions. It has x, y, width, and height set to 0.
+         */
+        const ZERO: Bounds;
+
+        /**
          * Checks whether the inner bounds are compeletely encompassed by the outer bounds.
          *
          * @param outer outer bounds
@@ -209,8 +214,31 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * @returns the sorted bounds
          */
         function sortBy<T>(rankFunc: (elem: T) => number, ...bounds: T[]): T[];
+
+        /**
+         * Moves the bounds by the given delta.
+         * @param bounds the bounds to move
+         * @param delta the delta to move the bounds by
+         * @returns the moved bounds
+         */
+        function move(bounds: Bounds, delta: Point): Bounds;
+
+        /**
+         * Resizes the bounds by the given delta.
+         * @param bounds the bounds to resize
+         * @param delta the delta to resize the bounds by
+         * @returns the resized bounds
+         */
+        function resize(bounds: Bounds, delta: Dimension): Bounds;
     }
 }
+
+(Bounds as any).ZERO = Object.freeze({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0
+});
 
 Bounds.encompasses = (outer: Bounds, inner: Bounds): boolean =>
     Bounds.includes(outer, Bounds.topLeft(inner)) && Bounds.includes(outer, Bounds.bottomRight(inner));
@@ -279,6 +307,14 @@ Bounds.from = (topLeft: Point, bottomRight: Point): Bounds => ({
     ...topLeft,
     width: bottomRight.x - topLeft.x,
     height: bottomRight.y - topLeft.y
+});
+
+Bounds.move = Bounds.translate;
+
+Bounds.resize = (bounds: Bounds, delta: Dimension): Bounds => ({
+    ...bounds,
+    width: bounds.width + delta.width,
+    height: bounds.height + delta.height
 });
 
 export { Bounds };

--- a/packages/protocol/src/sprotty-geometry-dimension.spec.ts
+++ b/packages/protocol/src/sprotty-geometry-dimension.spec.ts
@@ -83,6 +83,27 @@ describe('Dimension', () => {
             const isEqual = Dimension.equals(dimension1, dimension2);
             expect(isEqual).to.be.false;
         });
+
+        it('should return false if the dimensions have different width', () => {
+            const dimension1: Dimension = { width: 10, height: 20 };
+            const dimension2: Dimension = { width: 5, height: 20 };
+            const isEqual = Dimension.equals(dimension1, dimension2);
+            expect(isEqual).to.be.false;
+        });
+
+        it('should return false if the dimensions have different height', () => {
+            const dimension1: Dimension = { width: 10, height: 20 };
+            const dimension2: Dimension = { width: 10, height: 10 };
+            const isEqual = Dimension.equals(dimension1, dimension2);
+            expect(isEqual).to.be.false;
+        });
+
+        it('should consider epsilon', () => {
+            const dimension1: Dimension = { width: 10, height: 20 };
+            const dimension2: Dimension = { width: 10.0001, height: 20.0001 };
+            const isEqual = Dimension.equals(dimension1, dimension2, 0.001);
+            expect(isEqual).to.be.true;
+        });
     });
 
     describe('fromPoint', () => {
@@ -90,6 +111,14 @@ describe('Dimension', () => {
             const point = { x: 10, y: 20 };
             const dimension = Dimension.fromPoint(point);
             expect(dimension).to.deep.equal({ width: 10, height: 20 });
+        });
+    });
+
+    describe('area', () => {
+        it('should compute the area of the dimension', () => {
+            const dimension: Dimension = { width: 10, height: 20 };
+            const area = Dimension.area(dimension);
+            expect(area).to.equal(200);
         });
     });
 });

--- a/packages/protocol/src/sprotty-geometry-dimension.ts
+++ b/packages/protocol/src/sprotty-geometry-dimension.ts
@@ -78,7 +78,7 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * Checks if two dimensions are equal. Two dimensions are equal if their `width` and `height` are equal.
          * @param left the left dimension
          * @param right the right dimension
-         * @param eps the epsilon value
+         * @param eps @param eps the epsilon for the comparison
          * @returns true if the dimensions are equal, false otherwise
          */
         function equals(left: Dimension, right: Dimension, eps?: number): boolean;

--- a/packages/protocol/src/sprotty-geometry-dimension.ts
+++ b/packages/protocol/src/sprotty-geometry-dimension.ts
@@ -16,6 +16,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 
 import { Dimension, Point } from 'sprotty-protocol/lib/utils/geometry';
+import { equalUpTo } from './utils/math-util';
 
 declare module 'sprotty-protocol/lib/utils/geometry' {
     namespace Dimension {
@@ -77,9 +78,10 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * Checks if two dimensions are equal. Two dimensions are equal if their `width` and `height` are equal.
          * @param left the left dimension
          * @param right the right dimension
+         * @param eps the epsilon value
          * @returns true if the dimensions are equal, false otherwise
          */
-        function equals(left: Dimension, right: Dimension): boolean;
+        function equals(left: Dimension, right: Dimension, eps?: number): boolean;
 
         /**
          * Creates a new dimension from the given point. The `width` and `height` of the new dimension are the `x` and `y` of the point.
@@ -87,6 +89,13 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * @returns new dimension
          */
         function fromPoint(point: Point): Dimension;
+
+        /**
+         * Computes the area of the given dimension.
+         * @param dimension the dimension
+         * @returns the area of the dimension
+         */
+        function area(dimension: Dimension): number;
     }
 }
 
@@ -106,7 +115,9 @@ Dimension.map = <T extends Dimension>(dimension: T, callbackfn: (value: number, 
     width: callbackfn(dimension.width, 'width'),
     height: callbackfn(dimension.height, 'height')
 });
-Dimension.equals = (left: Dimension, right: Dimension): boolean => left.width === right.width && left.height === right.height;
+Dimension.equals = (left: Dimension, right: Dimension, eps?: number): boolean =>
+    equalUpTo(left.width, right.width, eps) && equalUpTo(left.height, right.height, eps);
 Dimension.fromPoint = (point: Point): Dimension => ({ width: point.x, height: point.y });
+Dimension.area = (dimension: Dimension): number => dimension.width * dimension.height;
 
 export { Dimension };

--- a/packages/protocol/src/sprotty-geometry-point.spec.ts
+++ b/packages/protocol/src/sprotty-geometry-point.spec.ts
@@ -113,4 +113,18 @@ describe('Point', () => {
             expect(Point.moveTowards(from, vector)).to.deep.equal(expectedMovement);
         });
     });
+
+    describe('equals', () => {
+        it('returns true for equal points', () => {
+            expect(Point.equals({ x: 1, y: 2 }, { x: 1, y: 2 })).to.be.true;
+        });
+
+        it('returns false for different points', () => {
+            expect(Point.equals({ x: 1, y: 2 }, { x: 1, y: 3 })).to.be.false;
+        });
+
+        it('returns true up to an epsilon', () => {
+            expect(Point.equals({ x: 1, y: 2 }, { x: 1.0001, y: 2.0001 }, 0.001)).to.be.true;
+        });
+    });
 });

--- a/packages/protocol/src/sprotty-geometry-point.ts
+++ b/packages/protocol/src/sprotty-geometry-point.ts
@@ -43,7 +43,7 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * Checks whether the given points are equal up to a certain epsilon.
          * @param one the first point
          * @param other the second point
-         * @param eps the epsilon value
+         * @param eps @param eps the epsilon for the comparison
          */
         function equals(one: Point, other: Point, eps?: number): boolean;
 

--- a/packages/protocol/src/sprotty-geometry-point.ts
+++ b/packages/protocol/src/sprotty-geometry-point.ts
@@ -17,9 +17,14 @@
 
 import { Point } from 'sprotty-protocol/lib/utils/geometry';
 import { AnyObject, Movement, Vector, hasNumberProp } from './utils';
+import { equalUpTo } from './utils/math-util';
 
 declare module 'sprotty-protocol/lib/utils/geometry' {
     namespace Point {
+        /**
+         * Type guard to check if the given object is a point.
+         * @param point the object to be checked
+         */
         function is(point: any): point is Point;
         /**
          * The absolute variant of that point, i.e., each coordinate uses its absolute value.
@@ -33,6 +38,15 @@ declare module 'sprotty-protocol/lib/utils/geometry' {
          * @param point the point to be checked for validity
          */
         function isValid(point?: Point): point is Point;
+
+        /**
+         * Checks whether the given points are equal up to a certain epsilon.
+         * @param one the first point
+         * @param other the second point
+         * @param eps the epsilon value
+         */
+        function equals(one: Point, other: Point, eps?: number): boolean;
+
         /**
          * The absolute variant of that point, i.e., each coordinate uses its absolute value.
          *
@@ -134,5 +148,7 @@ Point.moveTowards = (from: Point, vector: Vector): Movement => {
     const dir = Vector.direction(vector);
     return { from, to, vector, direction: dir };
 };
+
+Point.equals = (one: Point, other: Point, eps?: number): boolean => equalUpTo(one.x, other.x, eps) && equalUpTo(one.y, other.y, eps);
 
 export { Point };

--- a/packages/protocol/src/utils/index.ts
+++ b/packages/protocol/src/utils/index.ts
@@ -19,4 +19,5 @@ export * from './event';
 export * from './geometry-movement';
 export * from './geometry-util';
 export * from './geometry-vector';
+export * from './math-util';
 export * from './type-util';

--- a/packages/protocol/src/utils/math-util.ts
+++ b/packages/protocol/src/utils/math-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 EclipseSource and others.
+ * Copyright (c) 2024 Axon Ivy AG and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,20 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.helper-line {
-    pointer-events: none;
-    stroke: #f7086c;
-    stroke-width: 0.5;
-    opacity: 1;
-}
-
-.selection-bounds {
-    pointer-events: none;
-    fill: blue;
-    fill-opacity: 0.05;
-    stroke-linejoin: miter;
-    stroke-linecap: round;
-    stroke: darkblue;
-    stroke-width: 0.5;
-    stroke-dasharray: 2;
+export function equalUpTo(one: number, other: number, epsilon: number = Number.EPSILON): boolean {
+    return Math.abs(one - other) <= epsilon;
 }

--- a/packages/protocol/src/utils/type-util.ts
+++ b/packages/protocol/src/utils/type-util.ts
@@ -69,6 +69,11 @@ export type MaybePromise<T> = T | PromiseLike<T>;
  */
 export type TypeGuard<T> = (element: any) => element is T;
 
+/** Utility function to combine two type guards */
+export function typeGuard<T, G>(one: TypeGuard<T>, other: TypeGuard<G>): TypeGuard<T & G> {
+    return (element: any): element is T & G => one(element) && other(element);
+}
+
 /**
  * Utility function that create a typeguard function for a given class constructor.
  * Essentially this wraps an instance of check as typeguard function.


### PR DESCRIPTION
#### What it does

Improve handling of change bounds

- Introduce change bounds manager to centralize bounds-related services
-- Bounds changes through position snapping and movement restriction
-- Validation for size and position of an element
-- Customizable methods for when to use move and resize options

- Introduce change bounds tracker for moves and resizes
-- Tracker calculates move on diagram and calculates move and resizes
-- Tracker supports options on which parts of the process are applied

- Provide moveable wrappers for resize and routing handles

Fixes https://github.com/eclipse-glsp/glsp/issues/1337

- Extend current resize capabilities
-- Introduce mode for symmetric resize
-- Introduce one-dimensional resize on top, right, bottom and left side

Fixes https://github.com/eclipse-glsp/glsp/issues/1338
Fixes https://github.com/eclipse-glsp/glsp/issues/1339

- Fix elements moving during resizing when hitting minimum bounds
-- Store calculated minimum size from layouter in element
-- Adapt resize so we do not produce invalid sized bounds

Fixes https://github.com/eclipse-glsp/glsp/issues/1340

Minor:
- Ensure we get proper cursor feedback when hovering over resize handle
- Add additional convenience functions
- Add origin viewport command for convenience

**_Please note this PR builds upon https://github.com/eclipse-glsp/glsp-client/pull/343 and should only be merged afterwards!_**

#### How to test

- Double check that everything behaves as before (minus the bugs)
- Symmetric resize can be tested using the Ctrl Key
- Additional resize handles can be tested by adding the locations to the ChangeBoundsManager. The corners are kept for backwards-compatibilty.
- General sizing can be tested more easily with the debug bounds module from https://github.com/eclipse-glsp/glsp-client/pull/343

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)

As soon as we agree on the PR, I'll write a paragraph about the changes ;-) 