### PR TITLE
GLSP-1416: Align ActionDispatcher API

### DIFF
--- a/examples/workflow-glsp/src/direct-task-editing/direct-task-editor.ts
+++ b/examples/workflow-glsp/src/direct-task-editing/direct-task-editor.ts
@@ -19,8 +19,8 @@ import {
     DOMHelper,
     EditorContextService,
     GLSPAbstractUIExtension,
-    GLSPActionDispatcher,
     GModelRoot,
+    IActionDispatcher,
     ILogger,
     LabeledAction,
     ModelIndexImpl,
@@ -95,7 +95,7 @@ export class TaskEditor extends GLSPAbstractUIExtension {
     };
 
     @inject(TYPES.IActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    protected actionDispatcher: IActionDispatcher;
 
     @inject(EditorContextService)
     protected editorContextService: EditorContextService;

--- a/packages/client/src/base/action-dispatcher.ts
+++ b/packages/client/src/base/action-dispatcher.ts
@@ -13,7 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, ActionDispatcher, EMPTY_ROOT, GModelRoot, RequestAction, ResponseAction, SetModelAction } from '@eclipse-glsp/sprotty';
+import {
+    Action,
+    ActionDispatcher,
+    EMPTY_ROOT,
+    GModelRoot,
+    IActionDispatcher,
+    RequestAction,
+    ResponseAction,
+    SetModelAction
+} from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
 import { GLSPActionHandlerRegistry } from './action-handler-registry';
 import { IGModelRootListener } from './editor-context-service';
@@ -21,7 +30,7 @@ import { OptionalAction } from './model/glsp-model-source';
 import { ModelInitializationConstraint } from './model/model-initialization-constraint';
 
 @injectable()
-export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRootListener {
+export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRootListener, IActionDispatcher {
     protected readonly timeouts: Map<string, NodeJS.Timeout> = new Map();
     protected initializedConstraint = false;
 

--- a/packages/client/src/base/auto-complete/base-autocomplete-palette.ts
+++ b/packages/client/src/base/auto-complete/base-autocomplete-palette.ts
@@ -14,10 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action, GModelRoot, LabeledAction, TYPES } from '@eclipse-glsp/sprotty';
+import { Action, GModelRoot, IActionDispatcher, LabeledAction, TYPES } from '@eclipse-glsp/sprotty';
 import { inject } from 'inversify';
 import '../../../css/autocomplete-palette.css';
-import { GLSPActionDispatcher } from '../action-dispatcher';
 import { GLSPAbstractUIExtension } from '../ui-extension/ui-extension';
 import { AutoCompleteWidget, CloseReason, toActionArray } from './auto-complete-widget';
 
@@ -38,7 +37,7 @@ export abstract class BaseAutocompletePalette extends GLSPAbstractUIExtension {
     protected autocompleteWidget: AutoCompleteWidget;
 
     @inject(TYPES.IActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    protected actionDispatcher: IActionDispatcher;
 
     containerClass(): string {
         return 'autocomplete-palette';

--- a/packages/client/src/base/editor-context-service.ts
+++ b/packages/client/src/base/editor-context-service.ts
@@ -26,6 +26,7 @@ import {
     Event,
     GModelElement,
     GModelRoot,
+    IActionDispatcher,
     IActionHandler,
     LazyInjector,
     MaybePromise,
@@ -36,7 +37,6 @@ import {
     ValueChange
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
-import { GLSPActionDispatcher } from './action-dispatcher';
 import { FocusChange, FocusTracker } from './focus/focus-tracker';
 import { IDiagramOptions, IDiagramStartup } from './model/diagram-loader';
 import { SelectionChange, SelectionService } from './selection-service';
@@ -89,8 +89,8 @@ export class EditorContextService implements IActionHandler, Disposable, IDiagra
     @inject(TYPES.IDiagramOptions)
     protected diagramOptions: IDiagramOptions;
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     @inject(FocusTracker)
     protected focusTracker: FocusTracker;

--- a/packages/client/src/base/model/diagram-loader.ts
+++ b/packages/client/src/base/model/diagram-loader.ts
@@ -20,6 +20,7 @@ import {
     Args,
     EMPTY_ROOT,
     GLSPClient,
+    IActionDispatcher,
     InitializeParameters,
     LazyInjector,
     MaybePromise,
@@ -30,7 +31,6 @@ import {
     hasNumberProp
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../action-dispatcher';
 import { Ranked } from '../ranked';
 import { GLSPModelSource } from './glsp-model-source';
 import { ModelInitializationConstraint } from './model-initialization-constraint';
@@ -148,8 +148,8 @@ export class DiagramLoader {
     @inject(TYPES.IDiagramOptions)
     protected options: IDiagramOptions;
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     @inject(GLSPModelSource)
     protected modelSource: GLSPModelSource;

--- a/packages/client/src/features/accessibility/edge-autocomplete/edge-autocomplete-palette.ts
+++ b/packages/client/src/features/accessibility/edge-autocomplete/edge-autocomplete-palette.ts
@@ -13,28 +13,28 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable } from 'inversify';
 import {
+    Action,
     codiconCSSString,
-    isConnectable,
+    CreateEdgeOperation,
     GModelElement,
     GModelRoot,
+    IActionHandler,
+    isConnectable,
     LabeledAction,
     name,
     SetUIExtensionVisibilityAction,
-    IActionHandler,
-    Action,
-    CreateEdgeOperation,
+    toArray,
     TriggerEdgeCreationAction
 } from '@eclipse-glsp/sprotty';
-import { EnableDefaultToolsAction } from '../../../base/tool-manager/tool';
-import { toArray } from 'sprotty/lib/utils/iterable';
-import { EdgeAutocompleteContext } from './edge-autocomplete-context';
-import { SearchAutocompletePalette } from '../search/search-palette';
-import { SetEdgeTargetSelectionAction } from './action';
+import { injectable } from 'inversify';
 import { CloseReason, toActionArray } from '../../../base/auto-complete/auto-complete-widget';
 import { AutocompleteSuggestion, IAutocompleteSuggestionProvider } from '../../../base/auto-complete/autocomplete-suggestion-providers';
+import { EnableDefaultToolsAction } from '../../../base/tool-manager/tool';
 import { GEdge } from '../../../model';
+import { SearchAutocompletePalette } from '../search/search-palette';
+import { SetEdgeTargetSelectionAction } from './action';
+import { EdgeAutocompleteContext } from './edge-autocomplete-context';
 
 export namespace EdgeAutocompletePaletteMetadata {
     export const ID = 'edge-autocomplete-palette';

--- a/packages/client/src/features/accessibility/edge-autocomplete/edge-autocomplete-tool.ts
+++ b/packages/client/src/features/accessibility/edge-autocomplete/edge-autocomplete-tool.ts
@@ -13,10 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Action, GModelElement, KeyListener, KeyTool, matchesKeystroke, SetUIExtensionVisibilityAction } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { KeyTool, KeyListener, SetUIExtensionVisibilityAction, GModelElement, Action } from '@eclipse-glsp/sprotty';
 import { Tool } from '../../../base/tool-manager/tool';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import { EdgeAutocompletePaletteMetadata } from './edge-autocomplete-palette';
 
 @injectable()

--- a/packages/client/src/features/accessibility/element-navigation/diagram-navigation-tool.ts
+++ b/packages/client/src/features/accessibility/element-navigation/diagram-navigation-tool.ts
@@ -18,6 +18,7 @@ import {
     Action,
     GModelElement,
     GModelRoot,
+    IActionDispatcher,
     KeyListener,
     KeyTool,
     SelectAction,
@@ -26,13 +27,13 @@ import {
     findParentByFeature,
     isBoundsAware,
     isSelectable,
-    isSelected
+    isSelected,
+    matchesKeystroke,
+    toArray
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { toArray } from 'sprotty/lib/utils/iterable';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { EnableDefaultToolsAction, EnableToolsAction, Tool } from '../../../base/tool-manager/tool';
+import { GEdge } from '../../../model';
 import { SelectableBoundsAware } from '../../../utils/gmodel-util';
 import { RepositionAction } from '../../viewport/reposition';
 import { SetAccessibleKeyShortcutAction } from '../key-shortcut/accessible-key-shortcut';
@@ -41,7 +42,6 @@ import { SearchAutocompletePaletteTool } from '../search/search-tool';
 import * as messages from '../toast/messages.json';
 import { ShowToastMessageAction } from '../toast/toast-handler';
 import { ElementNavigator } from './element-navigator';
-import { GEdge } from '../../../model';
 
 @injectable()
 export class ElementNavigatorTool implements Tool {
@@ -53,7 +53,7 @@ export class ElementNavigatorTool implements Tool {
     @inject(KeyTool) protected readonly keytool: KeyTool;
     @inject(TYPES.IElementNavigator) readonly elementNavigator: ElementNavigator;
     @inject(TYPES.ILocalElementNavigator) readonly localElementNavigator: ElementNavigator;
-    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
 
     get id(): string {
         return ElementNavigatorTool.ID;

--- a/packages/client/src/features/accessibility/element-navigation/left-right-top-bottom-navigator.ts
+++ b/packages/client/src/features/accessibility/element-navigation/left-right-top-bottom-navigator.ts
@@ -14,12 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { EdgeRouterRegistry, findParentByFeature, GModelElement, GModelRoot, Point } from '@eclipse-glsp/sprotty';
+import { EdgeRouterRegistry, findParentByFeature, GModelElement, GModelRoot, Point, toArray } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
-import { toArray } from 'sprotty/lib/utils/iterable';
+import { GEdge } from '../../../model';
 import { calcElementAndRoute, isRoutable, isSelectableAndBoundsAware, SelectableBoundsAware } from '../../../utils/gmodel-util';
 import { ElementNavigator } from './element-navigator';
-import { GEdge } from '../../../model';
 
 @injectable()
 export class LeftToRightTopToBottomElementNavigator implements ElementNavigator {

--- a/packages/client/src/features/accessibility/element-navigation/local-element-navigator.ts
+++ b/packages/client/src/features/accessibility/element-navigation/local-element-navigator.ts
@@ -13,9 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { EdgeRouterRegistry, GConnectableElement, GModelElement, GModelRoot, TYPES } from '@eclipse-glsp/sprotty';
+import { EdgeRouterRegistry, GConnectableElement, GModelElement, GModelRoot, IActionDispatcher, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { applyCssClasses, deleteCssClasses } from '../../../base/feedback/css-feedback';
 import { GEdge } from '../../../model';
 import { BoundsAwareModelElement, SelectableBoundsAware } from '../../../utils/gmodel-util';
@@ -25,7 +24,7 @@ import { ElementNavigator } from './element-navigator';
 export class LocalElementNavigator implements ElementNavigator {
     navigableElementCSS = 'navigable-element';
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
-    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: IActionDispatcher;
 
     previous(
         root: Readonly<GModelRoot>,

--- a/packages/client/src/features/accessibility/element-navigation/position-navigator.ts
+++ b/packages/client/src/features/accessibility/element-navigation/position-navigator.ts
@@ -14,16 +14,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import {
+    Bounds,
+    GChildElement,
+    GModelElement,
+    GModelRoot,
+    GNode,
+    IActionDispatcher,
+    Point,
+    TYPES,
+    isBoundsAware,
+    isSelectable,
+    toArray
+} from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { toArray } from 'sprotty/lib/utils/iterable';
-import { Bounds, GChildElement, Point, GModelElement, GModelRoot, GNode, TYPES, isBoundsAware, isSelectable } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { SelectableBoundsAware } from '../../../utils/gmodel-util';
 import { ElementNavigator } from './element-navigator';
 
 @injectable()
 export class PositionNavigator implements ElementNavigator {
-    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: IActionDispatcher;
 
     previous(
         root: Readonly<GModelRoot>,

--- a/packages/client/src/features/accessibility/focus-tracker/focus-tracker-tool.ts
+++ b/packages/client/src/features/accessibility/focus-tracker/focus-tracker-tool.ts
@@ -14,9 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { IActionDispatcher, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { Tool } from '../../../base/tool-manager/tool';
 import * as messages from '../toast/messages.json';
 import { ShowToastMessageAction } from '../toast/toast-handler';
@@ -27,7 +26,7 @@ export class FocusTrackerTool implements Tool {
 
     isEditTool = false;
     @inject(TYPES.IActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.ViewerOptions)
     protected readonly viewerOptions: ViewerOptions;
 

--- a/packages/client/src/features/accessibility/global-keylistener-tool.ts
+++ b/packages/client/src/features/accessibility/global-keylistener-tool.ts
@@ -13,16 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Action, IActionDispatcher, matchesKeystroke, SetUIExtensionVisibilityAction, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { SetUIExtensionVisibilityAction, Action } from '@eclipse-glsp/sprotty';
 import { Tool } from '../../base/tool-manager/tool';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
+import { KeyboardGridMetadata, KeyboardNodeGridMetadata } from '../accessibility/keyboard-grid/constants';
 import { ToolPalette } from '../tool-palette/tool-palette';
 import { FocusDomAction } from './actions';
-import { KeyboardGridMetadata, KeyboardNodeGridMetadata } from '../accessibility/keyboard-grid/constants';
-import { KeyboardPointerMetadata } from './keyboard-pointer/constants';
 import { AccessibleKeyShortcutProvider, SetAccessibleKeyShortcutAction } from './key-shortcut/accessible-key-shortcut';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
+import { KeyboardPointerMetadata } from './keyboard-pointer/constants';
 import { KeyboardToolPalette } from './keyboard-tool-palette/keyboard-tool-palette';
 
 @injectable()
@@ -32,8 +30,8 @@ export class GlobalKeyListenerTool implements Tool, AccessibleKeyShortcutProvide
     isEditTool = false;
     protected alreadyRegistered = false;
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     get id(): string {
         return GlobalKeyListenerTool.ID;

--- a/packages/client/src/features/accessibility/keyboard-grid/keyboard-grid.ts
+++ b/packages/client/src/features/accessibility/keyboard-grid/keyboard-grid.ts
@@ -17,23 +17,24 @@ import '../../../../css/keyboard.css';
 
 import {
     Action,
-    ActionDispatcher,
     GModelRoot,
+    IActionDispatcher,
     IActionHandler,
     ICommand,
+    KeyCode,
+    matchesKeystroke,
     Point,
     SetUIExtensionVisibilityAction,
     TYPES
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { KeyCode, matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import { GLSPAbstractUIExtension } from '../../../base/ui-extension/ui-extension';
 import { EnableKeyboardGridAction, KeyboardGridCellSelectedAction, KeyboardGridKeyboardEventAction } from './action';
 import { KeyboardGridMetadata } from './constants';
 
 @injectable()
 export class KeyboardGrid extends GLSPAbstractUIExtension implements IActionHandler {
-    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: ActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: IActionDispatcher;
 
     protected triggerActions: Action[] = [];
     protected originId: string;

--- a/packages/client/src/features/accessibility/keyboard-grid/keyboard-node-grid.ts
+++ b/packages/client/src/features/accessibility/keyboard-grid/keyboard-node-grid.ts
@@ -15,14 +15,13 @@
  ********************************************************************************/
 import '../../../../css/keyboard.css';
 
+import { Action, ICommand, matchesKeystroke, SetUIExtensionVisibilityAction } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { ICommand, SetUIExtensionVisibilityAction, Action } from '@eclipse-glsp/sprotty';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { KeyboardPointer } from '../keyboard-pointer/keyboard-pointer';
 import { KeyboardPointerMetadata } from '../keyboard-pointer/constants';
-import { GridSearchPaletteMetadata } from './keyboard-grid-search-palette';
-import { KeyboardGrid } from './keyboard-grid';
+import { KeyboardPointer } from '../keyboard-pointer/keyboard-pointer';
 import { KeyboardNodeGridMetadata } from './constants';
+import { KeyboardGrid } from './keyboard-grid';
+import { GridSearchPaletteMetadata } from './keyboard-grid-search-palette';
 
 @injectable()
 export class KeyboardNodeGrid extends KeyboardGrid {

--- a/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer-listener.ts
+++ b/packages/client/src/features/accessibility/keyboard-pointer/keyboard-pointer-listener.ts
@@ -14,14 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { IActionDispatcher, SetUIExtensionVisibilityAction, CreateNodeOperation } from '@eclipse-glsp/sprotty';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
+import { CreateNodeOperation, IActionDispatcher, matchesKeystroke, SetUIExtensionVisibilityAction } from '@eclipse-glsp/sprotty';
+import { CursorCSS } from '../../../base/feedback/css-feedback';
+import { EnableDefaultToolsAction } from '../../../base/tool-manager/tool';
 import { KeyboardNodeGridMetadata } from '../keyboard-grid/constants';
 import { KeyboardPointerMetadata } from './constants';
 import { KeyboardPointer } from './keyboard-pointer';
 import { KeyboardPointerPosition } from './keyboard-pointer-position';
-import { EnableDefaultToolsAction } from '../../../base/tool-manager/tool';
-import { CursorCSS } from '../../../base/feedback/css-feedback';
 
 /**
  * Keyboard listener for the pointer with the necessary logic to handle keyboard events

--- a/packages/client/src/features/accessibility/keyboard-tool-palette/keyboard-tool-palette.ts
+++ b/packages/client/src/features/accessibility/keyboard-tool-palette/keyboard-tool-palette.ts
@@ -16,6 +16,8 @@
 import {
     Action,
     ICommand,
+    KeyCode,
+    matchesKeystroke,
     PaletteItem,
     RequestContextActions,
     RequestMarkersAction,
@@ -24,15 +26,14 @@ import {
     TriggerNodeCreationAction
 } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
-import { KeyCode, matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import { EnableDefaultToolsAction, EnableToolsAction } from '../../../base/tool-manager/tool';
 import {
-    EnableToolPaletteAction,
-    ToolPalette,
     changeCodiconClass,
     compare,
     createIcon,
-    createToolGroup
+    createToolGroup,
+    EnableToolPaletteAction,
+    ToolPalette
 } from '../../tool-palette/tool-palette';
 import { MouseDeleteTool } from '../../tools/deletion/delete-tool';
 import { MarqueeMouseTool } from '../../tools/marquee-selection/marquee-mouse-tool';

--- a/packages/client/src/features/accessibility/resize-key-tool/resize-key-tool.ts
+++ b/packages/client/src/features/accessibility/resize-key-tool/resize-key-tool.ts
@@ -14,10 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Action, GModelElement, IActionDispatcher, ISnapper, KeyListener, KeyTool, matchesKeystroke, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { Action, ISnapper, KeyListener, KeyTool, GModelElement, TYPES } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { SelectionService } from '../../../base/selection-service';
 import { EnableDefaultToolsAction, EnableToolsAction, Tool } from '../../../base/tool-manager/tool';
 import { IMovementRestrictor } from '../../change-bounds/movement-restrictor';
@@ -35,7 +33,7 @@ export class ResizeKeyTool implements Tool {
     @inject(KeyTool) protected readonly keytool: KeyTool;
     @inject(TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
     @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
-    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
     @inject(SelectionService) readonly selectionService: SelectionService;
 
     protected resizeKeyListener: ResizeKeyListener = new ResizeKeyListener(this);

--- a/packages/client/src/features/accessibility/search/search-palette.ts
+++ b/packages/client/src/features/accessibility/search/search-palette.ts
@@ -25,11 +25,11 @@ import {
     SelectAllAction,
     codiconCSSString,
     isNameable,
-    name
+    name,
+    toArray
 } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { isEqual } from 'lodash';
-import { toArray } from 'sprotty/lib/utils/iterable';
 import { BaseAutocompletePalette } from '../../../base/auto-complete/base-autocomplete-palette';
 
 import { AutocompleteSuggestion, IAutocompleteSuggestionProvider } from '../../../base/auto-complete/autocomplete-suggestion-providers';

--- a/packages/client/src/features/accessibility/search/search-tool.ts
+++ b/packages/client/src/features/accessibility/search/search-tool.ts
@@ -14,10 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import {
+    Action,
+    GModelElement,
+    IActionDispatcher,
+    KeyListener,
+    KeyTool,
+    matchesKeystroke,
+    SetUIExtensionVisibilityAction,
+    TYPES
+} from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { Action, KeyListener, KeyTool, GModelElement, SetUIExtensionVisibilityAction, TYPES } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { Tool } from '../../../base/tool-manager/tool';
 import { AccessibleKeyShortcutProvider, SetAccessibleKeyShortcutAction } from '../key-shortcut/accessible-key-shortcut';
 import { SearchAutocompletePalette } from './search-palette';
@@ -26,7 +33,7 @@ export class SearchAutocompletePaletteTool implements Tool {
     static readonly ID = 'glsp.search-autocomplete-palette-tool';
 
     protected readonly keyListener = new SearchAutocompletePaletteKeyListener(this);
-    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
     @inject(KeyTool) protected keyTool: KeyTool;
 
     get id(): string {

--- a/packages/client/src/features/accessibility/toast/toast-tool.ts
+++ b/packages/client/src/features/accessibility/toast/toast-tool.ts
@@ -14,9 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action, IActionHandler, ICommand, TYPES } from '@eclipse-glsp/sprotty';
+import { Action, IActionDispatcher, IActionHandler, ICommand, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { EditorContextService } from '../../../base/editor-context-service';
 import { IDiagramStartup } from '../../../base/model/diagram-loader';
 import { GLSPAbstractUIExtension } from '../../../base/ui-extension/ui-extension';
@@ -30,7 +29,7 @@ export class Toast extends GLSPAbstractUIExtension implements IActionHandler, ID
     static readonly ID = 'toast';
     protected messages: { [key: symbol]: ToastOptions } = {};
 
-    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected readonly actionDispatcher: IActionDispatcher;
     @inject(EditorContextService)
     protected editorContext: EditorContextService;
 

--- a/packages/client/src/features/accessibility/view-key-tools/deselect-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/deselect-key-tool.ts
@@ -14,10 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action, GModelElement, GRoutableElement, KeyListener, KeyTool, SelectAction, TYPES, isSelectable } from '@eclipse-glsp/sprotty';
+import {
+    Action,
+    GModelElement,
+    GRoutableElement,
+    KeyListener,
+    KeyTool,
+    SelectAction,
+    TYPES,
+    isSelectable,
+    matchesKeystroke,
+    toArray
+} from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { toArray } from 'sprotty/lib/utils/iterable';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import { Tool } from '../../../base/tool-manager/tool';
 import { IToolManager } from '../../../base/tool-manager/tool-manager';
 import { SwitchRoutingModeAction } from '../../tools/edge-edit/edge-edit-tool-feedback';

--- a/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/movement-key-tool.ts
@@ -14,10 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action, GModelElement, ISnapper, KeyListener, KeyTool, TYPES } from '@eclipse-glsp/sprotty';
+import { Action, GModelElement, IActionDispatcher, ISnapper, KeyListener, KeyTool, matchesKeystroke, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { SelectionService } from '../../../base/selection-service';
 import { Tool } from '../../../base/tool-manager/tool';
 import { Grid } from '../../grid/grid';
@@ -39,7 +37,7 @@ export class MovementKeyTool implements Tool {
     @inject(KeyTool) protected readonly keytool: KeyTool;
     @inject(SelectionService) selectionService: SelectionService;
     @inject(TYPES.ISnapper) @optional() readonly snapper?: ISnapper;
-    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
     @inject(TYPES.Grid) @optional() protected grid: Grid;
     @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
 

--- a/packages/client/src/features/accessibility/view-key-tools/zoom-key-tool.ts
+++ b/packages/client/src/features/accessibility/view-key-tools/zoom-key-tool.ts
@@ -14,32 +14,32 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from 'inversify';
-import { matchesKeystroke } from 'sprotty/lib/utils/keyboard';
 import {
     Action,
     CenterAction,
+    GModelElement,
+    GModelRoot,
+    IActionDispatcher,
     KeyListener,
     KeyTool,
     Point,
-    GModelElement,
-    GModelRoot,
     SetViewportAction,
     TYPES,
     Viewport,
-    isViewport
+    isViewport,
+    matchesKeystroke
 } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
+import { inject, injectable } from 'inversify';
+import { EditorContextService } from '../../../base/editor-context-service';
 import { SelectionService } from '../../../base/selection-service';
 import { Tool } from '../../../base/tool-manager/tool';
-import { SetAccessibleKeyShortcutAction } from '../key-shortcut/accessible-key-shortcut';
-import { ZoomElementAction, ZoomViewportAction } from '../move-zoom/zoom-handler';
-import { EnableKeyboardGridAction, KeyboardGridCellSelectedAction, KeyboardGridKeyboardEventAction } from '../keyboard-grid/action';
 import { getAbsolutePositionByPoint } from '../../../utils/viewpoint-util';
-import { EditorContextService } from '../../../base/editor-context-service';
-import { HideToastAction, ShowToastMessageAction } from '../toast/toast-handler';
 import { ElementNavigatorKeyListener } from '../element-navigation/diagram-navigation-tool';
+import { SetAccessibleKeyShortcutAction } from '../key-shortcut/accessible-key-shortcut';
+import { EnableKeyboardGridAction, KeyboardGridCellSelectedAction, KeyboardGridKeyboardEventAction } from '../keyboard-grid/action';
+import { ZoomElementAction, ZoomViewportAction } from '../move-zoom/zoom-handler';
 import * as messages from '../toast/messages.json';
+import { HideToastAction, ShowToastMessageAction } from '../toast/toast-handler';
 
 /**
  * Zoom viewport and elements when its focused and arrow keys are hit.
@@ -53,7 +53,7 @@ export class ZoomKeyTool implements Tool {
     protected readonly zoomKeyListener = new ZoomKeyListener(this);
 
     @inject(KeyTool) protected readonly keytool: KeyTool;
-    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) readonly actionDispatcher: IActionDispatcher;
     @inject(SelectionService) selectionService: SelectionService;
     @inject(EditorContextService)
     protected editorContextService: EditorContextService;

--- a/packages/client/src/features/bounds/local-bounds.ts
+++ b/packages/client/src/features/bounds/local-bounds.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 import {
     Action,
-    ActionDispatcher,
     Command,
     CommandExecutionContext,
     CommandResult,
@@ -24,6 +23,7 @@ import {
     ComputedBoundsApplicator,
     GModelRoot,
     GModelRootSchema,
+    IActionDispatcher,
     RequestBoundsAction,
     TYPES,
     ViewerOptions,
@@ -53,7 +53,7 @@ export namespace LocalRequestBoundsAction {
 
     export function fromCommand(
         { root }: CommandExecutionContext,
-        actionDispatcher: ActionDispatcher,
+        actionDispatcher: IActionDispatcher,
         cause?: Action,
         elementIDs?: string[]
     ): CommandResult {

--- a/packages/client/src/features/bounds/set-bounds-feedback-command.ts
+++ b/packages/client/src/features/bounds/set-bounds-feedback-command.ts
@@ -18,13 +18,13 @@ import {
     CommandExecutionContext,
     CommandReturn,
     ElementAndBounds,
+    IActionDispatcher,
     SetBoundsAction,
     SetBoundsCommand,
     TYPES,
     isLayoutContainer
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { FeedbackCommand } from '../../base/feedback/feedback-command';
 import { Ranked } from '../../base/ranked';
 import { LocalRequestBoundsAction } from './local-bounds';
@@ -51,7 +51,7 @@ export class SetBoundsFeedbackCommand extends SetBoundsCommand implements Feedba
 
     readonly rank: number = Ranked.DEFAULT_RANK;
 
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
 
     override execute(context: CommandExecutionContext): CommandReturn {
         super.execute(context);

--- a/packages/client/src/features/command-palette/server-command-palette-provider.ts
+++ b/packages/client/src/features/command-palette/server-command-palette-provider.ts
@@ -13,18 +13,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from 'inversify';
 import {
     Action,
+    GModelElement,
+    IActionDispatcher,
     ICommandPaletteActionProvider,
     LabeledAction,
     Point,
     RequestContextActions,
-    GModelElement,
     SetContextActions,
     TYPES
 } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
+import { inject, injectable } from 'inversify';
 import { EditorContextService } from '../../base/editor-context-service';
 
 export namespace ServerCommandPalette {
@@ -35,7 +35,7 @@ export namespace ServerCommandPalette {
 
 @injectable()
 export class ServerCommandPaletteActionProvider implements ICommandPaletteActionProvider {
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(EditorContextService) protected editorContext: EditorContextService;
 
     async getActions(_root: Readonly<GModelElement>, text: string, _lastMousePosition?: Point, index?: number): Promise<LabeledAction[]> {

--- a/packages/client/src/features/context-menu/glsp-context-menu-mouse-listener.ts
+++ b/packages/client/src/features/context-menu/glsp-context-menu-mouse-listener.ts
@@ -17,6 +17,7 @@ import {
     Action,
     ContextMenuProviderRegistry,
     GModelElement,
+    IActionDispatcher,
     IContextMenuService,
     IContextMenuServiceProvider,
     MouseListener,
@@ -26,7 +27,6 @@ import {
     isSelectable
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional, postConstruct } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { FocusStateChangedAction } from '../../base/focus/focus-state-change-action';
 
 @injectable()
@@ -39,8 +39,8 @@ export class GLSPContextMenuMouseListener extends MouseListener {
     @optional()
     protected menuProvider?: ContextMenuProviderRegistry;
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     protected menuService?: IContextMenuService;
 

--- a/packages/client/src/features/context-menu/server-context-menu-provider.ts
+++ b/packages/client/src/features/context-menu/server-context-menu-provider.ts
@@ -13,19 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from 'inversify';
 import {
     Action,
+    GModelElement,
+    IActionDispatcher,
     IContextMenuItemProvider,
     LabeledAction,
     Point,
     RequestContextActions,
-    GModelElement,
     SetContextActions,
     TYPES,
     isSelected
 } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
+import { inject, injectable } from 'inversify';
 import { EditorContextService } from '../../base/editor-context-service';
 
 export namespace ServerContextMenu {
@@ -34,7 +34,7 @@ export namespace ServerContextMenu {
 
 @injectable()
 export class ServerContextMenuItemProvider implements IContextMenuItemProvider {
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(EditorContextService) protected editorContext: EditorContextService;
 
     async getItems(root: Readonly<GModelElement>, _lastMousePosition?: Point): Promise<LabeledAction[]> {

--- a/packages/client/src/features/copy-paste/copy-paste-handler.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-handler.ts
@@ -13,18 +13,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from 'inversify';
-import { v4 as uuid } from 'uuid';
 import {
     ClipboardData,
     CutOperation,
+    IActionDispatcher,
     PasteOperation,
     RequestClipboardDataAction,
     SetClipboardDataAction,
     TYPES,
     ViewerOptions
 } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
+import { inject, injectable } from 'inversify';
+import { v4 as uuid } from 'uuid';
 import { EditorContextService } from '../../base/editor-context-service';
 
 export interface ICopyPasteHandler {
@@ -100,7 +100,7 @@ const CLIPBOARD_DATA_FORMAT = 'text/plain';
 
 @injectable()
 export class ServerCopyPasteHandler implements ICopyPasteHandler {
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
     @inject(TYPES.IAsyncClipboardService) protected clipboardService: IAsyncClipboardService;
     @inject(EditorContextService) protected editorContext: EditorContextService;

--- a/packages/client/src/features/element-template/add-template-element.ts
+++ b/packages/client/src/features/element-template/add-template-element.ts
@@ -21,12 +21,12 @@ import {
     ElementTemplate,
     GChildElement,
     GModelElementSchema,
+    IActionDispatcher,
     TYPES,
     distinctAdd,
     remove
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { FeedbackCommand } from '../../base/feedback/feedback-command';
 import { isNotUndefined } from '../../utils/gmodel-util';
 import { LocalRequestBoundsAction } from '../bounds/local-bounds';
@@ -57,7 +57,7 @@ export function getTemplateElementId(template: ElementTemplate): string {
 export class AddTemplateElementsFeedbackCommand extends FeedbackCommand {
     static readonly KIND = AddTemplateElementsAction.KIND;
 
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
 
     constructor(@inject(TYPES.Action) readonly action: AddTemplateElementsAction) {
         super();

--- a/packages/client/src/features/hints/type-hint-provider.spec.ts
+++ b/packages/client/src/features/hints/type-hint-provider.spec.ts
@@ -37,15 +37,16 @@ import { Container } from 'inversify';
 import * as sinon from 'sinon';
 import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { FeedbackActionDispatcher } from '../../base/feedback/feedback-action-dispatcher-default';
+import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
 import { GEdge } from '../../model';
 import { isResizable } from '../change-bounds/model';
 import { isReconnectable } from '../reconnect/model';
 import { Containable, isContainable, isReparentable } from './model';
 import { ApplyTypeHintsAction, ApplyTypeHintsCommand, ITypeHintProvider, TypeHintProvider } from './type-hint-provider';
-import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
 describe('TypeHintProvider', () => {
     const container = new Container();
     container.bind(GLSPActionDispatcher).toConstantValue(sinon.createStubInstance(GLSPActionDispatcher));
+    container.bind(TYPES.IActionDispatcher).toService(GLSPActionDispatcher);
     const stub = sinon.createStubInstance(FeedbackActionDispatcher);
     stub.createEmitter.returns(new FeedbackEmitter(stub));
     container.bind(TYPES.IFeedbackActionDispatcher).toConstantValue(stub);
@@ -163,6 +164,7 @@ describe('ApplyTypeHintCommand', () => {
         getShapeTypeHint: () => undefined
     });
     container.bind(GLSPActionDispatcher).toConstantValue(sandbox.createStubInstance(GLSPActionDispatcher));
+    container.bind(TYPES.IActionDispatcher).toService(GLSPActionDispatcher);
     container.bind(TYPES.IFeedbackActionDispatcher).toConstantValue(sandbox.createStubInstance(FeedbackActionDispatcher));
     container.bind(TYPES.ITypeHintProvider).toConstantValue(typeHintProviderMock);
     bindOrRebind(container, TYPES.Action).toConstantValue(ApplyTypeHintsAction.create());

--- a/packages/client/src/features/hints/type-hint-provider.ts
+++ b/packages/client/src/features/hints/type-hint-provider.ts
@@ -23,6 +23,7 @@ import {
     GModelRoot,
     GRoutableElement,
     GShapeElement,
+    IActionDispatcher,
     IActionHandler,
     RequestTypeHintsAction,
     SetTypeHintsAction,
@@ -37,7 +38,6 @@ import {
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, postConstruct } from 'inversify';
 
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { IFeedbackActionDispatcher } from '../../base/feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../base/feedback/feedback-command';
 import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
@@ -202,8 +202,8 @@ export class TypeHintProvider implements IActionHandler, ITypeHintProvider, IDia
     @inject(TYPES.IFeedbackActionDispatcher)
     protected feedbackActionDispatcher: IFeedbackActionDispatcher;
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     protected typeHintsFeedback: FeedbackEmitter;
     protected shapeHints: Map<string, ShapeTypeHint> = new Map();

--- a/packages/client/src/features/label-edit/edit-label-validator.ts
+++ b/packages/client/src/features/label-edit/edit-label-validator.ts
@@ -13,21 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from 'inversify';
 import {
     Action,
     EditLabelValidationResult,
     EditableLabel,
+    GModelElement,
+    IActionDispatcher,
     IEditLabelValidationDecorator,
     IEditLabelValidator,
     RequestEditValidationAction,
-    GModelElement,
     SetEditValidationResultAction,
     Severity,
     TYPES,
     ValidationStatus
 } from '@eclipse-glsp/sprotty';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
+import { inject, injectable } from 'inversify';
 
 export namespace LabelEditValidation {
     export const CONTEXT_ID = 'label-edit';
@@ -50,7 +50,7 @@ export namespace LabelEditValidation {
 
 @injectable()
 export class ServerEditLabelValidator implements IEditLabelValidator {
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
 
     async validate(value: string, label: EditableLabel & GModelElement): Promise<EditLabelValidationResult> {
         const action = LabelEditValidation.createValidationRequestAction(value, label.id);

--- a/packages/client/src/features/layout/layout-elements-action.spec.ts
+++ b/packages/client/src/features/layout/layout-elements-action.spec.ts
@@ -57,6 +57,18 @@ import {
 
 class MockActionDispatcher implements IActionDispatcher {
     constructor(public dispatchedActions: Action[] = []) {}
+    requestUntil<Res extends ResponseAction>(
+        action: RequestAction<Res>,
+        timeoutMs?: number | undefined,
+        rejectOnTimeout?: boolean | undefined
+    ): Promise<Res | undefined> {
+        throw new Error('Method not implemented.');
+    }
+    dispatchOnceModelInitialized(...actions: Action[]): void {}
+    onceModelInitialized(): Promise<void> {
+        return Promise.resolve();
+    }
+    dispatchAfterNextUpdate(...actions: Action[]): void {}
     dispatch(action: Action): Promise<void> {
         this.dispatchedActions.push(action);
         return Promise.resolve();

--- a/packages/client/src/features/status/status-overlay.ts
+++ b/packages/client/src/features/status/status-overlay.ts
@@ -13,9 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { IActionHandler, StatusAction, codiconCSSClasses } from '@eclipse-glsp/sprotty';
+import { IActionDispatcher, IActionHandler, StatusAction, TYPES, codiconCSSClasses } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { EditorContextService } from '../../base/editor-context-service';
 import { IDiagramStartup } from '../../base/model/diagram-loader';
 import { GLSPAbstractUIExtension } from '../../base/ui-extension/ui-extension';
@@ -27,8 +26,8 @@ import { GLSPAbstractUIExtension } from '../../base/ui-extension/ui-extension';
 export class StatusOverlay extends GLSPAbstractUIExtension implements IActionHandler, IDiagramStartup {
     static readonly ID = 'glsp.server.status.overlay';
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     @inject(EditorContextService)
     protected editorContext: EditorContextService;

--- a/packages/client/src/features/tool-palette/tool-palette.ts
+++ b/packages/client/src/features/tool-palette/tool-palette.ts
@@ -16,6 +16,7 @@
 import {
     Action,
     GModelRoot,
+    IActionDispatcher,
     IActionHandler,
     ICommand,
     MarkersReason,
@@ -32,7 +33,6 @@ import {
     matchesKeystroke
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional, postConstruct } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { EditorContextService, IEditModeListener } from '../../base/editor-context-service';
 import { FocusTracker } from '../../base/focus/focus-tracker';
 import { IDiagramStartup } from '../../base/model/diagram-loader';
@@ -69,8 +69,8 @@ export namespace EnableToolPaletteAction {
 export class ToolPalette extends GLSPAbstractUIExtension implements IActionHandler, IEditModeListener, IDiagramStartup {
     static readonly ID = 'tool-palette';
 
-    @inject(GLSPActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher)
+    protected actionDispatcher: IActionDispatcher;
 
     @inject(EditorContextService)
     protected editorContext: EditorContextService;

--- a/packages/client/src/features/tools/base-tools.ts
+++ b/packages/client/src/features/tools/base-tools.ts
@@ -13,9 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, Disposable, DisposableCollection, IActionHandler, TYPES } from '@eclipse-glsp/sprotty';
+import { Action, Disposable, DisposableCollection, IActionDispatcher, IActionHandler, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { EditorContextService } from '../../base/editor-context-service';
 import { IFeedbackActionDispatcher, IFeedbackEmitter, MaybeActions } from '../../base/feedback/feedback-action-dispatcher';
 import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
@@ -59,7 +58,7 @@ export interface FeedbackAwareTool extends Tool {
 @injectable()
 export abstract class BaseEditTool implements FeedbackAwareTool {
     @inject(TYPES.IFeedbackActionDispatcher) protected feedbackDispatcher: IFeedbackActionDispatcher;
-    @inject(TYPES.IActionDispatcher) protected actionDispatcher: GLSPActionDispatcher;
+    @inject(TYPES.IActionDispatcher) protected actionDispatcher: IActionDispatcher;
     @inject(GLSPMouseTool) protected mouseTool: GLSPMouseTool;
     @inject(GLSPKeyTool) protected keyTool: GLSPKeyTool;
     @inject(EditorContextService) protected readonly editorContext: EditorContextService;

--- a/packages/client/src/features/tools/edge-creation/edge-creation-tool.ts
+++ b/packages/client/src/features/tools/edge-creation/edge-creation-tool.ts
@@ -19,6 +19,7 @@ import {
     Args,
     CreateEdgeOperation,
     GModelElement,
+    IActionDispatcher,
     RequestCheckEdgeAction,
     TYPES,
     TriggerEdgeCreationAction,
@@ -27,7 +28,6 @@ import {
     isCtrlOrCmd
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
-import { GLSPActionDispatcher } from '../../../base/action-dispatcher';
 import { DragAwareMouseListener } from '../../../base/drag-aware-mouse-listener';
 import { CursorCSS, cursorFeedbackAction } from '../../../base/feedback/css-feedback';
 import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
@@ -98,7 +98,7 @@ export class EdgeCreationToolMouseListener extends DragAwareMouseListener {
 
     constructor(
         protected triggerAction: TriggerEdgeCreationAction,
-        protected actionDispatcher: GLSPActionDispatcher,
+        protected actionDispatcher: IActionDispatcher,
         protected typeHintProvider: ITypeHintProvider,
         protected tool: EdgeCreationTool,
         protected dragSensitivity?: number

--- a/packages/client/src/features/validation/marker-navigator.ts
+++ b/packages/client/src/features/validation/marker-navigator.ts
@@ -19,6 +19,7 @@ import {
     GIssueSeverity,
     GModelElement,
     GModelRoot,
+    IActionDispatcher,
     IActionHandler,
     IContextMenuItemProvider,
     KeyListener,
@@ -34,7 +35,6 @@ import {
     matchesKeystroke
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { GLSPActionDispatcher } from '../../base/action-dispatcher';
 import { SelectionService } from '../../base/selection-service';
 import { BoundsAwareModelElement, SelectableElement, getElements, isSelectableAndBoundsAware } from '../../utils/gmodel-util';
 import { MarkerPredicates, collectIssueMarkers } from '../../utils/marker';
@@ -166,7 +166,7 @@ export class NavigateToMarkerActionHandler implements IActionHandler {
     protected selectionService: SelectionService;
 
     @inject(TYPES.IActionDispatcher)
-    protected actionDispatcher: GLSPActionDispatcher;
+    protected actionDispatcher: IActionDispatcher;
 
     handle(action: NavigateToMarkerAction): void {
         const selected = this.getSelectedElements(action);

--- a/packages/glsp-sprotty/src/api-override.ts
+++ b/packages/glsp-sprotty/src/api-override.ts
@@ -26,7 +26,7 @@ import {
     IButtonHandler as SIButtonHandler,
     ICommandPaletteActionProvider as SICommandPaletteActionProvider,
     IContextMenuItemProvider as SIContextMenuItemProvider,
-    IVNodePostprocessor as SIVnodePostprocessor,
+    IVNodePostprocessor as SIVNodePostprocessor,
     KeyListener as SKeyListener,
     MouseListener as SMouseListener
 } from 'sprotty';
@@ -130,7 +130,7 @@ export class MouseListener extends SMouseListener {
  * Manipulates a created VNode after it has been created.
  * Used to register listeners and add animations.
  */
-export interface IVNodePostprocessor extends SIVnodePostprocessor {
+export interface IVNodePostprocessor extends SIVNodePostprocessor {
     decorate(vnode: VNode, element: GModelElement): VNode;
 }
 
@@ -151,9 +151,9 @@ export interface IActionDispatcher extends SIActionDispatcher {
      * identifier is dispatched. That response is _not_ passed to the registered action
      * handlers. Instead, it is the responsibility of the caller of this method to handle
      * the response properly. For example, it can be sent to the registered handlers by
-     * passing it again to the `dispatch` method.
+     * passing it to the `dispatch` method.
      *
-     * If no explicit `requestId` has been set on the action,  a generated id will be set before dispatching the action
+     * If no explicit `requestId` has been set on the action, a generated id will be set before dispatching the action.
      */
     request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res>;
     // GLSP-specific API additions

--- a/packages/glsp-sprotty/src/api-override.ts
+++ b/packages/glsp-sprotty/src/api-override.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, LabeledAction, Point } from '@eclipse-glsp/protocol';
+import { Action, LabeledAction, Point, RequestAction, ResponseAction } from '@eclipse-glsp/protocol';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import {
@@ -21,10 +21,12 @@ import {
     SModelElementImpl as GModelElement,
     SModelRootImpl as GModelRoot,
     ICommand,
+    IActionDispatcher as SIActionDispatcher,
     IActionHandler as SIActionHandler,
     IButtonHandler as SIButtonHandler,
     ICommandPaletteActionProvider as SICommandPaletteActionProvider,
     IContextMenuItemProvider as SIContextMenuItemProvider,
+    IVNodePostprocessor as SIVnodePostprocessor,
     KeyListener as SKeyListener,
     MouseListener as SMouseListener
 } from 'sprotty';
@@ -32,9 +34,11 @@ import {
 /*
  * The GLSP-protocol comes with its own type definition for `Action`. However, sprotty
  * also has a separate `Action` definition that is heavily integrated into core API concepts.
- * While these two definitions are fully compatible it messes up IDE support for auto import
- * when implementing/overriding these API Concepts. To bypass this issue we create sub types
- * of the sprotty API concepts that use the Action definition from GLSP and export them instead.
+ * While these two definitions are fully compatible it messes up IDE support for auto import.
+ * The same problem also applies  to references of sprotty's internal SModel in the API.
+ * To bypass this issue we create sub types of the sprotty API concepts that use the Action/GModel definition from GLSP
+ * and export them instead.
+ *
  */
 
 /**
@@ -122,3 +126,68 @@ export class MouseListener extends SMouseListener {
         return vnode;
     }
 }
+/**
+ * Manipulates a created VNode after it has been created.
+ * Used to register listeners and add animations.
+ */
+export interface IVNodePostprocessor extends SIVnodePostprocessor {
+    decorate(vnode: VNode, element: GModelElement): VNode;
+}
+
+export interface IActionDispatcher extends SIActionDispatcher {
+    /**
+     * Dispatch an action by querying all handlers that are registered for its kind.
+     * The returned promise is resolved when all handler results (commands or actions)
+     * have been processed.
+     */
+    dispatch(action: Action): Promise<void>;
+    /**
+     * Calls `dispatch` on every action in the given array. The returned promise
+     * is resolved when the promises of all `dispatch` calls have been resolved.
+     */
+    dispatchAll(actions: Action[]): Promise<void>;
+    /**
+     * Dispatch a request. The returned promise is resolved when a response with matching
+     * identifier is dispatched. That response is _not_ passed to the registered action
+     * handlers. Instead, it is the responsibility of the caller of this method to handle
+     * the response properly. For example, it can be sent to the registered handlers by
+     * passing it again to the `dispatch` method.
+     *
+     * If no explicit `requestId` has been set on the action,  a generated id will be set before dispatching the action
+     */
+    request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res>;
+    // GLSP-specific API additions
+    /**
+     * Dispatch a request and waits for a response until the timeout given in `timeoutMs` (default 2000) has
+     * been reached. The returned promise is resolved when a response with matching identifier
+     * is dispatched or when the timeout has been reached. That response is _not_ passed to the
+     * registered action handlers. Instead, it is the responsibility of the caller of this method
+     * to handle the response properly. For example, it can be sent to the registered handlers by
+     * passing it again to the `dispatch` method.
+     * If `rejectOnTimeout` is set to false (default) the returned promise will be resolved with
+     * no value, otherwise it will be rejected.
+     */
+    requestUntil<Res extends ResponseAction>(
+        action: RequestAction<Res>,
+        timeoutMs?: number,
+        rejectOnTimeout?: boolean
+    ): Promise<Res | undefined>;
+    /**
+     * Processes all given actions, by dispatching them to the corresponding handlers, after the model initialization is completed.
+     */
+    dispatchOnceModelInitialized(...actions: Action[]): void;
+
+    /**
+     * Returns a promise that resolves once the model initialization is completed.
+     */
+    onceModelInitialized(): Promise<void>;
+
+    /**
+     * Processes all given actions, by dispatching them to the corresponding handlers, after the next model update.
+     * The given actions are queued until the next model update cycle has been completed i.e.
+     * the `EditorContextService.onModelRootChanged` event is triggered.
+     */
+    dispatchAfterNextUpdate(...actions: Action[]): void;
+}
+
+export type IActionDispatcherProvider = () => Promise<IActionDispatcher>;

--- a/packages/glsp-sprotty/src/index.ts
+++ b/packages/glsp-sprotty/src/index.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './action-override';
+export * from './api-override';
 export * from './feature-modules';
 export * from './re-exports';
 export * from './svg-views-override';

--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -27,12 +27,13 @@ export * from '@eclipse-glsp/protocol/lib/di';
 
 // Exclude  definition for labeled actions
 // export * from 'sprotty/lib/base/actions/action';
-export * from 'sprotty/lib/base/actions/action-dispatcher';
+// Exclude IActionDispatcher and IActionDispatcherProvider. Exported via api-override module instead
+export { ActionDispatcher, PostponedAction } from 'sprotty/lib/base/actions/action-dispatcher';
 export {
     ActionHandlerRegistration,
     ActionHandlerRegistry,
-    configureActionHandler,
     IActionHandlerInitializer,
+    configureActionHandler,
     onAction
 } from 'sprotty/lib/base/actions/action-handler';
 export * from 'sprotty/lib/base/actions/diagram-locker';
@@ -50,19 +51,18 @@ export * from 'sprotty/lib/base/features/initialize-canvas';
 export * from 'sprotty/lib/base/features/set-model';
 // Exclude SModelElementImpl as it as exported with augmentation module
 export {
-    createRandomId,
     FeatureSet,
     SChildElementImpl as GChildElement,
     SModelElementImpl as GModelElement,
     SModelRootImpl as GModelRoot,
     SParentElementImpl as GParentElement,
     IModelIndex,
-    isParent,
-    ModelIndexImpl
+    ModelIndexImpl,
+    createRandomId,
+    isParent
 } from 'sprotty/lib/base/model/smodel';
 
 export {
-    createFeatureSet,
     CustomFeatures,
     EMPTY_ROOT,
     SModelElementConstructor as GModelElementConstructor,
@@ -70,7 +70,8 @@ export {
     SModelFactory as GModelFactory,
     IModelFactory,
     // exported without alias we extend it in glsp-client to `GModelRegistry`
-    SModelRegistry
+    SModelRegistry,
+    createFeatureSet
 } from 'sprotty/lib/base/model/smodel-factory';
 export * from 'sprotty/lib/base/model/smodel-utils';
 
@@ -85,7 +86,8 @@ export * from 'sprotty/lib/base/views/view';
 export * from 'sprotty/lib/base/views/viewer';
 export * from 'sprotty/lib/base/views/viewer-cache';
 export * from 'sprotty/lib/base/views/viewer-options';
-export * from 'sprotty/lib/base/views/vnode-postprocessor';
+// Exclude IVnodePostprocessor. Exported via api-override module instead
+export { FocusFixPostprocessor } from 'sprotty/lib/base/views/vnode-postprocessor';
 export * from 'sprotty/lib/base/views/vnode-utils';
 
 // Exclude sprotty types and export augmented GLSP types instead
@@ -99,30 +101,30 @@ export * from 'sprotty/lib/features/bounds/hidden-bounds-updater';
 export * from 'sprotty/lib/features/bounds/layout';
 export { AbstractLayoutOptions } from 'sprotty/lib/features/bounds/layout-options';
 export {
-    alignFeature,
     InternalBoundsAware as BoundsAware,
+    SShapeElementImpl as GShapeElement,
+    InternalLayoutContainer as LayoutContainer,
+    InternalLayoutableChild as LayoutableChild,
+    ModelLayoutOptions,
+    alignFeature,
     boundsFeature,
     findChildrenAtPosition,
     getAbsoluteBounds,
     getAbsoluteClientBounds,
-    SShapeElementImpl as GShapeElement,
     isAlignable,
     isBoundsAware,
-    isLayoutableChild,
     isLayoutContainer,
+    isLayoutableChild,
     isSizeable,
-    InternalLayoutableChild as LayoutableChild,
-    layoutableChildFeature,
-    InternalLayoutContainer as LayoutContainer,
     layoutContainerFeature,
-    ModelLayoutOptions
+    layoutableChildFeature
 } from 'sprotty/lib/features/bounds/model';
 // exclude stack layout as its not supported in GLSP
 // export * from 'sprotty/lib/features/bounds/stack-layout';
 export * from 'sprotty/lib/features/bounds/vbox-layout';
 export * from 'sprotty/lib/features/bounds/views';
 
-export { ButtonHandlerRegistry, configureButtonHandler, IButtonHandlerRegistration } from 'sprotty/lib/features/button/button-handler';
+export { ButtonHandlerRegistry, IButtonHandlerRegistration, configureButtonHandler } from 'sprotty/lib/features/button/button-handler';
 export { SButtonImpl as GButton } from 'sprotty/lib/features/button/model';
 
 export {
@@ -138,7 +140,7 @@ export * from 'sprotty/lib/features/context-menu/mouse-listener';
 
 export * from 'sprotty/lib/features/edge-layout/di.config';
 export * from 'sprotty/lib/features/edge-layout/edge-layout';
-export { checkEdgePlacement, DEFAULT_EDGE_PLACEMENT, edgeLayoutFeature, isEdgeLayoutable } from 'sprotty/lib/features/edge-layout/model';
+export { DEFAULT_EDGE_PLACEMENT, checkEdgePlacement, edgeLayoutFeature, isEdgeLayoutable } from 'sprotty/lib/features/edge-layout/model';
 // Exclude client-side creation features (not supported in GLSP)
 // export * from 'sprotty/lib/features/edit/create';
 // export * from 'sprotty/lib/features/edit/create-on-drag';
@@ -169,10 +171,10 @@ export * from 'sprotty/lib/features/hover/popup-position-updater';
 export * from 'sprotty/lib/features/decoration/decoration-placer';
 export {
     Decoration,
-    decorationFeature,
     SDecoration as GDecoration,
-    isDecoration,
-    SIssueMarkerImpl
+    SIssueMarkerImpl,
+    decorationFeature,
+    isDecoration
 } from 'sprotty/lib/features/decoration/model';
 export * from 'sprotty/lib/features/decoration/views';
 
@@ -190,7 +192,7 @@ export * from 'sprotty/lib/features/nameable/model';
 export * from 'sprotty/lib/features/open/model';
 export * from 'sprotty/lib/features/open/open';
 
-export { getModelBounds, getProjectedBounds, getProjections, isProjectable, ViewProjection } from 'sprotty/lib/features/projection/model';
+export { ViewProjection, getModelBounds, getProjectedBounds, getProjections, isProjectable } from 'sprotty/lib/features/projection/model';
 export * from 'sprotty/lib/features/projection/views';
 
 export * from 'sprotty/lib/features/routing/abstract-edge-router';
@@ -203,17 +205,17 @@ export * from 'sprotty/lib/features/routing/manhattan-edge-router';
 // Alias SModel types
 export {
     Connectable,
+    SConnectableElementImpl as GConnectableElement,
+    SDanglingAnchorImpl as GDanglingAnchor,
+    SRoutableElementImpl as GRoutableElement,
+    SRoutingHandleImpl as GRoutingHandle,
+    RoutingHandleKind,
     connectableFeature,
     edgeInProgressID,
     edgeInProgressTargetHandleID,
-    SConnectableElementImpl as GConnectableElement,
-    SDanglingAnchorImpl as GDanglingAnchor,
     getAbsoluteRouteBounds,
     getRouteBounds,
-    SRoutableElementImpl as GRoutableElement,
-    SRoutingHandleImpl as GRoutingHandle,
-    isConnectable,
-    RoutingHandleKind
+    isConnectable
 } from 'sprotty/lib/features/routing/model';
 export * from 'sprotty/lib/features/routing/polyline-anchors';
 export * from 'sprotty/lib/features/routing/polyline-edge-router';


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Rename `action-override` module of @eclipse-glsp/sprotty to `api-override` which  a better fit.
- Add additional API methods of the `GLSPActionDispatcher` directly to the `IActionDispatcher` interface and update related code for consistent usage of the interface. Export new `IActionDispatcher` interface via api-override
- Also add API override for `IVNodePostProcessor`

Also:
- Adjust directs imports of `matchesKeystroke` and `toArray` from sprotty.  Import from @eclipse/glsp-sprotty instead

Fixes https://github.com/eclipse-glsp/glsp/issues/1416

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Everything should still work as expected.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
