### PR TITLE
Improve some aspects of change bounds, feedback and positioning

### DIFF
--- a/packages/client/css/change-bounds.css
+++ b/packages/client/css/change-bounds.css
@@ -38,12 +38,3 @@
     stroke: var(--glsp-error-foreground);
     stroke-width: 1.5px;
 }
-
-.move-mode .sprotty-projection-bar,
-.resize-mode .sprotty-projection-bar {
-    /**
-     * We are using mouse events (offsetX, offsetY) in the GLSPMousePositionTracker to calculate the diagram position relative to the parent.
-     * Other elements result in relative coordinates different from the graph and will therefore interfere with the correct position calculation.
-     */
-    pointer-events: none;
-}

--- a/packages/client/src/features/debug/debug-manager.ts
+++ b/packages/client/src/features/debug/debug-manager.ts
@@ -32,19 +32,21 @@ export class DebugManager implements IActionHandler {
         return this._debugEnabled;
     }
 
-    handle(action: EnableDebugModeAction): void {
-        this._debugEnabled = action.enable;
-    }
-
     @postConstruct()
     protected init(): void {
         this.debugFeedback = this.feedbackDispatcher.createEmitter();
     }
 
-    setDebugEnabled(visible: boolean): void {
-        if (!visible) {
+    handle(action: EnableDebugModeAction): void {
+        this.setDebugEnabled(action.enable);
+    }
+
+    setDebugEnabled(enabled: boolean): void {
+        if (this._debugEnabled && !enabled) {
+            this._debugEnabled = false;
             this.debugFeedback.dispose();
-        } else {
+        } else if (!this._debugEnabled && enabled) {
+            this._debugEnabled = true;
             this.debugFeedback
                 .add(EnableDebugModeAction.create({ enable: true }), EnableDebugModeAction.create({ enable: false }))
                 .submit();

--- a/packages/client/src/features/grid/grid-manager.ts
+++ b/packages/client/src/features/grid/grid-manager.ts
@@ -44,13 +44,15 @@ export class GridManager implements IActionHandler {
     }
 
     handle(action: ShowGridAction): void {
-        this._gridVisible = action.show;
+        this.setGridVisible(action.show);
     }
 
     setGridVisible(visible: boolean): void {
-        if (!visible) {
+        if (this._gridVisible && !visible) {
+            this._gridVisible = false;
             this.gridFeedback.dispose();
-        } else {
+        } else if (!this._gridVisible && visible) {
+            this._gridVisible = true;
             this.gridFeedback.add(ShowGridAction.create({ show: true }), ShowGridAction.create({ show: false })).submit();
         }
     }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -112,11 +112,9 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener {
         return [];
     }
 
-    override mouseMove(target: GModelElement, event: MouseEvent): Action[] {
-        super.mouseMove(target, event);
-        if (event.buttons === 0) {
-            return this.mouseUp(target, event);
-        } else if (this.tracker.isTracking()) {
+    override draggingMouseMove(target: GModelElement, event: MouseEvent): Action[] {
+        super.draggingMouseMove(target, event);
+        if (this.tracker.isTracking()) {
             return this.moveElements(target, event);
         }
         return [];

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -180,7 +180,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
             this.handleFeedback.submit();
             return true;
         } else {
-            this.dispose();
+            this.disposeResize();
             return false;
         }
     }
@@ -233,21 +233,19 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
     }
 
     override draggingMouseUp(target: GModelElement, event: MouseEvent): Action[] {
-        if (!this.tracker.isTracking()) {
-            return [];
-        }
         const actions: Action[] = [];
         if (this.activeResizeHandle) {
             actions.push(...this.handleResizeOnServer(this.activeResizeHandle));
         } else {
+            // since the move feedback is handled by another class we just see whether there is something to move
             actions.push(...this.handleMoveOnServer(target));
         }
-        this.disposeAllButHandles();
+        this.disposeResize({ keepHandles: true });
         return actions;
     }
 
     override nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {
-        this.disposeAllButHandles();
+        this.disposeResize({ keepHandles: true });
         return super.nonDraggingMouseUp(element, event);
     }
 
@@ -347,19 +345,19 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         return element !== undefined && this.activeResizeElement !== undefined && element.id === this.activeResizeElement.id;
     }
 
-    protected disposeAllButHandles(): void {
-        // We do not dispose the handle feedback as we want to keep showing the handles on selected elements
-        // this.handleFeedback.dispose();
+    protected disposeResize(opts: { keepHandles: boolean } = { keepHandles: false }): void {
+        if (!opts.keepHandles) {
+            this.handleFeedback.dispose();
+        }
         this.resizeFeedback.dispose();
         this.tracker.dispose();
         this.activeResizeElement = undefined;
         this.activeResizeHandle = undefined;
         this.initialBounds = undefined;
-        super.dispose();
     }
 
     override dispose(): void {
-        this.handleFeedback.dispose();
-        this.disposeAllButHandles();
+        this.disposeResize();
+        super.dispose();
     }
 }

--- a/packages/client/src/features/tools/edge-creation/edge-creation-tool.ts
+++ b/packages/client/src/features/tools/edge-creation/edge-creation-tool.ts
@@ -56,24 +56,32 @@ export class EdgeCreationTool extends BaseCreationTool<TriggerEdgeCreationAction
     }
 
     doEnable(): void {
-        const mouseMovingFeedback = new FeedbackEdgeEndMovingMouseListener(this.anchorRegistry, this.feedbackDispatcher);
+        this.toolFeedback();
+        this.creationListener();
+        this.trackFeedbackEdge();
+    }
+
+    protected toolFeedback(): void {
         const toolFeedback = this.createFeedbackEmitter()
             .add(cursorFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED), cursorFeedbackAction())
             .submit();
+        this.toDisposeOnDisable.push(toolFeedback);
+    }
+
+    protected creationListener(): void {
         const creationListener = new EdgeCreationToolMouseListener(
             this.triggerAction,
             this.actionDispatcher,
             this.typeHintProvider,
             this,
-            this.grid?.x / 2
+            this.grid ? this.grid.x / 2 : undefined
         );
-        this.toDisposeOnDisable.push(
-            mouseMovingFeedback,
-            this.mouseTool.registerListener(mouseMovingFeedback),
-            creationListener,
-            this.mouseTool.registerListener(creationListener),
-            toolFeedback
-        );
+        this.toDisposeOnDisable.push(creationListener, this.mouseTool.registerListener(creationListener));
+    }
+
+    protected trackFeedbackEdge(): void {
+        const mouseMovingFeedback = new FeedbackEdgeEndMovingMouseListener(this.anchorRegistry, this.feedbackDispatcher);
+        this.toDisposeOnDisable.push(mouseMovingFeedback, this.mouseTool.registerListener(mouseMovingFeedback));
     }
 }
 

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
@@ -267,7 +267,7 @@ export class FeedbackEdgeRouteMovingMouseListener extends DragAwareMouseListener
     }
 
     override mouseDown(target: GModelElement, event: MouseEvent): Action[] {
-        const result: Action[] = [];
+        const result = super.mouseDown(target, event);
         if (event.button === 0) {
             const routingHandle = findParentByFeature(target, isRoutingHandle);
             if (routingHandle !== undefined) {

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
@@ -41,6 +41,7 @@ import {
     typeGuard
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
+import { DragAwareMouseListener } from '../../../base/drag-aware-mouse-listener';
 import { IFeedbackActionDispatcher } from '../../../base/feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../../base/feedback/feedback-command';
 import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
@@ -254,7 +255,7 @@ export class FeedbackEdgeSourceMovingMouseListener extends MouseListener impleme
     }
 }
 
-export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
+export class FeedbackEdgeRouteMovingMouseListener extends DragAwareMouseListener {
     protected tracker: ChangeBoundsTracker;
 
     constructor(
@@ -279,11 +280,9 @@ export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
         return result;
     }
 
-    override mouseMove(target: GModelElement, event: MouseEvent): Action[] {
-        super.mouseMove(target, event);
-        if (event.buttons === 0) {
-            return this.mouseUp(target, event);
-        } else if (this.tracker.isTracking()) {
+    override draggingMouseMove(target: GModelElement, event: MouseEvent): Action[] {
+        super.draggingMouseMove(target, event);
+        if (this.tracker.isTracking()) {
             return this.moveRoutingHandles(target, event);
         }
         return [];
@@ -327,9 +326,23 @@ export class FeedbackEdgeRouteMovingMouseListener extends MouseListener {
         return undefined;
     }
 
-    override mouseUp(_target: GModelElement, _event: MouseEvent): Action[] {
-        this.tracker.dispose();
+    override nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {
+        // should reset everything that may have happend on mouse down
+        this.tracker.stopTracking();
         return [];
+    }
+
+    override draggingMouseUp(_target: GModelElement, _event: MouseEvent): Action[] {
+        if (!this.tracker.isTracking()) {
+            return [];
+        }
+        this.dispose();
+        return [];
+    }
+
+    override dispose(): void {
+        this.tracker.dispose();
+        super.dispose();
     }
 }
 

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
@@ -80,6 +80,7 @@ export class EdgeEditTool extends BaseEditTool {
             this.mouseTool.registerListener(this.edgeEditListener),
             this.feedbackEdgeSourceMovingListener,
             this.feedbackEdgeTargetMovingListener,
+            this.feedbackMovingListener,
             this.selectionService.onSelectionChanged(change => this.edgeEditListener.selectionChanged(change.root, change.selectedElements))
         );
     }
@@ -110,10 +111,12 @@ export class EdgeEditListener extends DragAwareMouseListener implements ISelecti
     // active reconnect handle data
     protected reconnectMode?: 'NEW_SOURCE' | 'NEW_TARGET';
 
+    protected cursorFeedback: FeedbackEmitter;
     protected editFeedback: FeedbackEmitter;
 
     constructor(protected tool: EdgeEditTool) {
         super();
+        this.cursorFeedback = this.tool.createFeedbackEmitter();
         this.editFeedback = this.tool.createFeedbackEmitter();
     }
 
@@ -264,11 +267,11 @@ export class EdgeEditListener extends DragAwareMouseListener implements ISelecti
                         (this.reconnectMode === 'NEW_SOURCE' && currentTarget.canConnect(this.edge, 'source')) ||
                         (this.reconnectMode === 'NEW_TARGET' && currentTarget.canConnect(this.edge, 'target'))
                     ) {
-                        this.editFeedback.add(cursorFeedbackAction(CursorCSS.EDGE_RECONNECT), cursorFeedbackAction()).submit();
+                        this.cursorFeedback.add(cursorFeedbackAction(CursorCSS.EDGE_RECONNECT), cursorFeedbackAction()).submit();
                         return [];
                     }
                 }
-                this.editFeedback.add(cursorFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED), cursorFeedbackAction()).submit();
+                this.cursorFeedback.add(cursorFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED), cursorFeedbackAction()).submit();
             }
         }
         return [];
@@ -307,6 +310,7 @@ export class EdgeEditListener extends DragAwareMouseListener implements ISelecti
         this.reconnectMode = undefined;
         this.newConnectable = undefined;
         this.routingHandle = undefined;
+        this.cursorFeedback.dispose();
         this.editFeedback.dispose();
         this.tool.deregisterFeedbackListeners();
         super.dispose();

--- a/packages/glsp-sprotty/src/svg-views-override.tsx
+++ b/packages/glsp-sprotty/src/svg-views-override.tsx
@@ -61,13 +61,22 @@ export class CircularNodeView extends SprottyCircularNodeView {
 
 /**
  * Creates a hidden rectangle with the bounds of the given element.
+ * This is typically used to fixate the size of an element and avoid size changes that may happen during rendering.
+ * Changes can happen if the resulting bounding box (BBox) of the rendered element is different form the given bounds.
+ * The created bounding rect needs to be placed within a root SVG group (g) element to take effect.
+ *
  * @param withBounds The element to create the hidden rectangle for.
+ * @param context The rendering context. If provided, a rect is only created if the context is 'hidden'.
  * @returns The hidden rectangle.
  */
-export function hiddenBoundingRect(withBounds: BoundsAware): VNode {
+export function hiddenBoundingRect(withBounds: BoundsAware): VNode;
+export function hiddenBoundingRect(withBounds: BoundsAware, context: RenderingContext): VNode | undefined;
+export function hiddenBoundingRect(withBounds: BoundsAware, context?: RenderingContext): VNode | undefined {
     // an element with attribute ATTR_BBOX_ELEMENT is used by the hidden bounds updater to determine the bounds if it is within a g-element
     // we set the fill to transparent since the SVG export uses the hidden rendering to generate the image and we do not want to be seen
-    return <rect attrs={{ [ATTR_BBOX_ELEMENT]: true }} {...Bounds.dimension(withBounds.bounds)} style={{ fill: 'transparent' }} />;
+    return !context || context.targetKind === 'hidden' ? (
+        <rect attrs={{ [ATTR_BBOX_ELEMENT]: true }} {...Bounds.dimension(withBounds.bounds)} style={{ fill: 'transparent' }} />
+    ) : undefined;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Ensure GridManager properly tracks state if action is used on startup
- Ensure DebugManager properly tracks state if action is used on startup
- Avoid cursor feedback interfering with edge edit feedback in disposal
- Avoid unnecessary disposal calls by calling mouseUp on mouseMove
- Fix issue with non-resizable elements not being movable
- Fix calculation of position on diagram for nested HTML elements

#### How to test

- GridManager/DebugManager: Send a ShowGridAction, EnableDebugModeAction on startup and see that the feedback is applied even after a server update (e.g., move an element).
- Feedback edge: Edit an edge and hit 'Escape' in the middle, ensure that feedback edge is properly disposed.
- Element Move: Remove the resize feature (or typehint) from an element on the server, check whether in can be moved.
- Diagram Position: Introduce a foreign object within your SVG element or drag/resize towards the projection bars.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
