### PR TITLE
Remove eager default prevention from standalone copy paste handlder

### DIFF
--- a/packages/client/src/features/copy-paste/copy-paste-standalone.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-standalone.ts
@@ -35,15 +35,12 @@ export class CopyPasteStartup implements IDiagramStartup, Disposable {
         }
         const copyListener = (e: ClipboardEvent): void => {
             this.copyPasteHandler?.handleCopy(e);
-            e.preventDefault();
         };
         const cutListener = (e: ClipboardEvent): void => {
             this.copyPasteHandler?.handleCut(e);
-            e.preventDefault();
         };
         const pasteListener = (e: ClipboardEvent): void => {
             this.copyPasteHandler?.handlePaste(e);
-            e.preventDefault();
         };
         window.addEventListener('copy', copyListener);
         window.addEventListener('cut', cutListener);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Default event prevention should be handled by the `ICopyPasteHandler` implementation. e.g. The default `ServerCopyPasteHandler` has guard clauses to check wether a copy or paste operation should be executed (diagram must be active and selection >0). It only default prevents if this condition is met. Currently we bypass this special check and always default prevent which causes issues in scenarios where the diagram is nested into a surrounding application frame or is currently not focused (e.g.) hidden.

See also https://github.com/eclipse-glsp/glsp/discussions/1331

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
