### PR TITLE
Ensure anyone who imports the di functionality gets decorated classes

### DIFF
--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -14,15 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { JsonrpcClientProxy } from '@eclipse-glsp/protocol';
-import { decorate, injectable } from 'inversify';
-
 /**
  * @eclipse-glsp/protocol
  */
 export * from '@eclipse-glsp/protocol';
 export * from '@eclipse-glsp/protocol/lib/di';
-decorate(injectable(), JsonrpcClientProxy);
 
 /*
  * sprotty

--- a/packages/protocol/src/di/re-decorate.ts
+++ b/packages/protocol/src/di/re-decorate.ts
@@ -13,8 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './container-configuration';
-export * from './feature-module';
-export * from './inversify-util';
-export * from './lazy-injector';
-export * from './re-decorate';
+
+import { decorate, injectable } from 'inversify';
+import { JsonrpcClientProxy } from '../client-server-protocol/jsonrpc/base-jsonrpc-glsp-client';
+
+// Decorate `JsonrpcClientProxy` as injectable for anyone who imports the di functionality, such as the client package,
+// the Theia integration package and the server package.
+decorate(injectable(), JsonrpcClientProxy);


### PR DESCRIPTION
#### What it does

Ensures that anyone with that imports '@eclipse-glsp/protocol/lib/di' will get the correctly decorated classes without the need to re-specify the decorations.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
