### PR TITLE
GLSP-1399: Fix MousePositionTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+-   [diagram] Ensure that `GLSPMousePositionTracker` correctly calculates the current position in diagram local coordinates [#391](https://github.com/eclipse-glsp/glsp-client/pull/391)
+
 ### Potentially breaking changes
 
 ## [v2.2.1 - 22/07/2024](https://github.com/eclipse-glsp/glsp-client/releases/tag/v2.2.1)

--- a/packages/client/src/base/mouse-position-tracker.ts
+++ b/packages/client/src/base/mouse-position-tracker.ts
@@ -14,16 +14,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import {
-    Action,
-    DOMHelper,
-    GModelElement,
-    MousePositionTracker,
-    Point,
-    TYPES,
-    ViewerOptions,
-    getAbsoluteClientBounds
-} from '@eclipse-glsp/sprotty';
+import { Action, DOMHelper, GModelElement, MousePositionTracker, Point, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
 import { Ranked } from './ranked';
 
@@ -38,9 +29,9 @@ export class GLSPMousePositionTracker extends MousePositionTracker implements Ra
     override mouseMove(target: GModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         // we cannot simply use the offsetX and offsetY properties of the event since they also consider nested HTML elements
         // such as foreignObjects or the projection bars divs. Instead, we manually translate the client coordinates to the diagram
-        const clientToRoot = getAbsoluteClientBounds(target.root, this.domHelper, this.viewerOptions);
+        const globalOrigin = target.root.canvasBounds;
         const clientToPosition = { x: event.clientX, y: event.clientY };
-        const rootToPosition = Point.subtract(clientToPosition, clientToRoot);
+        const rootToPosition = Point.subtract(clientToPosition, globalOrigin);
         const positionOnDiagram = target.root.parentToLocal(rootToPosition);
         this.lastPosition = positionOnDiagram;
         return [];

--- a/packages/client/src/base/mouse-position-tracker.ts
+++ b/packages/client/src/base/mouse-position-tracker.ts
@@ -14,17 +14,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, DOMHelper, GModelElement, MousePositionTracker, Point, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
-import { inject, injectable } from 'inversify';
+import { Action, GModelElement, MousePositionTracker, Point } from '@eclipse-glsp/sprotty';
+import { injectable } from 'inversify';
 import { Ranked } from './ranked';
 
 @injectable()
 export class GLSPMousePositionTracker extends MousePositionTracker implements Ranked {
     /* we want to be executed before all default mouse listeners since we are just tracking the position and others may need it */
     rank = Ranked.DEFAULT_RANK - 200;
-
-    @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
-    @inject(TYPES.DOMHelper) protected domHelper: DOMHelper;
 
     override mouseMove(target: GModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         // we cannot simply use the offsetX and offsetY properties of the event since they also consider nested HTML elements


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Ensure that the `GLSPMousePositionTracker` correctly calculates the diagram local mouse position

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Ensure that resize/move still works as expected.
Also test the corner case with resizing/moving near/over the projection bars
If you want to verify the tracked position you can add a log point in the `GLSPMousePositionTracker.mouseMove` method
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
