### PR TITLE
Revert "V2.2.0"

### DIFF
--- a/examples/workflow-glsp/package.json
+++ b/examples/workflow-glsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-glsp",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "GLSP diagrams for the Workflow DSL",
   "keywords": [
     "glsp",
@@ -40,7 +40,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "2.2.0",
+    "@eclipse-glsp/client": "2.2.0-next",
     "balloon-css": "^0.5.0"
   },
   "devDependencies": {

--- a/examples/workflow-glsp/src/direct-task-editing/direct-task-editor.ts
+++ b/examples/workflow-glsp/src/direct-task-editing/direct-task-editor.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/workflow-glsp/src/workflow-views.tsx
+++ b/examples/workflow-glsp/src/workflow-views.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/workflow-standalone/package.json
+++ b/examples/workflow-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-standalone",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "private": true,
   "description": "Standalone browser-app for the Workflow example",
   "homepage": "https://www.eclipse.org/glsp/",
@@ -32,8 +32,8 @@
     "watch:bundle": "webpack -w"
   },
   "dependencies": {
-    "@eclipse-glsp-examples/workflow-glsp": "2.2.0",
-    "@eclipse-glsp/client": "2.2.0",
+    "@eclipse-glsp-examples/workflow-glsp": "2.2.0-next",
+    "@eclipse-glsp/client": "2.2.0-next",
     "inversify-logger-middleware": "^3.1.0"
   },
   "devDependencies": {

--- a/examples/workflow-standalone/scripts/config.json
+++ b/examples/workflow-standalone/scripts/config.json
@@ -1,4 +1,4 @@
 {
   "fileName": "workflow-server",
-  "version": "2.2.0"
+  "version": "next"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.1.1",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -32,7 +32,7 @@
     "watch": "concurrently --kill-others -n tsc,standalone -c red,yellow \"tsc -b -w --preserveWatchOutput\" \"yarn -s standalone watch:bundle\""
   },
   "devDependencies": {
-    "@eclipse-glsp/dev": "2.2.0",
+    "@eclipse-glsp/dev": "next",
     "@types/lodash": "4.14.191",
     "@types/node": "16.x",
     "concurrently": "^8.2.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/client",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "A sprotty-based client for GLSP",
   "keywords": [
     "eclipse",
@@ -46,11 +46,11 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/sprotty": "2.2.0",
+    "@eclipse-glsp/sprotty": "2.2.0-next",
     "autocompleter": "^9.1.2",
     "file-saver": "^2.0.5",
-    "lodash": "4.17.21",
     "snabbdom": "~3.5.1",
+    "lodash": "4.17.21",
     "vscode-jsonrpc": "8.2.0"
   },
   "devDependencies": {

--- a/packages/client/src/base/auto-complete/base-autocomplete-palette.ts
+++ b/packages/client/src/base/auto-complete/base-autocomplete-palette.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/base/feedback/css-feedback.ts
+++ b/packages/client/src/base/feedback/css-feedback.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/base/model/model-registry.ts
+++ b/packages/client/src/base/model/model-registry.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/element-navigation/local-element-navigator.ts
+++ b/packages/client/src/features/accessibility/element-navigation/local-element-navigator.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut.ts
+++ b/packages/client/src/features/accessibility/key-shortcut/accessible-key-shortcut.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/keyboard-grid/keyboard-grid.ts
+++ b/packages/client/src/features/accessibility/keyboard-grid/keyboard-grid.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer-module.ts
+++ b/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer.ts
+++ b/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/keyboard-tool-palette/keyboard-tool-palette-module.ts
+++ b/packages/client/src/features/accessibility/keyboard-tool-palette/keyboard-tool-palette-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/keyboard-tool-palette/keyboard-tool-palette.ts
+++ b/packages/client/src/features/accessibility/keyboard-tool-palette/keyboard-tool-palette.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/move-zoom/move-zoom-module.ts
+++ b/packages/client/src/features/accessibility/move-zoom/move-zoom-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/resize-key-tool/resize-key-module.ts
+++ b/packages/client/src/features/accessibility/resize-key-tool/resize-key-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/search/search-palette-module.ts
+++ b/packages/client/src/features/accessibility/search/search-palette-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/toast/toast-tool.ts
+++ b/packages/client/src/features/accessibility/toast/toast-tool.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/accessibility/view-key-tools/view-key-tools-module.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/view-key-tools-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/bounds/bounds-module.ts
+++ b/packages/client/src/features/bounds/bounds-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/bounds/freeform-layout.ts
+++ b/packages/client/src/features/bounds/freeform-layout.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/bounds/hbox-layout.ts
+++ b/packages/client/src/features/bounds/hbox-layout.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/bounds/vbox-layout.ts
+++ b/packages/client/src/features/bounds/vbox-layout.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/change-bounds/point-position-updater.spec.ts
+++ b/packages/client/src/features/change-bounds/point-position-updater.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/change-bounds/point-position-updater.ts
+++ b/packages/client/src/features/change-bounds/point-position-updater.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/change-bounds/snap.ts
+++ b/packages/client/src/features/change-bounds/snap.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/context-menu/context-menu-module.ts
+++ b/packages/client/src/features/context-menu/context-menu-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/copy-paste/copy-paste-modules.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-modules.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/copy-paste/copy-paste-standalone.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-standalone.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/decoration/decoration-module.ts
+++ b/packages/client/src/features/decoration/decoration-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/element-template/element-template-module.ts
+++ b/packages/client/src/features/element-template/element-template-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/export/export-modules.ts
+++ b/packages/client/src/features/export/export-modules.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/export/glsp-svg-exporter.ts
+++ b/packages/client/src/features/export/glsp-svg-exporter.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/grid/grid-snapper.spec.ts
+++ b/packages/client/src/features/grid/grid-snapper.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/helper-lines/helper-line-module.ts
+++ b/packages/client/src/features/helper-lines/helper-line-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/helper-lines/model.ts
+++ b/packages/client/src/features/helper-lines/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/helper-lines/view.tsx
+++ b/packages/client/src/features/helper-lines/view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/hints/type-hints-module.ts
+++ b/packages/client/src/features/hints/type-hints-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/hover/hover-module.ts
+++ b/packages/client/src/features/hover/hover-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/label-edit/label-edit-module.ts
+++ b/packages/client/src/features/label-edit/label-edit-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/layout/layout-elements-action.ts
+++ b/packages/client/src/features/layout/layout-elements-action.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/layout/layout-module.ts
+++ b/packages/client/src/features/layout/layout-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/navigation/navigation-module.ts
+++ b/packages/client/src/features/navigation/navigation-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/routing/routing-module.ts
+++ b/packages/client/src/features/routing/routing-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/save/save-module.ts
+++ b/packages/client/src/features/save/save-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/select/select-module.ts
+++ b/packages/client/src/features/select/select-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/source-model-watcher/source-model-watcher-module.ts
+++ b/packages/client/src/features/source-model-watcher/source-model-watcher-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/status/status-module.ts
+++ b/packages/client/src/features/status/status-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/status/status-overlay.ts
+++ b/packages/client/src/features/status/status-overlay.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/svg-metadata/svg-metadata-module.ts
+++ b/packages/client/src/features/svg-metadata/svg-metadata-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tool-palette/tool-palette-module.ts
+++ b/packages/client/src/features/tool-palette/tool-palette-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/deletion/delete-tool.ts
+++ b/packages/client/src/features/tools/deletion/delete-tool.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/deletion/deletion-tool-module.ts
+++ b/packages/client/src/features/tools/deletion/deletion-tool-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/edge-creation/edege-creation-module.ts
+++ b/packages/client/src/features/tools/edge-creation/edege-creation-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/edge-creation/view.tsx
+++ b/packages/client/src/features/tools/edge-creation/view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/edge-edit/edge-edit-module.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/marquee-selection/marquee-behavior.spec.ts
+++ b/packages/client/src/features/tools/marquee-selection/marquee-behavior.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/marquee-selection/marquee-behavior.ts
+++ b/packages/client/src/features/tools/marquee-selection/marquee-behavior.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/marquee-selection/marquee-selection-module.ts
+++ b/packages/client/src/features/tools/marquee-selection/marquee-selection-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/marquee-selection/view.tsx
+++ b/packages/client/src/features/tools/marquee-selection/view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/tool-focus-loss-module.ts
+++ b/packages/client/src/features/tools/tool-focus-loss-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/validation/issue-marker.ts
+++ b/packages/client/src/features/validation/issue-marker.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/validation/marker-navigator.ts
+++ b/packages/client/src/features/validation/marker-navigator.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/validation/validation-modules.ts
+++ b/packages/client/src/features/validation/validation-modules.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/viewport/reposition.ts
+++ b/packages/client/src/features/viewport/reposition.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/viewport/viewport-modules.ts
+++ b/packages/client/src/features/viewport/viewport-modules.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/standalone-modules.ts
+++ b/packages/client/src/standalone-modules.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/utils/geometry-util.ts
+++ b/packages/client/src/utils/geometry-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/utils/layout-utils.ts
+++ b/packages/client/src/utils/layout-utils.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/utils/viewpoint-util.ts
+++ b/packages/client/src/utils/viewpoint-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/views/base-view-module.ts
+++ b/packages/client/src/views/base-view-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/views/compartments.tsx
+++ b/packages/client/src/views/compartments.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/views/gedge-view.tsx
+++ b/packages/client/src/views/gedge-view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/views/issue-marker-view.tsx
+++ b/packages/client/src/views/issue-marker-view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2024 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/views/rounded-corner-view.tsx
+++ b/packages/client/src/views/rounded-corner-view.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/glsp-sprotty/package.json
+++ b/packages/glsp-sprotty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/sprotty",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Augmented reexport of the sprotty API for GLSP",
   "homepage": "https://www.eclipse.org/glsp/",
   "bugs": "https://github.com/eclipse-glsp/glsp/issues",
@@ -33,7 +33,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/protocol": "2.2.0",
+    "@eclipse-glsp/protocol": "2.2.0-next",
     "autocompleter": "^9.1.0",
     "snabbdom": "~3.5.1",
     "sprotty": "1.2.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/protocol",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "The protocol definition for client-server communication in GLSP",
   "keywords": [
     "eclipse",

--- a/packages/protocol/src/action-protocol/types.ts
+++ b/packages/protocol/src/action-protocol/types.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 STMicroelectronics and others.
+ * Copyright (c) 2021-2023 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/client-server-protocol/jsonrpc/worker-connection-provider.ts
+++ b/packages/protocol/src/client-server-protocol/jsonrpc/worker-connection-provider.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/re-exports.ts
+++ b/packages/protocol/src/re-exports.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/utils/array-util.ts
+++ b/packages/protocol/src/utils/array-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/utils/disposable.ts
+++ b/packages/protocol/src/utils/disposable.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/utils/type-util.ts
+++ b/packages/protocol/src/utils/type-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2024 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,10 +214,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eclipse-glsp/cli@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.2.0.tgz#1f9659c2ee05739d167f1c40ab79c689e56967d6"
-  integrity sha512-bR/Wb3cvJRA1LcghYEJAG9PB3Dc4NLYrl75lCmjsyWzl8RXoxKfTTCgFoCmFRZdxtkufMr3kQZirnRCyjeVl6w==
+"@eclipse-glsp/cli@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.2.0-next.c32aadb.160.tgz#1171b21aec7bddfcc73e68cc41d0b9dcb199c258"
+  integrity sha512-Clw0YKkMg41vQnd3UY9quIConKdQoQ98+dp15ouKps5yG8l3xpmjCC44V10N4LJ5l2Jmol6UTJfPGmA9FyrGdw==
   dependencies:
     commander "^10.0.1"
     glob "^10.3.10"
@@ -228,13 +228,13 @@
     semver "^7.5.1"
     shelljs "^0.8.5"
 
-"@eclipse-glsp/config-test@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.2.0.tgz#a4e108463a98ee5be2946682ff2624f36a073ce1"
-  integrity sha512-rRzZUNsT8p9vkGWqfaHNZg+4x7oIYfMfPP40BUx4lktch+riETkGdsdtecWs9K8TYOLx+SWSaq6hfyZl3832Dw==
+"@eclipse-glsp/config-test@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.2.0-next.c32aadb.160.tgz#30f409221024544604f5030caf092ac89d22867d"
+  integrity sha512-STBp0y+SmvpWz+D8wdyiVMelE7jFAGVxicFekalmoNaDO3pUSR3QmuxGHsSwWQ3qOB30vic4eMc3rSMrR4dABw==
   dependencies:
-    "@eclipse-glsp/mocha-config" "2.2.0"
-    "@eclipse-glsp/nyc-config" "2.2.0"
+    "@eclipse-glsp/mocha-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/nyc-config" "2.2.0-next.c32aadb.160+c32aadb"
     "@istanbuljs/nyc-config-typescript" "^1.0.2"
     "@types/chai" "^4.3.7"
     "@types/mocha" "^10.0.2"
@@ -248,14 +248,14 @@
     sinon "^15.1.0"
     ts-node "^10.9.1"
 
-"@eclipse-glsp/config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.2.0.tgz#a55d7bd482e749e036ea4806aa3b6c3bf34a6225"
-  integrity sha512-tEPoYKxlL/8gSoS4B16H51JqzHGhdvDGvhOvu/iefwcuOGM7ZVSR4YzJjSFZjDQfsMPXtKXKFZqT2lizD283iA==
+"@eclipse-glsp/config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.2.0-next.c32aadb.160.tgz#5e0c25ef98f2aad44de9cb3de1cb8c2523543835"
+  integrity sha512-rFpykLbc3VC+Nx9iR5dOQUGU9FXYOrxC8qnOOBt+ou+xkSvdDTUYHKC4QKmXRZbiVnhfpbj7CIauBoU2XxineA==
   dependencies:
-    "@eclipse-glsp/eslint-config" "2.2.0"
-    "@eclipse-glsp/prettier-config" "2.2.0"
-    "@eclipse-glsp/ts-config" "2.2.0"
+    "@eclipse-glsp/eslint-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/prettier-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/ts-config" "2.2.0-next.c32aadb.160+c32aadb"
     "@typescript-eslint/eslint-plugin" "^6.7.5"
     "@typescript-eslint/parser" "^6.7.5"
     eslint "^8.51.0"
@@ -269,41 +269,41 @@
     reflect-metadata "^0.1.13"
     rimraf "^5.0.5"
 
-"@eclipse-glsp/dev@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.2.0.tgz#cf745fe50c58a2036da07c92880f23a2336cdc7c"
-  integrity sha512-xXDHdS15ADqvc9iWoPlM78qNUKrVUyMAeiBOZHKcbMWNdqx6kg8w3oUNAmm2C896T8KHrdSLP5meGS2KChjY+g==
+"@eclipse-glsp/dev@next":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.2.0-next.c32aadb.160.tgz#d67cdceed91cb779e9495d06b6b4c7106541bc4f"
+  integrity sha512-ns0jJBxcW3qkzx8RV8JB/YYHOrK/9OXy7qrvhNabqAPRTpzn5ovp2kv7rZd97JGMPenq+2iSgbcY39eqq4zAHg==
   dependencies:
-    "@eclipse-glsp/cli" "2.2.0"
-    "@eclipse-glsp/config" "2.2.0"
-    "@eclipse-glsp/config-test" "2.2.0"
+    "@eclipse-glsp/cli" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/config-test" "2.2.0-next.c32aadb.160+c32aadb"
 
-"@eclipse-glsp/eslint-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.2.0.tgz#c98deff84bf2b7c368fd1d1ed6d232037fc1cf06"
-  integrity sha512-3zbBM3su+iKLwxHoTML6N3/y3MxRtQmDgxyNu4sR9LbBLZshiqd4kUeLFCAzFSznwe+5btbRabClv8pR33FTNQ==
+"@eclipse-glsp/eslint-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.2.0-next.c32aadb.160.tgz#40a2f916d662b5bd5eefac469214b2e74ba8d28c"
+  integrity sha512-BDYLSB9lkgGmwA2fPB8OjnZTD4r48AHWAYSwkFdy/1RwJxL/F8fWlfWu6c8o5AVuNyMkrqedtmfdehSZA01u7A==
 
-"@eclipse-glsp/mocha-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.2.0.tgz#77ab2664ea978db3400c0669ab5114417c1814e0"
-  integrity sha512-Vr9wEuYsTdV7ES0+G43yzSdZzpWn738W8LjSPySjpnrTHVABAB7b3Ba9ITd74Y/pdQXsL+6R47dEV1yoSIu/9A==
+"@eclipse-glsp/mocha-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.2.0-next.c32aadb.160.tgz#c440d499ced653d342dcb39c52944e03b879ec40"
+  integrity sha512-n3T212zAl5oKMGQM1V8L/GvDsZwyIDdZAVh25yHjh0hFgVfraaGqzvGPTZxlKmJBuD0++6LH9FDhUNcNhMllHQ==
 
-"@eclipse-glsp/nyc-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.2.0.tgz#3f62f6a1c13931b88ebe916d29eda6b2d9c58895"
-  integrity sha512-msBjz00ytdrAigloUtrJBY1pHm2Ugkeqi3ccJrkgxM164YZ/9iQrKCV0iUy9SoydbYCVFF0EtA4aH1jHVIrsbg==
+"@eclipse-glsp/nyc-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.2.0-next.c32aadb.160.tgz#9f84da72015c90aa2beb1394e14643f353a16158"
+  integrity sha512-m00F5RLly63TNDe76pW2yk/BLGKWpoD+qvga7ZSVDf2KPpdjf2cBjw2ei816H+Avl1TI+ufauQO8NdRu5O5Vuw==
 
-"@eclipse-glsp/prettier-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.2.0.tgz#76c686ea5f829d54f9cccc4d73eb097efe721dba"
-  integrity sha512-5FozTM0xUe0E/k2bqz1D0lPj4waAQyttSMmKIpNH1GwG8eS6lveAtPOuxhCNCR4vNCmhCDtazy+lCGmaKmlJcA==
+"@eclipse-glsp/prettier-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.2.0-next.c32aadb.160.tgz#c4e019dbbafd04483cc7916f25c8b3a151f7d916"
+  integrity sha512-xqfSe+UMS4p5WGimZnX5iIm1AX+x1CAAippobgogGRnbA5RBsUdOh/odFgfRcme6/IfyFWj5m4IY7IHlFPZwCw==
   dependencies:
     prettier-plugin-packagejson "~2.4.6"
 
-"@eclipse-glsp/ts-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.2.0.tgz#f08b683e9cc265280cd037965e35824b9a2df709"
-  integrity sha512-U2eD3kdKICK7OQXObLeMsrd80o+eHSIjss0HiUZjF7NQxsrNX9p04rJjEpO4HPrInUQPmpxsw3HVwk3mgo1mew==
+"@eclipse-glsp/ts-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.2.0-next.c32aadb.160.tgz#d660cd736056a91c0c79fb2076835073ad12d7b9"
+  integrity sha512-05D85X5tUY/M23rTDs1b9MfF+YbV7j97rTFss5PHad7YI2DOByqMGRxaoPI+xzyoQUUAHTxKekGb5KbE8douDQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"


### PR DESCRIPTION
Reverts eclipse-glsp/glsp-client#376
Due to a bug discovered during the release process its necessary to revert the currently ongoing 2.2.0 release.
Already published artifacts will be removed/ unpublished
and a clean 2.2.1 release will be published