### PR TITLE
GLSP-1309: Improve error handling of startup hooks

### DIFF
--- a/packages/client/src/base/model/diagram-loader.ts
+++ b/packages/client/src/base/model/diagram-loader.ts
@@ -192,7 +192,11 @@ export class DiagramLoader {
 
     protected async invokeStartupHook(hook: keyof Omit<IDiagramStartup, 'rank'>): Promise<void> {
         for (const startup of this.diagramStartups) {
-            await startup[hook]?.();
+            try {
+                await startup[hook]?.();
+            } catch (err) {
+                console.error(`Error invoking diagram startup hook '${hook}':`, '\n', err);
+            }
         }
     }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Refactor `DiagramLoader` to catch and log errors that occur when invoking startup hooks
- This ensures both: failure of one hook does not affect execution of following hooks and if  a hook fails for any reason we provide the reason in the log output
- Refactor `RestoreViewportHandler` to use the actual dom id of the root element for querying/focusing the graph. This ensures that the focusing also works if the root model element is not of type `graph`.

Fixes https://github.com/eclipse-glsp/glsp/issues/1309


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
