### PR TITLE
Minor cleanup & deprecations

### DIFF
--- a/examples/workflow-glsp/src/workflow-diagram-module.ts
+++ b/examples/workflow-glsp/src/workflow-diagram-module.ts
@@ -20,6 +20,7 @@ import {
     DefaultTypes,
     DeleteElementContextMenuItemProvider,
     DiamondNodeView,
+    FeatureModule,
     GCompartment,
     GCompartmentView,
     GEdge,
@@ -45,7 +46,7 @@ import {
     initializeDiagramContainer
 } from '@eclipse-glsp/client';
 import 'balloon-css/balloon.min.css';
-import { Container, ContainerModule } from 'inversify';
+import { Container } from 'inversify';
 import 'sprotty/css/edit-label.css';
 import '../css/diagram.css';
 import { directTaskEditor } from './direct-task-editing/di.config';
@@ -54,43 +55,46 @@ import { WorkflowSnapper } from './workflow-snapper';
 import { WorkflowStartup } from './workflow-startup';
 import { IconView, WorkflowEdgeView } from './workflow-views';
 
-export const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const context = { bind, unbind, isBound, rebind };
+export const workflowDiagramModule = new FeatureModule(
+    (bind, unbind, isBound, rebind) => {
+        const context = { bind, unbind, isBound, rebind };
 
-    bindOrRebind(context, TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
-    bindOrRebind(context, TYPES.LogLevel).toConstantValue(LogLevel.warn);
-    bindAsService(context, TYPES.ICommandPaletteActionProvider, RevealNamedElementActionProvider);
-    bindAsService(context, TYPES.IContextMenuItemProvider, DeleteElementContextMenuItemProvider);
+        bindOrRebind(context, TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
+        bindOrRebind(context, TYPES.LogLevel).toConstantValue(LogLevel.warn);
+        bindAsService(context, TYPES.ICommandPaletteActionProvider, RevealNamedElementActionProvider);
+        bindAsService(context, TYPES.IContextMenuItemProvider, DeleteElementContextMenuItemProvider);
 
-    configureDefaultModelElements(context);
-    configureModelElement(context, 'task:automated', TaskNode, RoundedCornerNodeView);
-    configureModelElement(context, 'task:manual', TaskNode, RoundedCornerNodeView);
-    configureModelElement(context, 'label:heading', GLabel, GLabelView, { enable: [editLabelFeature] });
-    configureModelElement(context, 'comp:comp', GCompartment, GCompartmentView);
-    configureModelElement(context, 'comp:header', GCompartment, GCompartmentView);
-    configureModelElement(context, 'label:icon', GLabel, GLabelView);
-    configureModelElement(context, DefaultTypes.EDGE, GEdge, WorkflowEdgeView);
-    configureModelElement(context, 'edge:weighted', WeightedEdge, WorkflowEdgeView);
-    configureModelElement(context, 'icon', Icon, IconView);
-    configureModelElement(context, 'activityNode:merge', BranchingNode, DiamondNodeView);
-    configureModelElement(context, 'activityNode:decision', BranchingNode, DiamondNodeView);
-    configureModelElement(context, 'activityNode:fork', SynchronizationNode, RectangularNodeView);
-    configureModelElement(context, 'activityNode:join', SynchronizationNode, RectangularNodeView);
-    configureModelElement(context, DefaultTypes.GRAPH, GGraph, GLSPProjectionView);
-    configureModelElement(context, 'category', CategoryNode, RoundedCornerNodeView);
-    configureModelElement(context, 'struct', GCompartment, StructureCompartmentView);
+        configureDefaultModelElements(context);
+        configureModelElement(context, 'task:automated', TaskNode, RoundedCornerNodeView);
+        configureModelElement(context, 'task:manual', TaskNode, RoundedCornerNodeView);
+        configureModelElement(context, 'label:heading', GLabel, GLabelView, { enable: [editLabelFeature] });
+        configureModelElement(context, 'comp:comp', GCompartment, GCompartmentView);
+        configureModelElement(context, 'comp:header', GCompartment, GCompartmentView);
+        configureModelElement(context, 'label:icon', GLabel, GLabelView);
+        configureModelElement(context, DefaultTypes.EDGE, GEdge, WorkflowEdgeView);
+        configureModelElement(context, 'edge:weighted', WeightedEdge, WorkflowEdgeView);
+        configureModelElement(context, 'icon', Icon, IconView);
+        configureModelElement(context, 'activityNode:merge', BranchingNode, DiamondNodeView);
+        configureModelElement(context, 'activityNode:decision', BranchingNode, DiamondNodeView);
+        configureModelElement(context, 'activityNode:fork', SynchronizationNode, RectangularNodeView);
+        configureModelElement(context, 'activityNode:join', SynchronizationNode, RectangularNodeView);
+        configureModelElement(context, DefaultTypes.GRAPH, GGraph, GLSPProjectionView);
+        configureModelElement(context, 'category', CategoryNode, RoundedCornerNodeView);
+        configureModelElement(context, 'struct', GCompartment, StructureCompartmentView);
 
-    bind<IHelperLineOptions>(TYPES.IHelperLineOptions).toDynamicValue(ctx => {
-        const options: IHelperLineOptions = {};
-        // skip icons for alignment as well as compartments which are only used for structure
-        options.alignmentElementFilter = element =>
-            DEFAULT_ALIGNABLE_ELEMENT_FILTER(element) && !(element instanceof Icon) && !(element instanceof GCompartment);
-        return options;
-    });
+        bind<IHelperLineOptions>(TYPES.IHelperLineOptions).toDynamicValue(ctx => {
+            const options: IHelperLineOptions = {};
+            // skip icons for alignment as well as compartments which are only used for structure
+            options.alignmentElementFilter = element =>
+                DEFAULT_ALIGNABLE_ELEMENT_FILTER(element) && !(element instanceof Icon) && !(element instanceof GCompartment);
+            return options;
+        });
 
-    bindAsService(context, TYPES.IDiagramStartup, WorkflowStartup);
-    bindOrRebind(context, TYPES.ISnapper).to(WorkflowSnapper);
-});
+        bindAsService(context, TYPES.IDiagramStartup, WorkflowStartup);
+        bindOrRebind(context, TYPES.ISnapper).to(WorkflowSnapper);
+    },
+    { featureId: Symbol('workflowDiagram') }
+);
 
 export function createWorkflowDiagramContainer(...containerConfiguration: ContainerConfiguration): Container {
     return initializeWorkflowDiagramContainer(new Container(), ...containerConfiguration);

--- a/packages/client/src/features/accessibility/accessibility-module.ts
+++ b/packages/client/src/features/accessibility/accessibility-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,7 @@
 import { FeatureModule } from '@eclipse-glsp/sprotty';
 import { configureElementNavigationTool } from './element-navigation/element-navigation-module';
 import { configureFocusTrackerTool } from './focus-tracker/focus-tracker-module';
-import { configureShortcutHelpTool } from './key-shortcut/di.config';
+import { configureShortcutHelpTool } from './key-shortcut/shortcut-help-module';
 import { configureKeyboardControlTools } from './keyboard-pointer/keyboard-pointer-module';
 import { configureKeyboardToolPaletteTool } from './keyboard-tool-palette/keyboard-tool-palette-module';
 import { configureMoveZoom } from './move-zoom/move-zoom-module';

--- a/packages/client/src/features/accessibility/element-navigation/element-navigation-module.ts
+++ b/packages/client/src/features/accessibility/element-navigation/element-navigation-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,24 +13,31 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ContainerModule } from 'inversify';
-import { BindingContext, TYPES, bindAsService } from '@eclipse-glsp/sprotty';
-import { PositionNavigator } from './position-navigator';
-import { LocalElementNavigator } from './local-element-navigator';
-import { ElementNavigatorTool } from './diagram-navigation-tool';
+import { BindingContext, FeatureModule, TYPES, bindAsService } from '@eclipse-glsp/sprotty';
 import '../../../../css/navigation.css';
+import { ElementNavigatorTool } from './diagram-navigation-tool';
+import { LocalElementNavigator } from './local-element-navigator';
+import { PositionNavigator } from './position-navigator';
 
 /**
  * Handles element navigation actions.
  */
 
-export const glspElementNavigationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const context = { bind, unbind, isBound, rebind };
-    configureElementNavigationTool(context);
-});
+export const elementNavigationModule = new FeatureModule(
+    (bind, unbind, isBound, rebind) => {
+        const context = { bind, unbind, isBound, rebind };
+        configureElementNavigationTool(context);
+    },
+    { featureId: Symbol('elementNavigation') }
+);
 
 export function configureElementNavigationTool(context: BindingContext): void {
     bindAsService(context, TYPES.IDefaultTool, ElementNavigatorTool);
     bindAsService(context, TYPES.IElementNavigator, PositionNavigator);
     bindAsService(context, TYPES.ILocalElementNavigator, LocalElementNavigator);
 }
+
+export {
+    /** Deprecated use {@link elementNavigationModule} instead */
+    elementNavigationModule as glspElementNavigationModule
+};

--- a/packages/client/src/features/accessibility/focus-tracker/focus-tracker-module.ts
+++ b/packages/client/src/features/accessibility/focus-tracker/focus-tracker-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,19 +14,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
+import { BindingContext, FeatureModule, TYPES, bindAsService } from '@eclipse-glsp/sprotty';
 import { FocusTrackerTool } from './focus-tracker-tool';
-import { BindingContext, TYPES, bindAsService } from '@eclipse-glsp/sprotty';
 
 /**
  * Handles actions for tracking the focus of the cursor.
  */
 
-export const glspFocusTrackerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const context = { bind, unbind, isBound, rebind };
-    configureFocusTrackerTool(context);
-});
+export const focusTrackerModule = new FeatureModule(
+    (bind, unbind, isBound, rebind) => {
+        const context = { bind, unbind, isBound, rebind };
+        configureFocusTrackerTool(context);
+    },
+    { featureId: Symbol('focusTracker') }
+);
 
 export function configureFocusTrackerTool(context: BindingContext): void {
     bindAsService(context, TYPES.IDefaultTool, FocusTrackerTool);
 }
+
+export {
+    /** Deprecated use {@link focusTrackerModule} instead */
+    focusTrackerModule as glspFocusTrackerModule
+};

--- a/packages/client/src/features/accessibility/key-shortcut/shortcut-help-module.ts
+++ b/packages/client/src/features/accessibility/key-shortcut/shortcut-help-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { bindAsService, BindingContext, configureActionHandler, TYPES } from '@eclipse-glsp/sprotty';
+import { bindAsService, BindingContext, configureActionHandler, FeatureModule, TYPES } from '@eclipse-glsp/sprotty';
 import '../../../../css/key-shortcut.css';
 import { KeyShortcutUIExtension, SetAccessibleKeyShortcutAction } from './accessible-key-shortcut';
 import { AccessibleKeyShortcutTool } from './accessible-key-shortcut-tool';
@@ -23,13 +22,21 @@ import { AccessibleKeyShortcutTool } from './accessible-key-shortcut-tool';
 /**
  * Handles actions for displaying help/information about keyboard shortcuts.
  */
-export const glspShortcutHelpModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const context = { bind, unbind, isBound, rebind };
-    configureShortcutHelpTool(context);
-});
+export const shortcutHelpModule = new FeatureModule(
+    (bind, unbind, isBound, rebind) => {
+        const context = { bind, unbind, isBound, rebind };
+        configureShortcutHelpTool(context);
+    },
+    { featureId: Symbol('shortcutHelp') }
+);
 
 export function configureShortcutHelpTool(context: BindingContext): void {
     bindAsService(context, TYPES.IDefaultTool, AccessibleKeyShortcutTool);
     bindAsService(context, TYPES.IUIExtension, KeyShortcutUIExtension);
     configureActionHandler(context, SetAccessibleKeyShortcutAction.KIND, KeyShortcutUIExtension);
 }
+
+export {
+    /** Deprecated use {@link shortcutHelpModule} instead */
+    shortcutHelpModule as glspShortcutHelpModule
+};

--- a/packages/client/src/features/accessibility/toast/toast-module.ts
+++ b/packages/client/src/features/accessibility/toast/toast-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,8 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ContainerModule } from 'inversify';
-import { bindAsService, BindingContext, configureActionHandler, TYPES } from '@eclipse-glsp/sprotty';
+import { bindAsService, BindingContext, configureActionHandler, FeatureModule, TYPES } from '@eclipse-glsp/sprotty';
 import '../../../../css/toast.css';
 import { HideToastAction, ShowToastMessageAction } from './toast-handler';
 import { Toast } from './toast-tool';
@@ -23,10 +22,13 @@ import { Toast } from './toast-tool';
  * Handles toast/user notification actions.
  */
 
-export const glspToastModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const context = { bind, unbind, isBound, rebind };
-    configureToastTool(context);
-});
+export const toastModule = new FeatureModule(
+    (bind, unbind, isBound, rebind) => {
+        const context = { bind, unbind, isBound, rebind };
+        configureToastTool(context);
+    },
+    { featureId: Symbol('toast') }
+);
 
 export function configureToastTool(context: BindingContext): void {
     bindAsService(context, TYPES.IUIExtension, Toast);
@@ -34,3 +36,8 @@ export function configureToastTool(context: BindingContext): void {
     configureActionHandler(context, ShowToastMessageAction.KIND, Toast);
     configureActionHandler(context, HideToastAction.KIND, Toast);
 }
+
+export {
+    /** Deprecated use {@link toastModule} instead */
+    toastModule as glspToastModule
+};

--- a/packages/client/src/features/accessibility/view-key-tools/deselect-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/deselect-key-tool.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,21 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from 'inversify';
-import { toArray } from 'sprotty/lib/utils/iterable';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import {
     Action,
-    KeyListener,
-    KeyTool,
     GModelElement,
     GRoutableElement,
+    KeyListener,
+    KeyTool,
     SelectAction,
     SwitchEditModeAction,
     isSelectable
 } from '@eclipse-glsp/sprotty';
+import { inject, injectable } from 'inversify';
+import { toArray } from 'sprotty/lib/utils/iterable';
+import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import { Tool } from '../../../base/tool-manager/tool';
-import { SResizeHandle } from '../../change-bounds/model';
+import { GResizeHandle } from '../../change-bounds/model';
 
 /**
  * Deselects the element if there is no interaction possible with element.
@@ -59,7 +59,7 @@ export class DeselectKeyTool implements Tool {
 export class DeselectKeyListener extends KeyListener {
     override keyDown(target: GModelElement, event: KeyboardEvent): Action[] {
         if (this.matchesDeselectKeystroke(event)) {
-            const isResizeHandleActive = toArray(target.root.index.all().filter(el => el instanceof SResizeHandle)).length > 0;
+            const isResizeHandleActive = toArray(target.root.index.all().filter(el => el instanceof GResizeHandle)).length > 0;
 
             if (isResizeHandleActive) {
                 return [];

--- a/packages/client/src/features/change-bounds/model.ts
+++ b/packages/client/src/features/change-bounds/model.ts
@@ -109,14 +109,14 @@ export function isBoundsAwareMoveable(element: GModelElement): element is Bounds
     return isMoveable(element) && isBoundsAware(element);
 }
 
-export class SResizeHandle extends GChildElement implements Hoverable {
+export class GResizeHandle extends GChildElement implements Hoverable {
     static readonly TYPE = 'resize-handle';
 
     override readonly parent: ResizableModelElement;
 
     constructor(
         readonly location: ResizeHandleLocation,
-        override readonly type: string = SResizeHandle.TYPE,
+        override readonly type: string = GResizeHandle.TYPE,
         readonly hoverFeedback: boolean = false
     ) {
         super();
@@ -166,12 +166,12 @@ export class SResizeHandle extends GChildElement implements Hoverable {
         return this.isNeResize() || this.isSwResize();
     }
 
-    static getHandlePosition(handle: SResizeHandle): Point;
+    static getHandlePosition(handle: GResizeHandle): Point;
     static getHandlePosition(parent: ResizableModelElement, location: ResizeHandleLocation): Point;
     static getHandlePosition(bounds: Bounds, location: ResizeHandleLocation): Point;
-    static getHandlePosition(first: ResizableModelElement | SResizeHandle | Bounds, second?: ResizeHandleLocation): Point {
-        const bounds = SResizeHandle.is(first) ? first.parent.bounds : first instanceof GModelElement ? first.bounds : first;
-        const location = SResizeHandle.is(first) ? first.location : second!;
+    static getHandlePosition(first: ResizableModelElement | GResizeHandle | Bounds, second?: ResizeHandleLocation): Point {
+        const bounds = GResizeHandle.is(first) ? first.parent.bounds : first instanceof GModelElement ? first.bounds : first;
+        const location = GResizeHandle.is(first) ? first.location : second!;
         switch (location) {
             case ResizeHandleLocation.TopLeft:
                 return Bounds.topLeft(bounds);
@@ -192,7 +192,7 @@ export class SResizeHandle extends GChildElement implements Hoverable {
         }
     }
 
-    static getCursorCss(handle: SResizeHandle): string {
+    static getCursorCss(handle: GResizeHandle): string {
         switch (handle.location) {
             case ResizeHandleLocation.TopLeft:
                 return CursorCSS.RESIZE_NW;
@@ -213,17 +213,17 @@ export class SResizeHandle extends GChildElement implements Hoverable {
         }
     }
 
-    static is(handle: unknown): handle is SResizeHandle {
-        return typeof handle === 'object' && !!handle && 'type' in handle && handle.type === SResizeHandle.TYPE;
+    static is(handle: unknown): handle is GResizeHandle {
+        return typeof handle === 'object' && !!handle && 'type' in handle && handle.type === GResizeHandle.TYPE;
     }
 }
 
 export function addResizeHandles(element: ResizableModelElement, locations: ResizeHandleLocation[] = ResizeHandleLocation.CORNERS): void {
     for (const location of ResizeHandleLocation.ALL) {
-        const existing = element.children.find(child => child instanceof SResizeHandle && child.location === location);
+        const existing = element.children.find(child => child instanceof GResizeHandle && child.location === location);
         if (locations.includes(location) && !existing) {
             // add missing handle
-            element.add(new SResizeHandle(location));
+            element.add(new GResizeHandle(location));
         } else if (!locations.includes(location) && existing) {
             // remove existing handle
             element.remove(existing);
@@ -232,5 +232,10 @@ export function addResizeHandles(element: ResizableModelElement, locations: Resi
 }
 
 export function removeResizeHandles(element: GParentElement): void {
-    element.removeAll(child => child instanceof SResizeHandle);
+    element.removeAll(child => child instanceof GResizeHandle);
 }
+
+export {
+    /** @deprecated Use {@link GResizeHandle} instead */
+    GResizeHandle as SResizeHandle
+};

--- a/packages/client/src/features/change-bounds/movement-restrictor.ts
+++ b/packages/client/src/features/change-bounds/movement-restrictor.ts
@@ -18,7 +18,7 @@ import { injectable } from 'inversify';
 import { ModifyCSSFeedbackAction } from '../../base/feedback/css-feedback';
 import { BoundsAwareModelElement } from '../../utils/gmodel-util';
 import { toAbsoluteBounds } from '../../utils/viewpoint-util';
-import { SResizeHandle } from './model';
+import { GResizeHandle } from './model';
 
 /**
  * A `MovementRestrictor` is an optional service that can be used by tools to validate
@@ -86,7 +86,7 @@ export function createMovementRestrictionFeedback(
 ): ModifyCSSFeedbackAction {
     const elements: GModelElement[] = [element];
     if (element instanceof GParentElement) {
-        element.children.filter(child => child instanceof SResizeHandle).forEach(e => elements.push(e));
+        element.children.filter(child => child instanceof GResizeHandle).forEach(e => elements.push(e));
     }
     return ModifyCSSFeedbackAction.create({ elements, add: movementRestrictor.cssClasses });
 }
@@ -103,7 +103,7 @@ export function removeMovementRestrictionFeedback(
 ): ModifyCSSFeedbackAction {
     const elements: GModelElement[] = [element];
     if (element instanceof GParentElement) {
-        element.children.filter(child => child instanceof SResizeHandle).forEach(e => elements.push(e));
+        element.children.filter(child => child instanceof GResizeHandle).forEach(e => elements.push(e));
     }
 
     return ModifyCSSFeedbackAction.create({ elements, remove: movementRestrictor.cssClasses });

--- a/packages/client/src/features/helper-lines/helper-line-manager-default.ts
+++ b/packages/client/src/features/helper-lines/helper-line-manager-default.ts
@@ -30,7 +30,7 @@ import { IFeedbackActionDispatcher } from '../../base/feedback/feedback-action-d
 import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
 import { ISelectionListener, SelectionService } from '../../base/selection-service';
 import { SetBoundsFeedbackAction } from '../bounds/set-bounds-feedback-command';
-import { ResizeHandleLocation, SResizeHandle } from '../change-bounds/model';
+import { GResizeHandle, ResizeHandleLocation } from '../change-bounds/model';
 import { Grid } from '../grid/grid';
 import { MoveFinishedEventAction, MoveInitializedEventAction } from '../tools/change-bounds/change-bounds-tool-feedback';
 import {
@@ -182,7 +182,7 @@ export class HelperLineManager implements IActionHandler, ISelectionListener, IH
 
         const minimum: Writable<Vector> = { ...Vector.ZERO };
         const resize =
-            element instanceof SResizeHandle
+            element instanceof GResizeHandle
                 ? ResizeHandleLocation.direction(element.location)
                 : [Direction.Left, Direction.Right, Direction.Up, Direction.Down];
 

--- a/packages/client/src/features/select/select-mouse-listener.ts
+++ b/packages/client/src/features/select/select-mouse-listener.ts
@@ -17,7 +17,7 @@ import { Action, BringToFrontAction, GModelElement, SelectAction, SelectMouseLis
 import { inject, injectable, optional } from 'inversify';
 import { Ranked } from '../../base/ranked';
 import { SelectableElement } from '../../utils/gmodel-util';
-import { SResizeHandle } from '../change-bounds/model';
+import { GResizeHandle } from '../change-bounds/model';
 import { ChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
 
 /**
@@ -60,7 +60,7 @@ export class RankedSelectMouseListener extends SelectMouseListener implements Ra
     }
 
     protected override handleButton(target: GModelElement, event: MouseEvent): (Action | Promise<Action>)[] | undefined {
-        if (target instanceof SResizeHandle && this.changeBoundsManager?.useSymmetricResize(event)) {
+        if (target instanceof GResizeHandle && this.changeBoundsManager?.useSymmetricResize(event)) {
             // avoid de-selecting elements when resizing with a modifier key
             return [];
         }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-manager.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-manager.ts
@@ -40,7 +40,7 @@ import {
 import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
 import { isValidMove, minDimensions } from '../../../utils/layout-utils';
 import { LayoutAware } from '../../bounds/layout-data';
-import { ResizeHandleLocation, SResizeHandle } from '../../change-bounds/model';
+import { GResizeHandle, ResizeHandleLocation } from '../../change-bounds/model';
 import {
     IMovementRestrictor,
     movementRestrictionFeedback,
@@ -154,7 +154,7 @@ export class ChangeBoundsManager {
         );
 
         // cursor feedback on graph
-        const cursorClass = SResizeHandle.getCursorCss(resize.handleMove.element);
+        const cursorClass = GResizeHandle.getCursorCss(resize.handleMove.element);
         feedback.add(cursorFeedbackAction(cursorClass), cursorFeedbackAction(CursorCSS.DEFAULT));
 
         // handle feedback

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-module.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-module.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 import { FeatureModule, TYPES, bindAsService, configureCommand, configureView } from '@eclipse-glsp/sprotty';
 import '../../../../css/change-bounds.css';
-import { SResizeHandle } from '../../change-bounds/model';
+import { GResizeHandle } from '../../change-bounds/model';
 import { ChangeBoundsManager } from './change-bounds-manager';
 import { ChangeBoundsTool } from './change-bounds-tool';
 import { HideChangeBoundsToolResizeFeedbackCommand, ShowChangeBoundsToolResizeFeedbackCommand } from './change-bounds-tool-feedback';
-import { SResizeHandleView } from './view';
+import { GResizeHandleView } from './view';
 
 export const changeBoundsToolModule = new FeatureModule(
     (bind, unbind, isBound, rebind) => {
@@ -28,7 +28,7 @@ export const changeBoundsToolModule = new FeatureModule(
         bindAsService(context, TYPES.IDefaultTool, ChangeBoundsTool);
         configureCommand(context, ShowChangeBoundsToolResizeFeedbackCommand);
         configureCommand(context, HideChangeBoundsToolResizeFeedbackCommand);
-        configureView(context, SResizeHandle.TYPE, SResizeHandleView);
+        configureView(context, GResizeHandle.TYPE, GResizeHandleView);
     },
     { featureId: Symbol('changeBoundsTool') }
 );

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -26,7 +26,7 @@ import {
     isNonRoutableSelectedMovableBoundsAware,
     removeDescendants
 } from '../../../utils/gmodel-util';
-import { SResizeHandle } from '../../change-bounds/model';
+import { GResizeHandle } from '../../change-bounds/model';
 import { ChangeBoundsTool } from './change-bounds-tool';
 import { MoveFinishedEventAction, MoveInitializedEventAction } from './change-bounds-tool-feedback';
 import { ChangeBoundsTracker, TrackedMove } from './change-bounds-tracker';
@@ -66,7 +66,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener {
     }
 
     protected initializeMove(target: GModelElement, event: MouseEvent): void {
-        if (target instanceof SResizeHandle) {
+        if (target instanceof GResizeHandle) {
             // avoid conflict with resize tool
             return;
         }
@@ -102,7 +102,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener {
     }
 
     protected isValidMoveable(element?: GModelElement): element is MoveableElement {
-        return !!element && isNonRoutableSelectedMovableBoundsAware(element) && !(element instanceof SResizeHandle);
+        return !!element && isNonRoutableSelectedMovableBoundsAware(element) && !(element instanceof GResizeHandle);
     }
 
     override nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -51,7 +51,7 @@ import {
 } from '../../../utils/gmodel-util';
 import { LocalRequestBoundsAction } from '../../bounds/local-bounds';
 import { SetBoundsFeedbackAction } from '../../bounds/set-bounds-feedback-command';
-import { SResizeHandle, isResizable } from '../../change-bounds/model';
+import { GResizeHandle, isResizable } from '../../change-bounds/model';
 import { IMovementRestrictor } from '../../change-bounds/movement-restrictor';
 import { BaseEditTool } from '../base-tools';
 import { CSS_ACTIVE_HANDLE, ChangeBoundsManager } from './change-bounds-manager';
@@ -131,7 +131,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
 
     // members for resize mode
     protected activeResizeElement?: ResizableModelElement;
-    protected activeResizeHandle?: SResizeHandle;
+    protected activeResizeHandle?: GResizeHandle;
     protected handleFeedback: FeedbackEmitter;
     protected resizeFeedback: FeedbackEmitter;
 
@@ -155,7 +155,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
     }
 
     protected updateResizeElement(target: GModelElement, event?: MouseEvent): boolean {
-        this.activeResizeHandle = target instanceof SResizeHandle ? target : undefined;
+        this.activeResizeHandle = target instanceof GResizeHandle ? target : undefined;
         this.activeResizeElement = this.activeResizeHandle?.parent ?? this.findResizeElement(target);
         if (this.activeResizeElement) {
             if (event) {
@@ -301,7 +301,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         return newRoutingPoints.length > 0 ? [ChangeRoutingPointsOperation.create(newRoutingPoints)] : [];
     }
 
-    protected handleResizeOnServer(activeResizeHandle: SResizeHandle): Action[] {
+    protected handleResizeOnServer(activeResizeHandle: GResizeHandle): Action[] {
         if (this.initialBounds && this.isValidResize(activeResizeHandle.parent)) {
             const elementAndBounds = toElementAndBounds(activeResizeHandle.parent);
             if (!this.initialBounds.newPosition || !elementAndBounds.newPosition) {

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tracker.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tracker.ts
@@ -32,7 +32,7 @@ import {
     isMoveable
 } from '@eclipse-glsp/sprotty';
 import { BoundsAwareModelElement, MoveableElement, ResizableModelElement, getElements } from '../../../utils/gmodel-util';
-import { ResizeHandleLocation, SResizeHandle } from '../../change-bounds/model';
+import { GResizeHandle, ResizeHandleLocation } from '../../change-bounds/model';
 import { DiagramMovementCalculator } from '../../change-bounds/tracker';
 import { ChangeBoundsManager } from './change-bounds-manager';
 
@@ -277,7 +277,7 @@ export class ChangeBoundsTracker {
     // RESIZE
     //
 
-    resizeElements(handle: SResizeHandle, opts?: Partial<ResizeOptions>): TrackedResize {
+    resizeElements(handle: GResizeHandle, opts?: Partial<ResizeOptions>): TrackedResize {
         const options = this.resolveResizeOptions(opts);
         const update = this.calculateDiagramMovement();
         const handleMove = this.calculateHandleMove(new MoveableResizeHandle(handle), update.vector, options);
@@ -315,7 +315,7 @@ export class ChangeBoundsTracker {
         return this.calculateElementMove(handle, diagramMovement, moveOptions);
     }
 
-    protected getResizableElements(handle: SResizeHandle, options: ResizeOptions): ResizableModelElement[] {
+    protected getResizableElements(handle: GResizeHandle, options: ResizeOptions): ResizableModelElement[] {
         return [handle.parent];
     }
 
@@ -447,11 +447,11 @@ export class ChangeBoundsTracker {
     }
 }
 
-export class MoveableResizeHandle extends SResizeHandle implements Locateable {
+export class MoveableResizeHandle extends GResizeHandle implements Locateable {
     constructor(
-        protected handle: SResizeHandle,
+        protected handle: GResizeHandle,
         override location: ResizeHandleLocation = handle.location,
-        readonly position = SResizeHandle.getHandlePosition(handle.parent, location)
+        readonly position = GResizeHandle.getHandlePosition(handle.parent, location)
     ) {
         super(location, handle.type, handle.hoverFeedback);
         this.id = handle.id;

--- a/packages/client/src/features/tools/change-bounds/view.tsx
+++ b/packages/client/src/features/tools/change-bounds/view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2023 EclipseSource and others.
+ * Copyright (c) 2019-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,14 +16,14 @@
 import { IView, Point, RenderingContext, setAttr, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { SResizeHandle } from '../../change-bounds/model';
+import { GResizeHandle } from '../../change-bounds/model';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const JSX = { createElement: svg };
 
 @injectable()
-export class SResizeHandleView implements IView {
-    render(handle: SResizeHandle, context: RenderingContext): VNode | undefined {
+export class GResizeHandleView implements IView {
+    render(handle: GResizeHandle, context: RenderingContext): VNode | undefined {
         if (context.targetKind === 'hidden') {
             return undefined;
         }
@@ -45,11 +45,16 @@ export class SResizeHandleView implements IView {
         return <g />;
     }
 
-    protected getPosition(handle: SResizeHandle): Point | undefined {
-        return Point.subtract(SResizeHandle.getHandlePosition(handle), handle.parent.bounds);
+    protected getPosition(handle: GResizeHandle): Point | undefined {
+        return Point.subtract(GResizeHandle.getHandlePosition(handle), handle.parent.bounds);
     }
 
     getRadius(): number {
         return 7;
     }
 }
+
+export {
+    /** @deprecated Use {@link GResizeHandleView} instead */
+    GResizeHandleView as SResizeHandleView
+};

--- a/packages/client/src/features/undo-redo/undo-redo-module.ts
+++ b/packages/client/src/features/undo-redo/undo-redo-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 EclipseSource and others.
+ * Copyright (c) 2023-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { bindAsService, TYPES } from '@eclipse-glsp/sprotty';
+import { bindAsService, FeatureModule, TYPES } from '@eclipse-glsp/sprotty';
 import { GLSPUndoRedoKeyListener } from './undo-redo-key-listener';
 
 /**
@@ -23,6 +22,9 @@ import { GLSPUndoRedoKeyListener } from './undo-redo-key-listener';
  * When integrated into an application frame (e.g Theia/VS Code) this module is typically omitted and/or replaced
  * with an application native module.
  */
-export const undoRedoModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bindAsService(bind, TYPES.KeyListener, GLSPUndoRedoKeyListener);
-});
+export const undoRedoModule = new FeatureModule(
+    (bind, unbind, isBound, rebind) => {
+        bindAsService(bind, TYPES.KeyListener, GLSPUndoRedoKeyListener);
+    },
+    { featureId: Symbol('undoRedo') }
+);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -67,7 +67,7 @@ export * from './features/accessibility/focus-tracker/focus-tracker-tool';
 export * from './features/accessibility/global-keylistener-tool';
 export * from './features/accessibility/key-shortcut/accessible-key-shortcut';
 export * from './features/accessibility/key-shortcut/accessible-key-shortcut-tool';
-export * from './features/accessibility/key-shortcut/di.config';
+export * from './features/accessibility/key-shortcut/shortcut-help-module';
 export * from './features/accessibility/keyboard-grid/action';
 export * from './features/accessibility/keyboard-grid/constants';
 export * from './features/accessibility/keyboard-grid/keyboard-grid';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Adjust name of `SResizeHandle` and `SResizeHandleview` to the gmodel namespace
and reexport under the old name as deprecated for backwards compatibility.

- Ensure that all diagram modules are constructed as `FeatureModules` instead of plain `ContainerModules`

- Rename modules that still have the glsp prefix and also reexport under old deprecated name


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
