### PR TITLE
GLSP-1369: Update example1.wf

### DIFF
--- a/examples/workflow-standalone/app/example1.wf
+++ b/examples/workflow-standalone/app/example1.wf
@@ -6,7 +6,7 @@
     "y": 0
   },
   "id": "sprotty",
-  "revision": 14,
+  "revision": 1,
   "children": [
     {
       "cssClasses": [
@@ -14,7 +14,7 @@
         "automated"
       ],
       "type": "task:automated",
-      "id": "b300bdb8-52c3-4903-ba09-36dff9b281fd",
+      "id": "task_ChkTp",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -26,7 +26,7 @@
         "x": 220,
         "y": 150
       },
-      "name": "AutomatedTask8",
+      "name": "ChkTp",
       "taskType": "automated",
       "layoutOptions": {
         "paddingRight": 10,
@@ -41,7 +41,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "b300bdb8-52c3-4903-ba09-36dff9b281fd_icon",
+          "id": "task_ChkTp_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -59,7 +59,7 @@
             "x": 20.6171875,
             "y": 13
           },
-          "id": "b300bdb8-52c3-4903-ba09-36dff9b281fd_classname",
+          "id": "task_ChkTp_label",
           "text": "ChkTp",
           "position": {
             "x": 31,
@@ -79,7 +79,7 @@
         "manual"
       ],
       "type": "task:manual",
-      "id": "3a083ea5-5d82-4942-8bb4-3c0c27e9a71d",
+      "id": "task_Push",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -91,7 +91,7 @@
         "x": 70,
         "y": 100
       },
-      "name": "ManualTask9",
+      "name": "Push",
       "taskType": "manual",
       "layoutOptions": {
         "paddingRight": 10,
@@ -106,7 +106,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "3a083ea5-5d82-4942-8bb4-3c0c27e9a71d_icon",
+          "id": "task_Push_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -124,7 +124,7 @@
             "x": 15.9609375,
             "y": 13
           },
-          "id": "task0",
+          "id": "task_Push_label",
           "text": "Push",
           "position": {
             "x": 31,
@@ -143,7 +143,7 @@
         "forkOrJoin"
       ],
       "type": "activityNode:fork",
-      "id": "16c7860a-c38b-4761-bb48-baa92113478b",
+      "id": "fork_1",
       "position": {
         "x": 170,
         "y": 90
@@ -159,18 +159,18 @@
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "a8ffb72a-a632-4133-a55f-95e4df297875",
-      "sourceId": "3a083ea5-5d82-4942-8bb4-3c0c27e9a71d",
-      "targetId": "16c7860a-c38b-4761-bb48-baa92113478b",
+      "id": "edge_task_Push_fork_1",
+      "sourceId": "task_Push",
+      "targetId": "fork_1",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "d6fa4391-4139-4789-bd00-4c7509e5d4e1",
-      "sourceId": "16c7860a-c38b-4761-bb48-baa92113478b",
-      "targetId": "b300bdb8-52c3-4903-ba09-36dff9b281fd",
+      "id": "edge_fork1_task_ChkTp",
+      "sourceId": "fork_1",
+      "targetId": "task_ChkTp",
       "children": []
     },
     {
@@ -179,7 +179,7 @@
         "automated"
       ],
       "type": "task:automated",
-      "id": "5496d85e-104c-47a8-bfe6-75211dbf5ae1",
+      "id": "task_ChkWt",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -191,7 +191,7 @@
         "x": 220,
         "y": 50
       },
-      "name": "AutomatedTask10",
+      "name": "ChkWt",
       "taskType": "automated",
       "layoutOptions": {
         "paddingRight": 10,
@@ -206,7 +206,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "5496d85e-104c-47a8-bfe6-75211dbf5ae1_icon",
+          "id": "task_ChkWt_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -224,7 +224,7 @@
             "x": 21,
             "y": 13
           },
-          "id": "task0_automated",
+          "id": "task_ChkWt_label",
           "text": "ChkWt",
           "position": {
             "x": 31,
@@ -243,7 +243,7 @@
         "decision"
       ],
       "type": "activityNode:decision",
-      "id": "304abdb7-a8b3-4035-b73e-45cc611dd4c3",
+      "id": "decision_1",
       "position": {
         "x": 330,
         "y": 50
@@ -266,7 +266,7 @@
         "decision"
       ],
       "type": "activityNode:decision",
-      "id": "44cdab45-7480-4f67-850b-75d0bc2f22c4",
+      "id": "decision2",
       "position": {
         "x": 330,
         "y": 150
@@ -288,27 +288,27 @@
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "ea94aeb9-c86f-42b2-94c6-4cc91d34a883",
-      "sourceId": "5496d85e-104c-47a8-bfe6-75211dbf5ae1",
-      "targetId": "304abdb7-a8b3-4035-b73e-45cc611dd4c3",
+      "id": "edge_task_ChkWt_decision1",
+      "sourceId": "task_ChkWt",
+      "targetId": "decision_1",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "d7b69577-d35f-4e3b-b306-86e3f0b7008e",
-      "sourceId": "16c7860a-c38b-4761-bb48-baa92113478b",
-      "targetId": "5496d85e-104c-47a8-bfe6-75211dbf5ae1",
+      "id": "edge_fork1_task_ChkWt",
+      "sourceId": "fork_1",
+      "targetId": "task_ChkWt",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "5cb74a75-9676-4db4-a088-13d467234c19",
-      "sourceId": "b300bdb8-52c3-4903-ba09-36dff9b281fd",
-      "targetId": "44cdab45-7480-4f67-850b-75d0bc2f22c4",
+      "id": "edge_task_ChkTp_decision2",
+      "sourceId": "task_ChkTp",
+      "targetId": "decision2",
       "children": []
     },
     {
@@ -317,7 +317,7 @@
         "automated"
       ],
       "type": "task:automated",
-      "id": "ab6e230a-33e6-4a0c-a08b-c0930767a437",
+      "id": "task_PreHeat",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -329,7 +329,7 @@
         "x": 390,
         "y": 180
       },
-      "name": "AutomatedTask11",
+      "name": "PreHeat",
       "taskType": "automated",
       "layoutOptions": {
         "paddingRight": 10,
@@ -344,7 +344,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "ab6e230a-33e6-4a0c-a08b-c0930767a437_icon",
+          "id": "task_PreHeat_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -362,7 +362,7 @@
             "x": 25.6796875,
             "y": 13
           },
-          "id": "ab6e230a-33e6-4a0c-a08b-c0930767a437_classname",
+          "id": "task_PreHeat_label",
           "text": "PreHeat",
           "position": {
             "x": 31,
@@ -382,7 +382,7 @@
         "automated"
       ],
       "type": "task:automated",
-      "id": "8360c168-8f25-438a-a213-d5a84e9ae4cd",
+      "id": "task_KeepTp",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -394,7 +394,7 @@
         "x": 390,
         "y": 130
       },
-      "name": "AutomatedTask12",
+      "name": "KeepTp",
       "taskType": "automated",
       "layoutOptions": {
         "paddingRight": 10,
@@ -409,7 +409,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "8360c168-8f25-438a-a213-d5a84e9ae4cd_icon",
+          "id": "task_KeepTp_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -427,7 +427,7 @@
             "x": 24.5234375,
             "y": 13
           },
-          "id": "8360c168-8f25-438a-a213-d5a84e9ae4cd_classname",
+          "id": "task_KeepTp_label",
           "text": "KeepTp",
           "position": {
             "x": 31,
@@ -447,7 +447,7 @@
         "manual"
       ],
       "type": "task:manual",
-      "id": "ef349859-2a89-46b0-b394-c339a79c10e3",
+      "id": "task_RflWt",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -457,9 +457,9 @@
       },
       "position": {
         "x": 390,
-        "y": 30
+        "y": 20
       },
-      "name": "ManualTask13",
+      "name": "RflWt",
       "taskType": "manual",
       "layoutOptions": {
         "paddingRight": 10,
@@ -474,7 +474,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "ef349859-2a89-46b0-b394-c339a79c10e3_icon",
+          "id": "task_RflWt_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -492,7 +492,7 @@
             "x": 17.109375,
             "y": 13
           },
-          "id": "ef349859-2a89-46b0-b394-c339a79c10e3_classname",
+          "id": "task_RflWt_label",
           "text": "RflWt",
           "position": {
             "x": 31,
@@ -512,7 +512,7 @@
         "automated"
       ],
       "type": "task:automated",
-      "id": "da626312-7545-4b15-a502-766ab2da1e65",
+      "id": "task_WtOK",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -524,7 +524,7 @@
         "x": 390,
         "y": 80
       },
-      "name": "AutomatedTask14",
+      "name": "WtOK",
       "taskType": "automated",
       "layoutOptions": {
         "paddingRight": 10,
@@ -539,7 +539,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "da626312-7545-4b15-a502-766ab2da1e65_icon",
+          "id": "task_WtOK_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -557,7 +557,7 @@
             "x": 18.671875,
             "y": 13
           },
-          "id": "da626312-7545-4b15-a502-766ab2da1e65_classname",
+          "id": "task_WtOK_label",
           "text": "WtOK",
           "position": {
             "x": 31,
@@ -577,9 +577,9 @@
       ],
       "type": "edge:weighted",
       "routingPoints": [],
-      "id": "b42e5b46-38c8-4a8b-a75c-34e7b503b123",
-      "sourceId": "304abdb7-a8b3-4035-b73e-45cc611dd4c3",
-      "targetId": "ef349859-2a89-46b0-b394-c339a79c10e3",
+      "id": "edge_decision1_task_RflWt",
+      "sourceId": "decision_1",
+      "targetId": "task_RflWt",
       "probability": "medium",
       "children": []
     },
@@ -589,9 +589,9 @@
       ],
       "type": "edge:weighted",
       "routingPoints": [],
-      "id": "254aa972-f692-4e71-ba47-69dd564146e6",
-      "sourceId": "304abdb7-a8b3-4035-b73e-45cc611dd4c3",
-      "targetId": "da626312-7545-4b15-a502-766ab2da1e65",
+      "id": "edge_decision_1_task_WtOK",
+      "sourceId": "decision_1",
+      "targetId": "task_WtOK",
       "probability": "medium",
       "children": []
     },
@@ -601,9 +601,9 @@
       ],
       "type": "edge:weighted",
       "routingPoints": [],
-      "id": "b65bb287-ba47-4c2c-9714-0fa61345e891",
-      "sourceId": "44cdab45-7480-4f67-850b-75d0bc2f22c4",
-      "targetId": "8360c168-8f25-438a-a213-d5a84e9ae4cd",
+      "id": "edege_decision_2_task_KeepTp",
+      "sourceId": "decision2",
+      "targetId": "task_KeepTp",
       "probability": "medium",
       "children": []
     },
@@ -613,9 +613,9 @@
       ],
       "type": "edge:weighted",
       "routingPoints": [],
-      "id": "c3fd1ee7-d8df-4ba2-9741-95cca3d6f268",
-      "sourceId": "44cdab45-7480-4f67-850b-75d0bc2f22c4",
-      "targetId": "ab6e230a-33e6-4a0c-a08b-c0930767a437",
+      "id": "edege_decision2_task_PreHeat",
+      "sourceId": "decision2",
+      "targetId": "task_PreHeat",
       "probability": "medium",
       "children": []
     },
@@ -624,7 +624,7 @@
         "forkOrJoin"
       ],
       "type": "activityNode:join",
-      "id": "8668b502-0a10-4f32-b751-97dbaa4f5372",
+      "id": "join_1",
       "position": {
         "x": 560,
         "y": 90
@@ -642,7 +642,7 @@
         "automated"
       ],
       "type": "task:automated",
-      "id": "532ff124-9e72-4335-9e2b-423a544f1318",
+      "id": "task_Brew",
       "layout": "hbox",
       "args": {
         "radiusTopLeft": 5,
@@ -654,7 +654,7 @@
         "x": 600,
         "y": 100
       },
-      "name": "AutomatedTask15",
+      "name": "Brew",
       "taskType": "automated",
       "layoutOptions": {
         "paddingRight": 10,
@@ -669,7 +669,7 @@
         {
           "cssClasses": [],
           "type": "icon",
-          "id": "532ff124-9e72-4335-9e2b-423a544f1318_icon",
+          "id": "task_Brew_icon",
           "position": {
             "x": 5,
             "y": 5
@@ -687,7 +687,7 @@
             "x": 15.953125,
             "y": 13
           },
-          "id": "532ff124-9e72-4335-9e2b-423a544f1318_classname",
+          "id": "task_Brew_label",
           "text": "Brew",
           "position": {
             "x": 31,
@@ -706,7 +706,7 @@
         "merge"
       ],
       "type": "activityNode:merge",
-      "id": "ba5ec10f-1aed-458f-a5a5-eb30b127f4b6",
+      "id": "merge_1",
       "position": {
         "x": 500,
         "y": 50
@@ -729,7 +729,7 @@
         "merge"
       ],
       "type": "activityNode:merge",
-      "id": "55be52aa-fb5d-4f5c-8cdf-05c17cd9a1e3",
+      "id": "merge_2",
       "position": {
         "x": 500,
         "y": 150
@@ -751,63 +751,63 @@
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "7b660e4a-c5cf-4746-91d6-5a7e732008de",
-      "sourceId": "ef349859-2a89-46b0-b394-c339a79c10e3",
-      "targetId": "ba5ec10f-1aed-458f-a5a5-eb30b127f4b6",
+      "id": "edge_task_RflWt_merge_1",
+      "sourceId": "task_RflWt",
+      "targetId": "merge_1",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "2a0ddf8c-fb98-4432-9844-e9189ba2fa6c",
-      "sourceId": "da626312-7545-4b15-a502-766ab2da1e65",
-      "targetId": "ba5ec10f-1aed-458f-a5a5-eb30b127f4b6",
+      "id": "edge_task_WTOK_merge_1",
+      "sourceId": "task_WtOK",
+      "targetId": "merge_1",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "58114c96-6558-4b46-9d91-a480e3f9c3cd",
-      "sourceId": "8360c168-8f25-438a-a213-d5a84e9ae4cd",
-      "targetId": "55be52aa-fb5d-4f5c-8cdf-05c17cd9a1e3",
+      "id": "edge_task_KeepTp_merge_2",
+      "sourceId": "task_KeepTp",
+      "targetId": "merge_2",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "7633af04-0cf0-4267-a681-646123270d54",
-      "sourceId": "ab6e230a-33e6-4a0c-a08b-c0930767a437",
-      "targetId": "55be52aa-fb5d-4f5c-8cdf-05c17cd9a1e3",
+      "id": "edege_task_PreHeat_merge_2",
+      "sourceId": "task_PreHeat",
+      "targetId": "merge_2",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "9ddef18e-ba9a-40a3-8961-eaee5ab0007f",
-      "sourceId": "55be52aa-fb5d-4f5c-8cdf-05c17cd9a1e3",
-      "targetId": "8668b502-0a10-4f32-b751-97dbaa4f5372",
+      "id": "edge_merge_2_join_1",
+      "sourceId": "merge_2",
+      "targetId": "join_1",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "191fea84-e6a7-4ad6-94ee-a8e939a5058d",
-      "sourceId": "ba5ec10f-1aed-458f-a5a5-eb30b127f4b6",
-      "targetId": "8668b502-0a10-4f32-b751-97dbaa4f5372",
+      "id": "edge_merge_1_join_1",
+      "sourceId": "merge_1",
+      "targetId": "join_1",
       "children": []
     },
     {
       "cssClasses": [],
       "type": "edge",
       "routingPoints": [],
-      "id": "c8fe1b1c-54fd-4bcd-b194-acc02299a0ed",
-      "sourceId": "8668b502-0a10-4f32-b751-97dbaa4f5372",
-      "targetId": "532ff124-9e72-4335-9e2b-423a544f1318",
+      "id": "edge_join_1_task_Brew",
+      "sourceId": "join_1",
+      "targetId": "task_Brew",
       "children": []
     }
   ]


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Update example1.wf file to consistently use easy human readable ids to fix currently failing playwright tests and make testing overall easier
- Update `DeselectKeyListener`. Remove condition to check for active resize handles. Resize handles are now longer reseteted on default tool activatin/focus switch. As a consequence the `DeselectKeyListener` no longer has to consider them and can just always trigger deselection

Part of https://github.com/eclipse-glsp/glsp/issues/1369


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
