### PR TITLE
Ensure no inversify-based code lands in the index

### DIFF
--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -14,11 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { JsonrpcClientProxy } from '@eclipse-glsp/protocol';
+import { decorate, injectable } from 'inversify';
+
 /**
  * @eclipse-glsp/protocol
  */
 export * from '@eclipse-glsp/protocol';
 export * from '@eclipse-glsp/protocol/lib/di';
+decorate(injectable(), JsonrpcClientProxy);
 
 /*
  * sprotty
@@ -31,8 +35,8 @@ export * from 'sprotty/lib/base/actions/action-dispatcher';
 export {
     ActionHandlerRegistration,
     ActionHandlerRegistry,
-    IActionHandlerInitializer,
     configureActionHandler,
+    IActionHandlerInitializer,
     onAction
 } from 'sprotty/lib/base/actions/action-handler';
 export * from 'sprotty/lib/base/actions/diagram-locker';
@@ -50,18 +54,19 @@ export * from 'sprotty/lib/base/features/initialize-canvas';
 export * from 'sprotty/lib/base/features/set-model';
 // Exclude SModelElementImpl as it as exported with augmentation module
 export {
+    createRandomId,
     FeatureSet,
     SChildElementImpl as GChildElement,
     SModelElementImpl as GModelElement,
     SModelRootImpl as GModelRoot,
     SParentElementImpl as GParentElement,
     IModelIndex,
-    ModelIndexImpl,
-    createRandomId,
-    isParent
+    isParent,
+    ModelIndexImpl
 } from 'sprotty/lib/base/model/smodel';
 
 export {
+    createFeatureSet,
     CustomFeatures,
     EMPTY_ROOT,
     SModelElementConstructor as GModelElementConstructor,
@@ -69,8 +74,7 @@ export {
     SModelFactory as GModelFactory,
     IModelFactory,
     // exported without alias we extend it in glsp-client to `GModelRegistry`
-    SModelRegistry,
-    createFeatureSet
+    SModelRegistry
 } from 'sprotty/lib/base/model/smodel-factory';
 export * from 'sprotty/lib/base/model/smodel-utils';
 
@@ -99,30 +103,30 @@ export * from 'sprotty/lib/features/bounds/hidden-bounds-updater';
 export * from 'sprotty/lib/features/bounds/layout';
 export { AbstractLayoutOptions } from 'sprotty/lib/features/bounds/layout-options';
 export {
-    InternalBoundsAware as BoundsAware,
-    SShapeElementImpl as GShapeElement,
-    InternalLayoutContainer as LayoutContainer,
-    InternalLayoutableChild as LayoutableChild,
-    ModelLayoutOptions,
     alignFeature,
+    InternalBoundsAware as BoundsAware,
     boundsFeature,
     findChildrenAtPosition,
     getAbsoluteBounds,
     getAbsoluteClientBounds,
+    SShapeElementImpl as GShapeElement,
     isAlignable,
     isBoundsAware,
-    isLayoutContainer,
     isLayoutableChild,
+    isLayoutContainer,
     isSizeable,
+    InternalLayoutableChild as LayoutableChild,
+    layoutableChildFeature,
+    InternalLayoutContainer as LayoutContainer,
     layoutContainerFeature,
-    layoutableChildFeature
+    ModelLayoutOptions
 } from 'sprotty/lib/features/bounds/model';
 // exclude stack layout as its not supported in GLSP
 // export * from 'sprotty/lib/features/bounds/stack-layout';
 export * from 'sprotty/lib/features/bounds/vbox-layout';
 export * from 'sprotty/lib/features/bounds/views';
 
-export { ButtonHandlerRegistry, IButtonHandlerRegistration, configureButtonHandler } from 'sprotty/lib/features/button/button-handler';
+export { ButtonHandlerRegistry, configureButtonHandler, IButtonHandlerRegistration } from 'sprotty/lib/features/button/button-handler';
 export { SButtonImpl as GButton } from 'sprotty/lib/features/button/model';
 
 export {
@@ -138,7 +142,7 @@ export * from 'sprotty/lib/features/context-menu/mouse-listener';
 
 export * from 'sprotty/lib/features/edge-layout/di.config';
 export * from 'sprotty/lib/features/edge-layout/edge-layout';
-export { DEFAULT_EDGE_PLACEMENT, checkEdgePlacement, edgeLayoutFeature, isEdgeLayoutable } from 'sprotty/lib/features/edge-layout/model';
+export { checkEdgePlacement, DEFAULT_EDGE_PLACEMENT, edgeLayoutFeature, isEdgeLayoutable } from 'sprotty/lib/features/edge-layout/model';
 // Exclude client-side creation features (not supported in GLSP)
 // export * from 'sprotty/lib/features/edit/create';
 // export * from 'sprotty/lib/features/edit/create-on-drag';
@@ -169,10 +173,10 @@ export * from 'sprotty/lib/features/hover/popup-position-updater';
 export * from 'sprotty/lib/features/decoration/decoration-placer';
 export {
     Decoration,
-    SDecoration as GDecoration,
-    SIssueMarkerImpl,
     decorationFeature,
-    isDecoration
+    SDecoration as GDecoration,
+    isDecoration,
+    SIssueMarkerImpl
 } from 'sprotty/lib/features/decoration/model';
 export * from 'sprotty/lib/features/decoration/views';
 
@@ -190,7 +194,7 @@ export * from 'sprotty/lib/features/nameable/model';
 export * from 'sprotty/lib/features/open/model';
 export * from 'sprotty/lib/features/open/open';
 
-export { ViewProjection, getModelBounds, getProjectedBounds, getProjections, isProjectable } from 'sprotty/lib/features/projection/model';
+export { getModelBounds, getProjectedBounds, getProjections, isProjectable, ViewProjection } from 'sprotty/lib/features/projection/model';
 export * from 'sprotty/lib/features/projection/views';
 
 export * from 'sprotty/lib/features/routing/abstract-edge-router';
@@ -203,17 +207,17 @@ export * from 'sprotty/lib/features/routing/manhattan-edge-router';
 // Alias SModel types
 export {
     Connectable,
-    SConnectableElementImpl as GConnectableElement,
-    SDanglingAnchorImpl as GDanglingAnchor,
-    SRoutableElementImpl as GRoutableElement,
-    SRoutingHandleImpl as GRoutingHandle,
-    RoutingHandleKind,
     connectableFeature,
     edgeInProgressID,
     edgeInProgressTargetHandleID,
+    SConnectableElementImpl as GConnectableElement,
+    SDanglingAnchorImpl as GDanglingAnchor,
     getAbsoluteRouteBounds,
     getRouteBounds,
-    isConnectable
+    SRoutableElementImpl as GRoutableElement,
+    SRoutingHandleImpl as GRoutingHandle,
+    isConnectable,
+    RoutingHandleKind
 } from 'sprotty/lib/features/routing/model';
 export * from 'sprotty/lib/features/routing/polyline-anchors';
 export * from 'sprotty/lib/features/routing/polyline-edge-router';

--- a/packages/protocol/src/client-server-protocol/jsonrpc/base-jsonrpc-glsp-client.ts
+++ b/packages/protocol/src/client-server-protocol/jsonrpc/base-jsonrpc-glsp-client.ts
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable } from 'inversify';
 import { Disposable, Message, MessageConnection } from 'vscode-jsonrpc';
 import { ActionMessage } from '../../action-protocol/base-protocol';
 import { Emitter, Event } from '../../utils/event';
@@ -175,7 +174,6 @@ export class BaseJsonrpcGLSPClient implements GLSPClient {
 /**
  * Default {@link GLSPClientProxy} implementation for jsonrpc-based client-server communication with typescript based servers.
  */
-@injectable()
 export class JsonrpcClientProxy implements GLSPClientProxy {
     protected clientConnection?: MessageConnection;
     protected enableLogging: boolean;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Ensure JsonrpcClientProxy is injectable in the glsp-sprotty context

Contributed on behalf of Axon Ivy AG
Part of https://github.com/eclipse-glsp/glsp/issues/1381

#### How to test

- Create an npm package that depends on the GLSP protocol but do not specify inversify as a dependency. Everything should still work.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
