### PR TITLE
GLSP-1393 Align Interface usage across *Manager classes

### DIFF
--- a/examples/workflow-glsp/src/workflow-startup.ts
+++ b/examples/workflow-glsp/src/workflow-startup.ts
@@ -14,15 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { GridManager, IDiagramStartup } from '@eclipse-glsp/client';
-import { MaybePromise } from '@eclipse-glsp/sprotty';
+import { IDiagramStartup, IGridManager } from '@eclipse-glsp/client';
+import { MaybePromise, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 
 @injectable()
 export class WorkflowStartup implements IDiagramStartup {
     rank = -1;
 
-    @inject(GridManager) @optional() protected gridManager?: GridManager;
+    @inject(TYPES.IGridManager) @optional() protected gridManager?: IGridManager;
 
     preRequestModel(): MaybePromise<void> {
         this.gridManager?.setGridVisible(true);

--- a/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
@@ -21,7 +21,7 @@ import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { SelectionService } from '../../../base/selection-service';
 import { Tool } from '../../../base/tool-manager/tool';
 import { Grid } from '../../grid/grid';
-import { ChangeBoundsManager } from '../../tools/change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../../tools/change-bounds/change-bounds-manager';
 import { AccessibleKeyShortcutProvider, SetAccessibleKeyShortcutAction } from '../key-shortcut/accessible-key-shortcut';
 import { MoveElementAction, MoveViewportAction } from '../move-zoom/move-handler';
 
@@ -41,7 +41,7 @@ export class MovementKeyTool implements Tool {
     @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
     @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
     @inject(TYPES.Grid) @optional() protected grid: Grid;
-    @inject(ChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
 
     get id(): string {
         return MovementKeyTool.ID;

--- a/packages/client/src/features/debug/debug-bounds-decorator.tsx
+++ b/packages/client/src/features/debug/debug-bounds-decorator.tsx
@@ -15,18 +15,18 @@
  ********************************************************************************/
 /* eslint-disable max-len */
 /** @jsx svg */
-import { Bounds, GModelElement, IVNodePostprocessor, Point, isDecoration, isSizeable, setClass, svg } from '@eclipse-glsp/sprotty';
+import { Bounds, GModelElement, IVNodePostprocessor, Point, TYPES, isDecoration, isSizeable, setClass, svg } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
 import { GGraph } from '../../model';
 import { BoundsAwareModelElement } from '../../utils/gmodel-util';
-import { DebugManager } from './debug-manager';
+import { IDebugManager } from './debug-manager';
 
 export const CSS_DEBUG_BOUNDS = 'debug-bounds';
 
 @injectable()
 export class DebugBoundsDecorator implements IVNodePostprocessor {
-    @inject(DebugManager) @optional() protected debugManager?: DebugManager;
+    @inject(TYPES.IDebugManager) @optional() protected debugManager?: IDebugManager;
 
     decorate(vnode: VNode, element: GModelElement): VNode {
         if (!this.debugManager?.isDebugEnabled) {

--- a/packages/client/src/features/debug/debug-manager.ts
+++ b/packages/client/src/features/debug/debug-manager.ts
@@ -20,8 +20,21 @@ import { IFeedbackActionDispatcher } from '../../base/feedback/feedback-action-d
 import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
 import { EnableDebugModeAction } from './debug-model';
 
+export interface IDebugManager {
+    /** Flag to indicate whether the debug mode is enabled. */
+    readonly isDebugEnabled: boolean;
+    /** Sets the debug enabled state. */
+    setDebugEnabled(enabled: boolean): void;
+    /** Toggles the debug enabled state. */
+    toggleDebugEnabled(): void;
+}
+
+/**
+ * The default {@link IDebugManager} implementation.
+ * This class manages the debug mode and provides functionality to enable or disable it.
+ */
 @injectable()
-export class DebugManager implements IActionHandler {
+export class DebugManager implements IActionHandler, IDebugManager {
     protected _debugEnabled: boolean = false;
     protected debugFeedback: FeedbackEmitter;
 

--- a/packages/client/src/features/debug/debug-module.ts
+++ b/packages/client/src/features/debug/debug-module.ts
@@ -26,7 +26,7 @@ export const debugModule = new FeatureModule(
 
         configureCommand(context, EnableDebugModeCommand);
 
-        bind(DebugManager).toSelf().inSingletonScope();
+        bindAsService(context, TYPES.IDebugManager, DebugManager);
         configureActionHandler(context, EnableDebugModeAction.KIND, DebugManager);
 
         bindAsService(context, TYPES.IVNodePostprocessor, DebugBoundsDecorator);

--- a/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
+++ b/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
@@ -32,12 +32,12 @@ import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
 import { MoveableElement } from '../../utils/gmodel-util';
 import { getAbsolutePosition } from '../../utils/viewpoint-util';
 import { FeedbackAwareTool } from '../tools/base-tools';
-import { ChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
 import { MoveFinishedEventAction } from '../tools/change-bounds/change-bounds-tool-feedback';
 import { ChangeBoundsTracker, TrackedMove } from '../tools/change-bounds/change-bounds-tracker';
 
 export interface PositioningTool extends FeedbackAwareTool {
-    readonly changeBoundsManager: ChangeBoundsManager;
+    readonly changeBoundsManager: IChangeBoundsManager;
 }
 
 export class MouseTrackingElementPositionListener extends DragAwareMouseListener {

--- a/packages/client/src/features/grid/grid-manager.ts
+++ b/packages/client/src/features/grid/grid-manager.ts
@@ -23,8 +23,23 @@ import { ShowGridAction } from './grid-model';
 
 export type GridStyle = Record<string, string> & Partial<PropertiesOfType<CSSStyleDeclaration, string>>;
 
+export interface IGridManager {
+    /** The grid to manage. */
+    readonly grid: Grid;
+    /** Flag to indicate whether the grid is visible. */
+    readonly isGridVisible: boolean;
+    /** Sets the visibility of the grid. */
+    setGridVisible(visible: boolean): void;
+    /** Toggles the visibility of the grid. */
+    toggleGridVisible(): void;
+}
+
+/**
+ * The default {@link IGridManager} implementation.
+ * This class manages the visibility and behavior of a grid in the application.
+ */
 @injectable()
-export class GridManager implements IActionHandler {
+export class GridManager implements IActionHandler, IGridManager {
     protected _gridVisible: boolean = false;
     protected gridFeedback: FeedbackEmitter;
 

--- a/packages/client/src/features/grid/grid-module.ts
+++ b/packages/client/src/features/grid/grid-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { FeatureModule, TYPES, configureActionHandler, configureCommand } from '@eclipse-glsp/sprotty';
+import { FeatureModule, TYPES, bindAsService, configureActionHandler, configureCommand } from '@eclipse-glsp/sprotty';
 import '../../../css/grid.css';
 import { GridManager } from './grid-manager';
 import { ShowGridAction, ShowGridCommand } from './grid-model';
@@ -28,7 +28,7 @@ export const gridModule = new FeatureModule(
 
         configureCommand(context, ShowGridCommand);
 
-        bind(GridManager).toSelf().inSingletonScope();
+        bindAsService(context, TYPES.IGridManager, GridManager);
         configureActionHandler(context, ShowGridAction.KIND, GridManager);
 
         bind(TYPES.ISnapper).to(GridSnapper);

--- a/packages/client/src/features/select/select-mouse-listener.ts
+++ b/packages/client/src/features/select/select-mouse-listener.ts
@@ -13,12 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, BringToFrontAction, GModelElement, SelectAction, SelectMouseListener } from '@eclipse-glsp/sprotty';
+import { Action, BringToFrontAction, GModelElement, SelectAction, SelectMouseListener, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { Ranked } from '../../base/ranked';
 import { SelectableElement } from '../../utils/gmodel-util';
 import { GResizeHandle } from '../change-bounds/model';
-import { ChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
 
 /**
  * Ranked select mouse listener that is executed before default mouse listeners when using the RankedMouseTool.
@@ -28,7 +28,7 @@ import { ChangeBoundsManager } from '../tools/change-bounds/change-bounds-manage
 export class RankedSelectMouseListener extends SelectMouseListener implements Ranked {
     rank: number = Ranked.DEFAULT_RANK - 100; /* we want to be executed before all default mouse listeners */
 
-    @inject(ChangeBoundsManager) @optional() readonly changeBoundsManager?: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) @optional() readonly changeBoundsManager?: IChangeBoundsManager;
 
     protected override handleSelectTarget(
         selectableTarget: SelectableElement,

--- a/packages/client/src/features/tool-palette/tool-palette.ts
+++ b/packages/client/src/features/tool-palette/tool-palette.ts
@@ -25,6 +25,7 @@ import {
     SetContextActions,
     SetModelAction,
     SetUIExtensionVisibilityAction,
+    TYPES,
     TriggerNodeCreationAction,
     UpdateModelAction,
     codiconCSSClasses,
@@ -37,8 +38,8 @@ import { FocusTracker } from '../../base/focus/focus-tracker';
 import { IDiagramStartup } from '../../base/model/diagram-loader';
 import { EnableDefaultToolsAction, EnableToolsAction } from '../../base/tool-manager/tool';
 import { GLSPAbstractUIExtension } from '../../base/ui-extension/ui-extension';
-import { DebugManager } from '../debug/debug-manager';
-import { GridManager } from '../grid/grid-manager';
+import { IDebugManager } from '../debug/debug-manager';
+import { IGridManager } from '../grid/grid-manager';
 import { MouseDeleteTool } from '../tools/deletion/delete-tool';
 import { MarqueeMouseTool } from '../tools/marquee-selection/marquee-mouse-tool';
 import { OriginViewportAction } from '../viewport/origin-viewport';
@@ -77,13 +78,13 @@ export class ToolPalette extends GLSPAbstractUIExtension implements IActionHandl
     @inject(FocusTracker)
     protected focusTracker: FocusTracker;
 
-    @inject(GridManager)
+    @inject(TYPES.IGridManager)
     @optional()
-    protected gridManager?: GridManager;
+    protected gridManager?: IGridManager;
 
-    @inject(DebugManager)
+    @inject(TYPES.IDebugManager)
     @optional()
-    protected debugManager?: DebugManager;
+    protected debugManager?: IDebugManager;
 
     protected paletteItems: PaletteItem[];
     protected paletteItemsCopy: PaletteItem[] = [];

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-feedback.ts
@@ -20,7 +20,7 @@ import { FeedbackCommand } from '../../../base/feedback/feedback-command';
 import { OptionalAction } from '../../../base/model/glsp-model-source';
 import { forEachElement } from '../../../utils/gmodel-util';
 import { ResizeHandleLocation, addResizeHandles, isResizable, removeResizeHandles } from '../../change-bounds/model';
-import { ChangeBoundsManager } from './change-bounds-manager';
+import { IChangeBoundsManager } from './change-bounds-manager';
 
 export interface ShowChangeBoundsToolResizeFeedbackAction extends Action {
     kind: typeof ShowChangeBoundsToolResizeFeedbackAction.KIND;
@@ -71,7 +71,7 @@ export class ShowChangeBoundsToolResizeFeedbackCommand extends FeedbackCommand {
     static readonly KIND = ShowChangeBoundsToolResizeFeedbackAction.KIND;
 
     @inject(TYPES.Action) protected action: ShowChangeBoundsToolResizeFeedbackAction;
-    @inject(ChangeBoundsManager) protected changeBoundsManager: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) protected changeBoundsManager: IChangeBoundsManager;
 
     execute(context: CommandExecutionContext): CommandReturn {
         const index = context.root.index;

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-module.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-module.ts
@@ -24,7 +24,7 @@ import { GResizeHandleView } from './view';
 export const changeBoundsToolModule = new FeatureModule(
     (bind, unbind, isBound, rebind) => {
         const context = { bind, unbind, isBound, rebind };
-        bind(ChangeBoundsManager).toSelf().inSingletonScope();
+        bindAsService(context, TYPES.IChangeBoundsManager, ChangeBoundsManager);
         bindAsService(context, TYPES.IDefaultTool, ChangeBoundsTool);
         configureCommand(context, ShowChangeBoundsToolResizeFeedbackCommand);
         configureCommand(context, HideChangeBoundsToolResizeFeedbackCommand);

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -54,7 +54,7 @@ import { SetBoundsFeedbackAction } from '../../bounds/set-bounds-feedback-comman
 import { GResizeHandle, isResizable } from '../../change-bounds/model';
 import { IMovementRestrictor } from '../../change-bounds/movement-restrictor';
 import { BaseEditTool } from '../base-tools';
-import { CSS_ACTIVE_HANDLE, ChangeBoundsManager } from './change-bounds-manager';
+import { CSS_ACTIVE_HANDLE, IChangeBoundsManager } from './change-bounds-manager';
 import {
     HideChangeBoundsToolResizeFeedbackAction,
     MoveFinishedEventAction,
@@ -83,7 +83,7 @@ export class ChangeBoundsTool extends BaseEditTool {
     @inject(SelectionService) protected selectionService: SelectionService;
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
     @inject(TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
-    @inject(ChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
 
     get id(): string {
         return ChangeBoundsTool.ID;

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
@@ -48,7 +48,7 @@ import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
 import { forEachElement, getMatchingElements, isRoutable, isRoutingHandle } from '../../../utils/gmodel-util';
 import { getAbsolutePosition, toAbsoluteBounds } from '../../../utils/viewpoint-util';
 import { addReconnectHandles, removeReconnectHandles } from '../../reconnect/model';
-import { ChangeBoundsManager } from '../change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../change-bounds/change-bounds-manager';
 import { ChangeBoundsTracker, MoveableRoutingHandle } from '../change-bounds/change-bounds-tracker';
 import { FeedbackEdgeEnd, feedbackEdgeEndId, feedbackEdgeId } from '../edge-creation/dangling-edge-feedback';
 import { FeedbackEdgeEndMovingMouseListener } from '../edge-creation/edge-creation-tool-feedback';
@@ -259,7 +259,7 @@ export class FeedbackEdgeRouteMovingMouseListener extends DragAwareMouseListener
     protected tracker: ChangeBoundsTracker;
 
     constructor(
-        protected changeBoundsManager: ChangeBoundsManager,
+        protected changeBoundsManager: IChangeBoundsManager,
         protected edgeRouterRegistry?: EdgeRouterRegistry
     ) {
         super();

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
@@ -24,6 +24,7 @@ import {
     GRoutableElement,
     GRoutingHandle,
     ReconnectEdgeOperation,
+    TYPES,
     canEditRouting,
     findParentByFeature,
     isConnectable,
@@ -37,7 +38,7 @@ import { ISelectionListener, SelectionService } from '../../../base/selection-se
 import { calcElementAndRoutingPoints, isRoutable, isRoutingHandle } from '../../../utils/gmodel-util';
 import { GReconnectHandle, isReconnectHandle, isReconnectable, isSourceRoutingHandle, isTargetRoutingHandle } from '../../reconnect/model';
 import { BaseEditTool } from '../base-tools';
-import { ChangeBoundsManager } from '../change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../change-bounds/change-bounds-manager';
 import { DrawFeedbackEdgeAction, RemoveFeedbackEdgeAction, feedbackEdgeId } from '../edge-creation/dangling-edge-feedback';
 import {
     DrawFeedbackEdgeSourceAction,
@@ -56,7 +57,7 @@ export class EdgeEditTool extends BaseEditTool {
     @inject(SelectionService) protected selectionService: SelectionService;
     @inject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry;
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
-    @inject(ChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
 
     protected feedbackEdgeSourceMovingListener: FeedbackEdgeSourceMovingMouseListener;
     protected feedbackEdgeTargetMovingListener: FeedbackEdgeTargetMovingMouseListener;

--- a/packages/client/src/features/tools/node-creation/container-manager.ts
+++ b/packages/client/src/features/tools/node-creation/container-manager.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { GModelElement, Point, findChildrenAtPosition } from '@eclipse-glsp/sprotty';
+import { GModelElement, Point, TYPES, findChildrenAtPosition } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
 import { CSS_GHOST_ELEMENT, CursorCSS, cursorFeedbackAction } from '../../../base/feedback/css-feedback';
 import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
 import { ContainerElement, isContainable } from '../../hints/model';
-import { ChangeBoundsManager } from '../change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../change-bounds/change-bounds-manager';
 
 export interface InsertOptions extends Record<string, unknown> {
     /** Flag to indicate whether the location within a container needs to be valid. Default: false */
@@ -58,7 +58,7 @@ export interface IContainerManager {
  */
 @injectable()
 export class ContainerManager implements IContainerManager {
-    @inject(ChangeBoundsManager) protected readonly changeBoundsManager: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) protected readonly changeBoundsManager: IChangeBoundsManager;
 
     insert(proxy: GModelElement, location: Point, elementTypeId: string, opts?: Partial<InsertOptions>): TrackedInsert {
         const options = { ...DEFAULT_INSERT_OPTIONS, ...opts };

--- a/packages/client/src/features/tools/node-creation/node-creation-tool.ts
+++ b/packages/client/src/features/tools/node-creation/node-creation-tool.ts
@@ -43,7 +43,7 @@ import { AddTemplateElementsAction, getTemplateElementId } from '../../element-t
 import { MouseTrackingElementPositionListener, PositioningTool } from '../../element-template/mouse-tracking-element-position-listener';
 import { RemoveTemplateElementsAction } from '../../element-template/remove-template-element';
 import { BaseCreationTool } from '../base-tools';
-import { ChangeBoundsManager } from '../change-bounds/change-bounds-manager';
+import { IChangeBoundsManager } from '../change-bounds/change-bounds-manager';
 import { TrackedMove } from '../change-bounds/change-bounds-tracker';
 import { IContainerManager, TrackedInsert } from './container-manager';
 import { InsertIndicator } from './insert-indicator';
@@ -54,7 +54,7 @@ export class NodeCreationTool extends BaseCreationTool<TriggerNodeCreationAction
 
     protected isTriggerAction = TriggerNodeCreationAction.is;
 
-    @inject(ChangeBoundsManager) readonly changeBoundsManager: ChangeBoundsManager;
+    @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
     @inject(TYPES.IContainerManager) readonly containerManager: IContainerManager;
     @inject(TYPES.IModelFactory) modelFactory: IModelFactory;
 

--- a/packages/client/src/views/ggraph-view.tsx
+++ b/packages/client/src/views/ggraph-view.tsx
@@ -13,15 +13,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Bounds, Dimension, Point, RenderingContext, SGraphImpl, SGraphView, Writable } from '@eclipse-glsp/sprotty';
+import { Bounds, Dimension, Point, RenderingContext, SGraphImpl, SGraphView, TYPES, Writable } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
-import { GridManager, GridStyle } from '../features/grid/grid-manager';
+import { GridStyle, IGridManager } from '../features/grid/grid-manager';
 import { GridProperty } from '../features/grid/grid-style';
 
 @injectable()
 export class GGraphView extends SGraphView {
-    @inject(GridManager) @optional() protected gridManager?: GridManager;
+    @inject(TYPES.IGridManager) @optional() protected gridManager?: IGridManager;
 
     override render(model: Readonly<SGraphImpl>, context: RenderingContext): VNode {
         const graph = super.render(model, context);
@@ -45,7 +45,7 @@ export class GGraphView extends SGraphView {
         };
     }
 
-    protected getBackgroundBounds(viewport: Readonly<SGraphImpl>, context: RenderingContext, gridManager: GridManager): Writable<Bounds> {
+    protected getBackgroundBounds(viewport: Readonly<SGraphImpl>, context: RenderingContext, gridManager: IGridManager): Writable<Bounds> {
         const position = Point.multiplyScalar(Point.subtract(gridManager.grid, viewport.scroll), viewport.zoom);
         const size = Dimension.fromPoint(Point.multiplyScalar(gridManager.grid, viewport.zoom));
         return { ...position, ...size };

--- a/packages/client/src/views/glsp-projection-view.tsx
+++ b/packages/client/src/views/glsp-projection-view.tsx
@@ -25,6 +25,7 @@ import {
     ProjectionParams,
     RenderingContext,
     SGraphImpl,
+    TYPES,
     ViewProjection,
     Writable,
     html,
@@ -33,7 +34,7 @@ import {
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { VNode, VNodeStyle, h } from 'snabbdom';
-import { GridManager, GridStyle } from '../features/grid/grid-manager';
+import { GridStyle, IGridManager } from '../features/grid/grid-manager';
 import { GridProperty } from '../features/grid/grid-style';
 
 /**
@@ -42,7 +43,7 @@ import { GridProperty } from '../features/grid/grid-style';
 @injectable()
 export class GLSPProjectionView extends ProjectedViewportView {
     @inject(EdgeRouterRegistry) edgeRouterRegistry: EdgeRouterRegistry;
-    @inject(GridManager) @optional() protected gridManager?: GridManager;
+    @inject(TYPES.IGridManager) @optional() protected gridManager?: IGridManager;
 
     override render(model: Readonly<GViewportRootElement>, context: RenderingContext, args?: IViewArgs): VNode {
         const rootNode: VNode = (
@@ -83,7 +84,7 @@ export class GLSPProjectionView extends ProjectedViewportView {
         };
     }
 
-    protected getBackgroundBounds(viewport: Readonly<SGraphImpl>, context: RenderingContext, gridManager: GridManager): Writable<Bounds> {
+    protected getBackgroundBounds(viewport: Readonly<SGraphImpl>, context: RenderingContext, gridManager: IGridManager): Writable<Bounds> {
         const position = Point.multiplyScalar(Point.subtract(gridManager.grid, viewport.scroll), viewport.zoom);
         const size = Dimension.fromPoint(Point.multiplyScalar(gridManager.grid, viewport.zoom));
         return { ...position, ...size };

--- a/packages/glsp-sprotty/src/types.ts
+++ b/packages/glsp-sprotty/src/types.ts
@@ -49,5 +49,8 @@ export const TYPES = {
     IDiagramStartup: Symbol('IDiagramStartup'),
     IToolManager: Symbol('IToolManager'),
     IContainerManager: Symbol('IContainerManager'),
+    IChangeBoundsManager: Symbol('IChangeBoundsManager'),
+    IGridManager: Symbol('IGridManager'),
+    IDebugManager: Symbol('IDebugManager'),
     Grid: Symbol('Grid')
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Align interface + symbol usage for *Manager classes
  - `ChangeBoundsManager`, `GridManager`, `DebugManager`
- Use bindAsService to ensure backward compatibility
- Update injects to use the symbol instead of the actual manager class

Resolves https://github.com/eclipse-glsp/glsp/issues/1393

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Changing bounds, grid toggling and debug mode toggling should work as before, this should not impact the functionality at all.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

--

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
