### PR TITLE
Fix issue with UI extensions

### DIFF
--- a/examples/workflow-glsp/src/direct-task-editing/direct-task-editor.ts
+++ b/examples/workflow-glsp/src/direct-task-editing/direct-task-editor.ts
@@ -14,19 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-    AbstractUIExtension,
     Action,
     AutoCompleteWidget,
     DOMHelper,
     EditorContextService,
+    GLSPAbstractUIExtension,
     GLSPActionDispatcher,
+    GModelRoot,
     ILogger,
     LabeledAction,
     ModelIndexImpl,
     Operation,
     RequestContextActions,
     RequestEditValidationAction,
-    GModelRoot,
     SetContextActions,
     SetEditValidationResultAction,
     TYPES,
@@ -85,7 +85,7 @@ export namespace EditTaskOperation {
 }
 
 @injectable()
-export class TaskEditor extends AbstractUIExtension {
+export class TaskEditor extends GLSPAbstractUIExtension {
     static readonly ID = 'task-editor';
     readonly autoSuggestionSettings = {
         noSuggestionsMessage: 'No suggestions available',

--- a/packages/client/src/base/auto-complete/base-autocomplete-palette.ts
+++ b/packages/client/src/base/auto-complete/base-autocomplete-palette.ts
@@ -14,10 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Action, GModelRoot, LabeledAction, TYPES } from '@eclipse-glsp/sprotty';
 import { inject } from 'inversify';
-import { AbstractUIExtension, Action, LabeledAction, GModelRoot, TYPES } from '@eclipse-glsp/sprotty';
 import '../../../css/autocomplete-palette.css';
 import { GLSPActionDispatcher } from '../action-dispatcher';
+import { GLSPAbstractUIExtension } from '../ui-extension/ui-extension';
 import { AutoCompleteWidget, CloseReason, toActionArray } from './auto-complete-widget';
 
 /**
@@ -25,7 +26,7 @@ import { AutoCompleteWidget, CloseReason, toActionArray } from './auto-complete-
  * using the {@link AutoCompleteWidget}.
  *
  */
-export abstract class BaseAutocompletePalette extends AbstractUIExtension {
+export abstract class BaseAutocompletePalette extends GLSPAbstractUIExtension {
     protected readonly autoSuggestionSettings = {
         noSuggestionsMessage: 'No suggestions available',
         suggestionsClass: 'command-palette-suggestions',

--- a/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut.ts
+++ b/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut.ts
@@ -14,9 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Action, GModelRoot, IActionHandler, ICommand, matchesKeystroke } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { groupBy } from 'lodash';
-import { AbstractUIExtension, Action, IActionHandler, ICommand, matchesKeystroke, GModelRoot } from '@eclipse-glsp/sprotty';
+import { GLSPAbstractUIExtension } from '../../../base/ui-extension/ui-extension';
 
 export interface AccessibleKeyShortcutProvider {
     registerShortcutKey(): void;
@@ -48,7 +49,7 @@ export namespace SetAccessibleKeyShortcutAction {
 }
 
 @injectable()
-export class KeyShortcutUIExtension extends AbstractUIExtension implements IActionHandler {
+export class KeyShortcutUIExtension extends GLSPAbstractUIExtension implements IActionHandler {
     static readonly ID = 'key-shortcut';
     protected container: HTMLDivElement;
     protected shortcutsContainer: HTMLDivElement;

--- a/packages/client/src/features/accessibility/keyboard-grid/keyboard-grid.ts
+++ b/packages/client/src/features/accessibility/keyboard-grid/keyboard-grid.ts
@@ -15,24 +15,24 @@
  ********************************************************************************/
 import '../../../../css/keyboard.css';
 
-import { inject, injectable } from 'inversify';
 import {
-    AbstractUIExtension,
-    ActionDispatcher,
-    IActionHandler,
-    SetUIExtensionVisibilityAction,
-    GModelRoot,
-    TYPES,
     Action,
+    ActionDispatcher,
+    GModelRoot,
+    IActionHandler,
     ICommand,
-    Point
+    Point,
+    SetUIExtensionVisibilityAction,
+    TYPES
 } from '@eclipse-glsp/sprotty';
+import { inject, injectable } from 'inversify';
 import { KeyCode, matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { KeyboardGridMetadata } from './constants';
+import { GLSPAbstractUIExtension } from '../../../base/ui-extension/ui-extension';
 import { EnableKeyboardGridAction, KeyboardGridCellSelectedAction, KeyboardGridKeyboardEventAction } from './action';
+import { KeyboardGridMetadata } from './constants';
 
 @injectable()
-export class KeyboardGrid extends AbstractUIExtension implements IActionHandler {
+export class KeyboardGrid extends GLSPAbstractUIExtension implements IActionHandler {
     @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: ActionDispatcher;
 
     protected triggerActions: Action[] = [];

--- a/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer.ts
+++ b/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer.ts
@@ -13,26 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Action, GModelRoot, IActionDispatcher, IActionHandler, TYPES, TriggerNodeCreationAction } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import {
-    AbstractUIExtension,
-    IActionDispatcher,
-    IActionHandler,
-    GModelRoot,
-    TYPES,
-    Action,
-    TriggerNodeCreationAction
-} from '@eclipse-glsp/sprotty';
+import { EditorContextService } from '../../../base/editor-context-service';
+import { CursorCSS } from '../../../base/feedback/css-feedback';
+import { GLSPAbstractUIExtension } from '../../../base/ui-extension/ui-extension';
+import { KeyboardGridCellSelectedAction } from '../keyboard-grid/action';
 import { SetKeyboardPointerRenderPositionAction } from './actions';
 import { KeyboardPointerMetadata } from './constants';
 import { KeyboardPointerKeyboardListener } from './keyboard-pointer-listener';
 import { KeyboardPointerPosition } from './keyboard-pointer-position';
-import { KeyboardGridCellSelectedAction } from '../keyboard-grid/action';
-import { EditorContextService } from '../../../base/editor-context-service';
-import { CursorCSS } from '../../../base/feedback/css-feedback';
 
 @injectable()
-export class KeyboardPointer extends AbstractUIExtension implements IActionHandler {
+export class KeyboardPointer extends GLSPAbstractUIExtension implements IActionHandler {
     protected _triggerAction: TriggerNodeCreationAction = {
         elementTypeId: 'task:automated',
         kind: 'triggerNodeCreation'

--- a/packages/client/src/features/accessibility/toast/toast-tool.ts
+++ b/packages/client/src/features/accessibility/toast/toast-tool.ts
@@ -14,18 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
-import { Action, AbstractUIExtension, IActionHandler, ICommand, TYPES } from '@eclipse-glsp/sprotty';
-import { IDiagramStartup } from '../../../base/model/diagram-loader';
+import { Action, IActionHandler, ICommand, TYPES } from '@eclipse-glsp/sprotty';
+import { inject, injectable } from 'inversify';
 import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { EditorContextService } from '../../../base/editor-context-service';
+import { IDiagramStartup } from '../../../base/model/diagram-loader';
+import { GLSPAbstractUIExtension } from '../../../base/ui-extension/ui-extension';
 import { HideToastAction, ShowToastMessageAction, ToastOptions } from './toast-handler';
 
 /**
  * This extension is used to create customized user notifications as toast messages.
  */
 @injectable()
-export class Toast extends AbstractUIExtension implements IActionHandler, IDiagramStartup {
+export class Toast extends GLSPAbstractUIExtension implements IActionHandler, IDiagramStartup {
     static readonly ID = 'toast';
     protected messages: { [key: symbol]: ToastOptions } = {};
 

--- a/packages/client/src/features/label-edit-ui/label-edit-ui.ts
+++ b/packages/client/src/features/label-edit-ui/label-edit-ui.ts
@@ -27,6 +27,7 @@ export class GlspEditLabelUI extends EditLabelUI {
     protected override setContainerVisible(visible: boolean): void {
         if (visible) {
             this.containerElement?.classList.remove(CSS_HIDDEN_EXTENSION_CLASS);
+            this.editControl.focus();
         } else {
             this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
         }

--- a/packages/client/src/features/status/status-overlay.ts
+++ b/packages/client/src/features/status/status-overlay.ts
@@ -13,17 +13,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { IActionHandler, StatusAction, codiconCSSClasses } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { AbstractUIExtension, IActionHandler, StatusAction, codiconCSSClasses } from '@eclipse-glsp/sprotty';
 import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { EditorContextService } from '../../base/editor-context-service';
 import { IDiagramStartup } from '../../base/model/diagram-loader';
+import { GLSPAbstractUIExtension } from '../../base/ui-extension/ui-extension';
 
 /**
  * A reusable status overlay for rendering (icon + message) and handling of {@link StatusAction}'s.
  */
 @injectable()
-export class StatusOverlay extends AbstractUIExtension implements IActionHandler, IDiagramStartup {
+export class StatusOverlay extends GLSPAbstractUIExtension implements IActionHandler, IDiagramStartup {
     static readonly ID = 'glsp.server.status.overlay';
 
     @inject(GLSPActionDispatcher)

--- a/packages/client/src/features/tool-palette/tool-palette.ts
+++ b/packages/client/src/features/tool-palette/tool-palette.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-    AbstractUIExtension,
     Action,
     GModelRoot,
     IActionHandler,
@@ -37,6 +36,7 @@ import { EditorContextService, IEditModeListener } from '../../base/editor-conte
 import { FocusTracker } from '../../base/focus/focus-tracker';
 import { IDiagramStartup } from '../../base/model/diagram-loader';
 import { EnableDefaultToolsAction, EnableToolsAction } from '../../base/tool-manager/tool';
+import { GLSPAbstractUIExtension } from '../../base/ui-extension/ui-extension';
 import { DebugManager } from '../debug/debug-manager';
 import { GridManager } from '../grid/grid-manager';
 import { MouseDeleteTool } from '../tools/deletion/delete-tool';
@@ -65,7 +65,7 @@ export namespace EnableToolPaletteAction {
     }
 }
 @injectable()
-export class ToolPalette extends AbstractUIExtension implements IActionHandler, IEditModeListener, IDiagramStartup {
+export class ToolPalette extends GLSPAbstractUIExtension implements IActionHandler, IEditModeListener, IDiagramStartup {
     static readonly ID = 'tool-palette';
 
     @inject(GLSPActionDispatcher)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Use our GLSPAbstractUIExtension instead of AbstractUIExtension
- Fix focus issue with GlspEditLabelUI

#### How to test

- Ensure that whenever you show the label edit UI, the text field gets proper focus
- Test other UI extensions behave as before

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
