### PR TITLE
Fix style handling in SVG exporter

### DIFF
--- a/packages/client/src/features/export/glsp-svg-exporter.ts
+++ b/packages/client/src/features/export/glsp-svg-exporter.ts
@@ -77,7 +77,7 @@ export class GLSPSvgExporter extends SvgExporter {
                 const propertyValue = sourceStyle.getPropertyValue(propertyName);
                 const propertyPriority = sourceStyle.getPropertyPriority(propertyName);
                 if (targetStyle.getPropertyValue(propertyName) !== propertyValue) {
-                    if (isElementCSSInlineStyle(target)) {
+                    if (this.shouldUpdateStyle(target)) {
                         // rather set the property directly on the element to keep other values intact
                         target.style.setProperty(propertyName, propertyValue);
                     } else {
@@ -90,6 +90,11 @@ export class GLSPSvgExporter extends SvgExporter {
         if (style !== '') {
             target.setAttribute('style', style.trim());
         }
+    }
+
+    protected shouldUpdateStyle(element: any): element is ElementCSSInlineStyle {
+        // we want to simply update the style of elements and keep other values intact if they have a style property
+        return 'tagName' in element && 'style' in element;
     }
 
     protected getSvgExport(
@@ -112,8 +117,4 @@ export class GLSPSvgExporter extends SvgExporter {
             'cursor: default !important;'
         );
     }
-}
-
-export function isElementCSSInlineStyle(element: any): element is ElementCSSInlineStyle {
-    return 'style' in element && element.style instanceof CSSStyleDeclaration;
 }


### PR DESCRIPTION
#### What it does

For some reason our created target elements are not actually instanceof Element even though everything is in their prototype chain. So instead, we now check whether it is an element with tag (HTML, SVG, Math) and whether it has a style property.

#### How to test

- Debug and you'll see that we do not keep the style of SVG elements etc.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
