### PR TITLE
GLSP-1421: Properly scope standalone copy-paste listeners

### DIFF
--- a/packages/client/src/features/copy-paste/copy-paste-modules.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-modules.ts
@@ -33,6 +33,7 @@ export const copyPasteModule = new FeatureModule(
 export const standaloneCopyPasteModule = new FeatureModule(
     (bind, _unbind, isBound) => {
         bindAsService(bind, TYPES.IDiagramStartup, CopyPasteStartup);
+        bind(TYPES.IGModelRootListener).toService(CopyPasteStartup);
     },
     {
         featureId: Symbol('standaloneCopyPaste'),


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Ensure that the cut/copy/paste listers for the standalonCopyPasteModule are only invoked if the diagram is currently active (i.e. the active dom element is the diagram svg)

Fixes https://github.com/eclipse-glsp/glsp/issues/1421

#### How to test

Copy & Paste on the diagram should work as expected.
If the diagram is not selected directly e.g. focus is on the tool palette the listener should not trigger.
1. Select and copy a part of the diagram (Ctrl+C)
2. Click a button of the tool palette
3. Try to paste with Ctrl+V
4. Ensure that no elemens are added to the diagram

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
