### PR TITLE
GLSP-1371: Introduce event for focus changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   [diagram] Update to sprotty 1.2.0. Non-breaking as all potential API breaks have been mitigated via the glsp-sprotty rexport layer [#357](https://github.com/eclipse-glsp/glsp-client/pull/357)
 -   [diagram] Fix a bug with the `AutocompleteWidget` that prevented proper application of valid suggestions [#362](https://github.com/eclipse-glsp/glsp-client/pull/362)
 -   [api] Improved behavior of default `ToolManager` to avoid unnecessary deactivation and reactivation of default tools [#367](https://github.com/eclipse-glsp/glsp-client/pull/367)
+-   [diagram] Add `onFocusChanged` event to `FocusTracker` and `EditorContextService` [#380](https://github.com/eclipse-glsp/glsp-client/pull/380)
 
 ### Potentially breaking changes
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "examples/*"
   ],
   "scripts": {
-    "all": "yarn install && yarn lint && yarn test",
+    "all": "yarn clean && yarn install && yarn lint && yarn test",
     "build": "yarn compile && yarn bundle",
     "bundle": "yarn standalone bundle",
     "check:headers": "glsp checkHeaders . -t lastCommit",

--- a/packages/client/src/base/editor-context-service.ts
+++ b/packages/client/src/base/editor-context-service.ts
@@ -37,8 +37,9 @@ import {
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 import { GLSPActionDispatcher } from './action-dispatcher';
+import { FocusChange, FocusTracker } from './focus/focus-tracker';
 import { IDiagramOptions, IDiagramStartup } from './model/diagram-loader';
-import { SelectionService } from './selection-service';
+import { SelectionChange, SelectionService } from './selection-service';
 
 /**
  * A hook to listen for model root changes. Will be called after a server update
@@ -91,22 +92,50 @@ export class EditorContextService implements IActionHandler, Disposable, IDiagra
     @inject(GLSPActionDispatcher)
     protected actionDispatcher: GLSPActionDispatcher;
 
+    @inject(FocusTracker)
+    protected focusTracker: FocusTracker;
+
     protected _editMode: string;
     protected onEditModeChangedEmitter = new Emitter<ValueChange<string>>();
+    /**
+     * Event that is fired when the edit mode of the diagram changes i.e. after a {@link SetEditModeAction} has been handled.
+     */
     get onEditModeChanged(): Event<ValueChange<string>> {
         return this.onEditModeChangedEmitter.event;
     }
 
     protected _isDirty: boolean;
     protected onDirtyStateChangedEmitter = new Emitter<DirtyStateChange>();
+    /**
+     * Event that is fired when the dirty state of the diagram changes i.e. after a {@link SetDirtyStateAction} has been handled.
+     */
     get onDirtyStateChanged(): Event<DirtyStateChange> {
         return this.onDirtyStateChangedEmitter.event;
     }
 
     protected _modelRoot?: Readonly<GModelRoot>;
+    /**
+     * Event that is fired when the model root of the diagram changes i.e. after the `CommandStack` has processed a model update.
+     */
     protected onModelRootChangedEmitter = new Emitter<Readonly<GModelRoot>>();
     get onModelRootChanged(): Event<Readonly<GModelRoot>> {
         return this.onModelRootChangedEmitter.event;
+    }
+
+    /**
+     * Event that is fired when the focus state of the diagram changes i.e. after a {@link FocusStateChangedAction} has been handled
+     * by the {@link FocusTracker}.
+     */
+    get onFocusChanged(): Event<FocusChange> {
+        return this.focusTracker.onFocusChanged;
+    }
+
+    /**
+     * Event that is fired when the selection of the diagram changes i.e. a selection change has been handled
+     * by the {@link SelectionService}.
+     */
+    get onSelectionChanged(): Event<SelectionChange> {
+        return this.selectionService.onSelectionChanged;
     }
 
     protected toDispose = new DisposableCollection();

--- a/packages/client/src/base/focus/focus-tracker.ts
+++ b/packages/client/src/base/focus/focus-tracker.ts
@@ -13,10 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Action, Emitter, Event, IActionHandler, ICommand, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { Action, IActionHandler, ICommand, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
 import { FocusStateChangedAction } from './focus-state-change-action';
 
+export interface FocusChange {
+    hasFocus: boolean;
+    focusElement: HTMLOrSVGElement | null;
+    diagramElement: HTMLElement | null;
+}
+
+/**
+ * Tracks the focus state of the diagram by handling {@link FocusStateChangedAction}s.
+ * Emits a {@link FocusChange} event when the focus state changes.
+ * Allows querying of the current focus state and the focused root diagram element and the currently focused element within the diagram.
+ */
 @injectable()
 export class FocusTracker implements IActionHandler {
     protected inActiveCssClass = 'inactive';
@@ -25,6 +36,14 @@ export class FocusTracker implements IActionHandler {
     protected _diagramElement: HTMLElement | null;
 
     @inject(TYPES.ViewerOptions) protected options: ViewerOptions;
+
+    protected onFocusChangedEmitter = new Emitter<FocusChange>();
+    /**
+     * Event that is fired when the focus state of the diagram changes i.e. after a {@link FocusStateChangedAction} has been handled.
+     */
+    get onFocusChanged(): Event<FocusChange> {
+        return this.onFocusChangedEmitter.event;
+    }
 
     get hasFocus(): boolean {
         return this._hasFocus;
@@ -39,20 +58,23 @@ export class FocusTracker implements IActionHandler {
     }
 
     handle(action: Action): void | Action | ICommand {
-        if (FocusStateChangedAction.is(action)) {
-            this._hasFocus = action.hasFocus;
-            this._focusElement = document.activeElement as HTMLOrSVGElement | null;
-            this._diagramElement = document.getElementById(this.options.baseDiv);
-            if (!this._diagramElement) {
-                return;
-            }
-            if (this.hasFocus) {
-                if (this._diagramElement.classList.contains(this.inActiveCssClass)) {
-                    this._diagramElement.classList.remove(this.inActiveCssClass);
-                }
-            } else {
-                this._diagramElement.classList.add(this.inActiveCssClass);
-            }
+        if (!FocusStateChangedAction.is(action)) {
+            return;
         }
+
+        this._hasFocus = action.hasFocus;
+        this._focusElement = document.activeElement as HTMLOrSVGElement | null;
+        this._diagramElement = document.getElementById(this.options.baseDiv);
+        if (!this._diagramElement) {
+            return;
+        }
+        if (this.hasFocus) {
+            if (this._diagramElement.classList.contains(this.inActiveCssClass)) {
+                this._diagramElement.classList.remove(this.inActiveCssClass);
+            }
+        } else {
+            this._diagramElement.classList.add(this.inActiveCssClass);
+        }
+        this.onFocusChangedEmitter.fire({ hasFocus: this.hasFocus, focusElement: this.focusElement, diagramElement: this.diagramElement });
     }
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Add `onFocusChanged` event to focus tracker and also expose it via EditorContextService
- Update documentation on `EditorContextService`. Also expose `onSelectionChanged` event via `EditorContextService` => `EditorContextService` becomes the central component to register for (most) GLSP event listeners https://github.com/eclipse-glsp/glsp/issues/1371

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
