### PR TITLE
View improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,13 @@ module.exports = {
                 message:
                     "The sprotty-protocol default exports are customized and reexported by GLSP. Please use '@eclipse-glsp/client' instead"
             }
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                args: 'none',
+                varsIgnorePattern: 'svg|html'
+            }
         ]
     }
 };

--- a/examples/workflow-glsp/src/workflow-diagram-module.ts
+++ b/examples/workflow-glsp/src/workflow-diagram-module.ts
@@ -43,7 +43,8 @@ import {
     editLabelFeature,
     gridModule,
     helperLineModule,
-    initializeDiagramContainer
+    initializeDiagramContainer,
+    overrideModelElement
 } from '@eclipse-glsp/client';
 import 'balloon-css/balloon.min.css';
 import { Container } from 'inversify';
@@ -69,16 +70,15 @@ export const workflowDiagramModule = new FeatureModule(
         configureModelElement(context, 'task:manual', TaskNode, RoundedCornerNodeView);
         configureModelElement(context, 'label:heading', GLabel, GLabelView, { enable: [editLabelFeature] });
         configureModelElement(context, 'comp:comp', GCompartment, GCompartmentView);
-        configureModelElement(context, 'comp:header', GCompartment, GCompartmentView);
         configureModelElement(context, 'label:icon', GLabel, GLabelView);
-        configureModelElement(context, DefaultTypes.EDGE, GEdge, WorkflowEdgeView);
+        overrideModelElement(context, DefaultTypes.EDGE, GEdge, WorkflowEdgeView);
         configureModelElement(context, 'edge:weighted', WeightedEdge, WorkflowEdgeView);
         configureModelElement(context, 'icon', Icon, IconView);
         configureModelElement(context, 'activityNode:merge', BranchingNode, DiamondNodeView);
         configureModelElement(context, 'activityNode:decision', BranchingNode, DiamondNodeView);
         configureModelElement(context, 'activityNode:fork', SynchronizationNode, RectangularNodeView);
         configureModelElement(context, 'activityNode:join', SynchronizationNode, RectangularNodeView);
-        configureModelElement(context, DefaultTypes.GRAPH, GGraph, GLSPProjectionView);
+        overrideModelElement(context, DefaultTypes.GRAPH, GGraph, GLSPProjectionView);
         configureModelElement(context, 'category', CategoryNode, RoundedCornerNodeView);
         configureModelElement(context, 'struct', GCompartment, StructureCompartmentView);
 

--- a/examples/workflow-glsp/src/workflow-views.tsx
+++ b/examples/workflow-glsp/src/workflow-views.tsx
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
 import {
     GEdge,
     Point,
@@ -29,9 +30,6 @@ import {
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { Icon, isTaskNode } from './model';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class WorkflowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {

--- a/packages/client/css/grid.css
+++ b/packages/client/css/grid.css
@@ -14,14 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/** Control visibility of background image through CSS class on parent */
 .grid-background .sprotty-graph,
 .grid-background.sprotty-graph {
-    --b-zoom: calc(1px * var(--grid-background-zoom));
-    --b-zoom-half: calc(var(--b-zoom) / 2);
+    --grid-stroke-width: calc(1px * var(--grid-background-zoom));
+    --grid-stroke-width-half: calc(var(--grid-stroke-width) / 2);
     --grid-color: rgba(0, 0, 0, 0.1);
-    background-image: linear-gradient(to right, var(--grid-color) var(--b-zoom), transparent var(--b-zoom)),
-        linear-gradient(to bottom, var(--grid-color) var(--b-zoom), transparent var(--b-zoom));
+    background-image: linear-gradient(to right, var(--grid-color) var(--grid-stroke-width), transparent var(--grid-stroke-width)),
+        linear-gradient(to bottom, var(--grid-color) var(--grid-stroke-width), transparent var(--grid-stroke-width));
     background-size: var(--grid-background-width) var(--grid-background-height);
-    background-position: calc(var(--grid-background-x) - var(--b-zoom-half)) calc(var(--grid-background-y) - var(--b-zoom-half));
+    background-position: calc(var(--grid-background-x) - var(--grid-stroke-width-half))
+        calc(var(--grid-background-y) - var(--grid-stroke-width-half));
 }

--- a/packages/client/css/grid.css
+++ b/packages/client/css/grid.css
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-:root {
-    --grid-color: rgba(0, 0, 0, 0.1);
-}
-
 /** Control visibility of background image through CSS class on parent */
 .grid-background .sprotty-graph,
 .grid-background.sprotty-graph {
-    background-image: var(--grid-background-image);
+    --b-zoom: calc(1px * var(--grid-background-zoom));
+    --b-zoom-half: calc(var(--b-zoom) / 2);
+    --grid-color: rgba(0, 0, 0, 0.1);
+    background-image: linear-gradient(to right, var(--grid-color) var(--b-zoom), transparent var(--b-zoom)),
+        linear-gradient(to bottom, var(--grid-color) var(--b-zoom), transparent var(--b-zoom));
+    background-size: var(--grid-background-width) var(--grid-background-height);
+    background-position: calc(var(--grid-background-x) - var(--b-zoom-half)) calc(var(--grid-background-y) - var(--b-zoom-half));
 }

--- a/packages/client/src/default-modules.spec.ts
+++ b/packages/client/src/default-modules.spec.ts
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { FeatureModule } from '@eclipse-glsp/sprotty';
+import { expect } from 'chai';
+import { Container } from 'inversify';
+import * as sinon from 'sinon';
+import { defaultModule } from './base/default.module';
+import { DEFAULT_MODULES, initializeDiagramContainer } from './default-modules';
+
+describe('default-modules', () => {
+    // InitializeDiagramContainer internally uses `resolveContainerConfiguration` so we only test functionality
+    // that is not covered by the tests of `resolveContainerConfiguration`.
+    describe('initializeDiagramContainer', () => {
+        const sandbox = sinon.createSandbox();
+        const container = new Container();
+        const loadSpy = sandbox.spy(container, 'load');
+        container.snapshot();
+
+        beforeEach(() => {
+            sandbox.reset();
+            container.restore();
+            container.snapshot();
+        });
+        it('should initialize the diagram container with the default modules in addition to the given config and load them first', () => {
+            const extraModule = new FeatureModule(() => {});
+            initializeDiagramContainer(container, { add: extraModule });
+            expect(loadSpy.calledOnce).to.be.true;
+            const callArgs = loadSpy.firstCall.args;
+            const lastModule = callArgs.pop();
+            expect(callArgs).to.be.deep.equal(DEFAULT_MODULES).ordered;
+            expect(lastModule).to.be.equal(extraModule);
+        });
+        it('should throw an error if the base (default) module is removed via configuration', () => {
+            expect(() => initializeDiagramContainer(container, { remove: defaultModule })).to.throw(/Invalid module configuration/);
+        });
+        // eslint-disable-next-line max-len
+        it('should throw an error if the base (default) module is not the first module of the resolved configured (removed and added again)', () => {
+            expect(() => initializeDiagramContainer(container, { remove: defaultModule, add: defaultModule })).to.throw(
+                /Invalid module configuration/
+            );
+        });
+    });
+});

--- a/packages/client/src/features/debug/debug-bounds-decorator.tsx
+++ b/packages/client/src/features/debug/debug-bounds-decorator.tsx
@@ -14,16 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 /* eslint-disable max-len */
-
+/** @jsx svg */
 import { Bounds, GModelElement, IVNodePostprocessor, Point, isDecoration, isSizeable, setClass, svg } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
 import { GGraph } from '../../model';
 import { BoundsAwareModelElement } from '../../utils/gmodel-util';
 import { DebugManager } from './debug-manager';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 export const CSS_DEBUG_BOUNDS = 'debug-bounds';
 

--- a/packages/client/src/features/helper-lines/view.tsx
+++ b/packages/client/src/features/helper-lines/view.tsx
@@ -13,13 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
 import { IViewArgs, RenderingContext, ShapeView, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { HelperLine, SelectionBounds } from './model';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class HelperLineView extends ShapeView {

--- a/packages/client/src/features/tools/change-bounds/view.tsx
+++ b/packages/client/src/features/tools/change-bounds/view.tsx
@@ -13,13 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
 import { IView, Point, RenderingContext, setAttr, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { GResizeHandle } from '../../change-bounds/model';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class GResizeHandleView implements IView {

--- a/packages/client/src/features/tools/edge-creation/view.tsx
+++ b/packages/client/src/features/tools/edge-creation/view.tsx
@@ -13,12 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
+import { GModelElement, IView, Point, RenderingContext, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { IView, Point, RenderingContext, GModelElement, svg } from '@eclipse-glsp/sprotty';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 /**
  * This view is used for the invisible end of the feedback edge.

--- a/packages/client/src/features/tools/marquee-selection/view.tsx
+++ b/packages/client/src/features/tools/marquee-selection/view.tsx
@@ -13,13 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
+import { RectangularNodeView, RenderingContext, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { RectangularNodeView, RenderingContext, svg } from '@eclipse-glsp/sprotty';
 import { MarqueeNode } from './model';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class MarqueeView extends RectangularNodeView {

--- a/packages/client/src/features/tools/node-creation/node-creation-views.tsx
+++ b/packages/client/src/features/tools/node-creation/node-creation-views.tsx
@@ -13,16 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-
+/** @jsx svg */
 import { IView, RenderingContext, TYPES, setClass, svg } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
 import { GArgument } from '../../../utils/argument-utils';
 import { Grid } from '../../grid/grid';
 import { ARG_LENGTH, InsertIndicator } from './insert-indicator';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class InsertIndicatorView implements IView {

--- a/packages/client/src/views/compartments.tsx
+++ b/packages/client/src/views/compartments.tsx
@@ -13,12 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
+import { GCompartment, RenderingContext, ShapeView, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { GCompartment, RenderingContext, ShapeView, svg } from '@eclipse-glsp/sprotty';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class StructureCompartmentView extends ShapeView {

--- a/packages/client/src/views/gedge-view.tsx
+++ b/packages/client/src/views/gedge-view.tsx
@@ -13,14 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
 import { Point, PolylineEdgeView, RenderingContext, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { Classes, VNode } from 'snabbdom';
-import { EdgePadding } from '../utils/argument-utils';
 import { GEdge } from '../model';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
+import { EdgePadding } from '../utils/argument-utils';
 
 @injectable()
 export class GEdgeView extends PolylineEdgeView {

--- a/packages/client/src/views/ggraph-view.tsx
+++ b/packages/client/src/views/ggraph-view.tsx
@@ -32,7 +32,7 @@ export class GGraphView extends SGraphView {
     }
 
     protected getGridStyle(viewport: Readonly<SGraphImpl>, context: RenderingContext): GridStyle {
-        if (context.targetKind === 'hidden' || !this.gridManager?.isGridVisible) {
+        if (context.targetKind === 'hidden' || !this.gridManager) {
             return {};
         }
         const bounds = this.getBackgroundBounds(viewport, context, this.gridManager);

--- a/packages/client/src/views/ggraph-view.tsx
+++ b/packages/client/src/views/ggraph-view.tsx
@@ -41,11 +41,7 @@ export class GGraphView extends SGraphView {
             [GridProperty.GRID_BACKGROUND_Y]: bounds.y + 'px',
             [GridProperty.GRID_BACKGROUND_WIDTH]: bounds.width + 'px',
             [GridProperty.GRID_BACKGROUND_HEIGHT]: bounds.height + 'px',
-            [GridProperty.GRID_BACKGROUND_ZOOM]: viewport.zoom + '',
-            [GridProperty.GRID_BACKGROUND_IMAGE]: this.getBackgroundImage(viewport, context, this.gridManager),
-            backgroundPosition: `${bounds.x}px ${bounds.y}px`,
-            backgroundSize: `${bounds.width}px ${bounds.height}px`
-            // we do not set the background-image directly in the style object, because we want to toggle it on and off via CSS
+            [GridProperty.GRID_BACKGROUND_ZOOM]: viewport.zoom + ''
         };
     }
 
@@ -53,11 +49,5 @@ export class GGraphView extends SGraphView {
         const position = Point.multiplyScalar(Point.subtract(gridManager.grid, viewport.scroll), viewport.zoom);
         const size = Dimension.fromPoint(Point.multiplyScalar(gridManager.grid, viewport.zoom));
         return { ...position, ...size };
-    }
-
-    protected getBackgroundImage(viewport: Readonly<SGraphImpl>, context: RenderingContext, gridManager: GridManager): string {
-        const color = getComputedStyle(document.documentElement).getPropertyValue(GridProperty.GRID_COLOR).trim().replace(/#/g, '%23');
-        // eslint-disable-next-line max-len
-        return `url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${gridManager.grid.x} ${gridManager.grid.y}"><rect width="${gridManager.grid.x}" height="${gridManager.grid.y}" x="0" y="0" fill="none" stroke="${color}" stroke-width="1" /></svg>')`;
     }
 }

--- a/packages/client/src/views/glsp-projection-view.tsx
+++ b/packages/client/src/views/glsp-projection-view.tsx
@@ -70,7 +70,7 @@ export class GLSPProjectionView extends ProjectedViewportView {
     }
 
     protected getGridStyle(viewport: Readonly<SGraphImpl>, context: RenderingContext): GridStyle {
-        if (context.targetKind === 'hidden' || !this.gridManager?.isGridVisible) {
+        if (context.targetKind === 'hidden' || !this.gridManager) {
             return {};
         }
         const bounds = this.getBackgroundBounds(viewport, context, this.gridManager);

--- a/packages/client/src/views/glsp-projection-view.tsx
+++ b/packages/client/src/views/glsp-projection-view.tsx
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-
+/** @jsx html */
 import {
     Bounds,
     Dimension,
@@ -35,9 +35,6 @@ import { inject, injectable, optional } from 'inversify';
 import { VNode, VNodeStyle, h } from 'snabbdom';
 import { GridManager, GridStyle } from '../features/grid/grid-manager';
 import { GridProperty } from '../features/grid/grid-style';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: html };
 
 /**
  * Special viewport root view that renders horizontal and vertical projection bars for quick navigation.
@@ -82,11 +79,7 @@ export class GLSPProjectionView extends ProjectedViewportView {
             [GridProperty.GRID_BACKGROUND_Y]: bounds.y + 'px',
             [GridProperty.GRID_BACKGROUND_WIDTH]: bounds.width + 'px',
             [GridProperty.GRID_BACKGROUND_HEIGHT]: bounds.height + 'px',
-            [GridProperty.GRID_BACKGROUND_ZOOM]: viewport.zoom + '',
-            [GridProperty.GRID_BACKGROUND_IMAGE]: this.getBackgroundImage(viewport, context, this.gridManager),
-            backgroundPosition: `${bounds.x}px ${bounds.y}px`,
-            backgroundSize: `${bounds.width}px ${bounds.height}px`
-            // we do not set the background-image directly in the style object, because we want to toggle it on and off via CSS
+            [GridProperty.GRID_BACKGROUND_ZOOM]: viewport.zoom + ''
         };
     }
 
@@ -96,35 +89,15 @@ export class GLSPProjectionView extends ProjectedViewportView {
         return { ...position, ...size };
     }
 
-    protected getBackgroundImage(viewport: Readonly<SGraphImpl>, context: RenderingContext, gridManager: GridManager): string {
-        const color = getComputedStyle(document.documentElement).getPropertyValue(GridProperty.GRID_COLOR).trim().replace(/#/g, '%23');
-        // eslint-disable-next-line max-len
-        return `url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${gridManager.grid.x} ${gridManager.grid.y}"><rect width="${gridManager.grid.x}" height="${gridManager.grid.y}" x="0" y="0" fill="none" stroke="${color}" stroke-width="1" /></svg>')`;
-    }
-
     protected override renderProjectionBar(
         projections: ViewProjection[],
         model: Readonly<GViewportRootElement>,
         modelBounds: Bounds,
         orientation: 'horizontal' | 'vertical'
     ): VNode {
-        const params: ProjectionParams = { modelBounds, orientation } as ProjectionParams;
-        // NOTE: Here we assume that the projection bars have the same size as the diagram canvas,
-        // i.e. they are drawn as overlay above the canvas.
-        params.factor =
-            orientation === 'horizontal' ? model.canvasBounds.width / modelBounds.width : model.canvasBounds.height / modelBounds.height;
-        params.zoomedFactor = params.factor / model.zoom;
-        return (
-            <div
-                class-sprotty-projection-bar={true}
-                class-horizontal={orientation === 'horizontal'}
-                class-vertical={orientation === 'vertical'}
-                class-bordered-projection-bar={true}
-            >
-                {this.renderViewport(model, params)}
-                {projections.map(p => this.renderProjection(p, model, params))}
-            </div>
-        );
+        const vnode = super.renderProjectionBar(projections, model, modelBounds, orientation);
+        setClass(vnode, 'bordered-projection-bar', true);
+        return vnode;
     }
 
     protected override renderViewport(model: Readonly<GViewportRootElement>, params: ProjectionParams): VNode {
@@ -170,50 +143,14 @@ export class GLSPProjectionView extends ProjectedViewportView {
         model: Readonly<GViewportRootElement>,
         params: ProjectionParams
     ): VNode {
-        let canvasSize;
-        let projPos;
-        let projSize: number;
-        if (params.orientation === 'horizontal') {
-            canvasSize = model.canvasBounds.width;
-            projPos = (projection.projectedBounds.x - params.modelBounds.x) * params.factor;
-            projSize = projection.projectedBounds.width * params.factor;
+        const vnode = super.renderProjection(projection, model, params);
+        setClass(vnode, 'glsp-projection', true);
+        const style = vnode.data!.style!;
+        if (style.left) {
+            style.height = '60%';
         } else {
-            canvasSize = model.canvasBounds.height;
-            projPos = (projection.projectedBounds.y - params.modelBounds.y) * params.factor;
-            projSize = projection.projectedBounds.height * params.factor;
+            style.width = '60%';
         }
-        if (projPos < 0) {
-            projSize += projPos;
-            projPos = 0;
-        } else if (projPos > canvasSize) {
-            projPos = canvasSize;
-        }
-        if (projSize < 0) {
-            projSize = 0;
-        } else if (projPos + projSize > canvasSize) {
-            projSize = canvasSize - projPos;
-        }
-        const style: VNodeStyle =
-            params.orientation === 'horizontal'
-                ? {
-                      left: `${projPos}px`,
-                      width: `${projSize}px`,
-                      height: '60%'
-                  }
-                : {
-                      top: `${projPos}px`,
-                      height: `${projSize}px`,
-                      width: '60%'
-                  };
-        const result = (
-            <div
-                id={`${params.orientation}-projection:${projection.elementId}`}
-                class-sprotty-projection={true}
-                class-glsp-projection={true}
-                style={style}
-            />
-        );
-        projection.cssClasses.forEach(cl => setClass(result, cl, true));
-        return result;
+        return vnode;
     }
 }

--- a/packages/client/src/views/issue-marker-view.tsx
+++ b/packages/client/src/views/issue-marker-view.tsx
@@ -14,13 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 /* eslint-disable max-len */
+/** @jsx svg */
 import { GIssueSeverity, IssueMarkerView, RenderingContext, setClass, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { GIssueMarker } from '../features/validation/issue-marker';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class GIssueMarkerView extends IssueMarkerView {

--- a/packages/client/src/views/rounded-corner-view.tsx
+++ b/packages/client/src/views/rounded-corner-view.tsx
@@ -13,14 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/** @jsx svg */
+import { GNode, GPort, GShapeElement, Hoverable, RectangularNodeView, RenderingContext, Selectable, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { Classes, VNode } from 'snabbdom';
-import { Hoverable, RectangularNodeView, RenderingContext, GNode, GPort, GShapeElement, Selectable, svg } from '@eclipse-glsp/sprotty';
 import { CornerRadius } from '../utils/argument-utils';
 import { RoundedCornerWrapper } from './rounded-corner';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class RoundedCornerNodeView extends RectangularNodeView {

--- a/packages/glsp-sprotty/src/svg-views-override.tsx
+++ b/packages/glsp-sprotty/src/svg-views-override.tsx
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-
+/** @jsx svg */
 import { Bounds, Hoverable, Selectable } from '@eclipse-glsp/protocol';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
@@ -27,9 +27,6 @@ import {
     DiamondNodeView as SprottyDiamondNodeView,
     svg
 } from 'sprotty';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class DiamondNodeView extends SprottyDiamondNodeView {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Refactor grind background image rendering to a css only approach
- Use @jsx annotion for view files Use @jsx annotation instead of const JSX definition for view files. Adapt eslint config to ignore  unused svg and html imports to avoid explict deactivation of the rule in each view file. Reason:
  - Sprotty base views also use annotations
   - Annotations are more robust. E.g. mocha tests with ts-node fail with an unused local error   when using JSX const

- Add tests for `initializeDiagramContainer`
- Cleanup GLSPProjectionView overrides

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
