### PR TITLE
GLSP-1393 Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 -   [diagram] Ensure that `GLSPMousePositionTracker` correctly calculates the current position in diagram local coordinates [#391](https://github.com/eclipse-glsp/glsp-client/pull/391)
+-   [di] Align Interface usage across \*Manager classes [#388](https://github.com/eclipse-glsp/glsp-client/pull/388)
+    -   Change DI bindings for: `GridManger` to `TYPES.IGridManager`, `ChangeBoundsManager` to `TYPES.IChangeBoundsManager` and `DebugManager` to `TYPES.IDebugManager`.
 
 ### Potentially breaking changes
 


### PR DESCRIPTION
While updating an existing glsp-client from 2.2.1 to 2.3.0-next.381 I ran into the changes from https://github.com/eclipse-glsp/glsp/issues/1393, which were not documented in the Changelog.

#### What it does

- Add changelog entry for change: https://github.com/eclipse-glsp/glsp-client/pull/388

#### How to test

--

#### Follow-ups

--

#### Changelog

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
