### PR TITLE
Fix: Proper alignment of ghost element after update in continuous mode

### DIFF
--- a/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
+++ b/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
@@ -54,6 +54,7 @@ export class MouseTrackingElementPositionListener extends DragAwareMouseListener
         super();
         this.tracker = this.tool.changeBoundsManager.createTracker();
         this.moveGhostFeedback = this.tool.createFeedbackEmitter();
+        this.toDispose.push(this.moveGhostFeedback);
         const modelRootChangedListener = editorContext?.onModelRootChanged(newRoot => this.modelRootChanged(newRoot));
         if (modelRootChangedListener) {
             this.toDispose.push(modelRootChangedListener);
@@ -115,7 +116,6 @@ export class MouseTrackingElementPositionListener extends DragAwareMouseListener
     }
 
     override dispose(): void {
-        this.moveGhostFeedback.dispose();
         this.toDispose.dispose();
         super.dispose();
     }

--- a/packages/client/src/features/tools/node-creation/node-creation-tool.ts
+++ b/packages/client/src/features/tools/node-creation/node-creation-tool.ts
@@ -34,6 +34,7 @@ import {
 import { inject, injectable } from 'inversify';
 import '../../../../css/ghost-element.css';
 import { DragAwareMouseListener } from '../../../base/drag-aware-mouse-listener';
+import { EditorContextService } from '../../../base/editor-context-service';
 import { CSS_GHOST_ELEMENT, CSS_HIDDEN, CursorCSS, cursorFeedbackAction } from '../../../base/feedback/css-feedback';
 import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
 import { EnableDefaultToolsAction } from '../../../base/tool-manager/tool';
@@ -77,7 +78,8 @@ export class NodeCreationTool extends BaseCreationTool<TriggerNodeCreationAction
             getTemplateElementId(ghostElement.template),
             this.triggerAction.elementTypeId,
             this,
-            position
+            position,
+            this.editorContext
         );
         return new DisposableCollection(trackingListener, this.mouseTool.registerListener(trackingListener));
     }
@@ -101,9 +103,10 @@ export class NodeInsertTrackingListener extends MouseTrackingElementPositionList
         elementId: string,
         protected elementTypeId: string,
         protected override tool: ContainerPositioningTool,
-        cursorPosition: 'top-left' | 'middle' = 'top-left'
+        cursorPosition: 'top-left' | 'middle' = 'top-left',
+        editorContext?: EditorContextService
     ) {
-        super(elementId, tool, cursorPosition);
+        super(elementId, tool, cursorPosition, editorContext);
     }
 
     protected override addMoveFeedback(move: TrackedMove, ctx: GModelElement, event: MouseEvent): void {


### PR DESCRIPTION
#### What it does

When in stamp mode when you move the mouse while the creation of a node using ghost feedback is still on-going, you will see that the mouse cursor and the ghost feedback will get out of sync. The reason is that there are no mouse events for some time until the diagram is properly re-rendered. We therefore re-initialize tracking position once we have a new root element.

#### How to test

- Use Stamp mode (keep Ctrl pressed)
- Create a node, keep moving the mouse during creation
- Check if ghost element is properly aligned

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
