### PR TITLE
GLSP-1423 Add MovementBehavior to control invalid multi element movements

### DIFF
--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -185,14 +185,14 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener {
         if (!this.tracker.isTracking()) {
             return [];
         }
-        const elementToMove = this.getElementsToMove(target);
-        if (!this.tool.movementBehavior.allElementsNeedToBeValid) {
+        const elementsToMove = this.getElementsToMove(target);
+        if (!this.tool.movementOptions.allElementsNeedToBeValid) {
             // only reset the move of invalid elements, the others will be handled by the change bounds tool itself
-            elementToMove
+            elementsToMove
                 .filter(element => this.tool.changeBoundsManager.isValid(element))
                 .forEach(element => this.elementId2startPos.delete(element.id));
         } else {
-            if (elementToMove.every(element => this.tool.changeBoundsManager.isValid(element))) {
+            if (elementsToMove.every(element => this.tool.changeBoundsManager.isValid(element))) {
                 // do not reset any element as all are valid
                 this.elementId2startPos.clear();
             }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -185,10 +185,18 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener {
         if (!this.tracker.isTracking()) {
             return [];
         }
-        // only reset the move of invalid elements, the others will be handled by the change bounds tool itself
-        this.getElementsToMove(target)
-            .filter(element => this.tool.changeBoundsManager.isValid(element))
-            .forEach(element => this.elementId2startPos.delete(element.id));
+        const elementToMove = this.getElementsToMove(target);
+        if (!this.tool.movementBehavior.allElementsNeedToBeValid) {
+            // only reset the move of invalid elements, the others will be handled by the change bounds tool itself
+            elementToMove
+                .filter(element => this.tool.changeBoundsManager.isValid(element))
+                .forEach(element => this.elementId2startPos.delete(element.id));
+        } else {
+            if (elementToMove.find(element => !this.tool.changeBoundsManager.isValid(element)) === undefined) {
+                // do not reset any element as all are valid
+                this.elementId2startPos.clear();
+            }
+        }
         this.dispose();
         return [];
     }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -192,7 +192,7 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener {
                 .filter(element => this.tool.changeBoundsManager.isValid(element))
                 .forEach(element => this.elementId2startPos.delete(element.id));
         } else {
-            if (elementToMove.find(element => !this.tool.changeBoundsManager.isValid(element)) === undefined) {
+            if (elementToMove.every(element => this.tool.changeBoundsManager.isValid(element))) {
                 // do not reset any element as all are valid
                 this.elementId2startPos.clear();
             }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -63,7 +63,8 @@ import {
 import { FeedbackMoveMouseListener } from './change-bounds-tool-move-feedback';
 import { ChangeBoundsTracker, TrackedElementResize, TrackedResize } from './change-bounds-tracker';
 
-export interface IMovementBehavior {
+export interface IMovementOptions {
+    /** If set to true, a move with multiple elements is only performed if each individual move is valid. */
     readonly allElementsNeedToBeValid: boolean;
 }
 
@@ -88,7 +89,7 @@ export class ChangeBoundsTool extends BaseEditTool {
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
     @inject(TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
     @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
-    @inject(TYPES.IMovementBehavior) @optional() readonly movementBehavior: IMovementBehavior = { allElementsNeedToBeValid: true };
+    @inject(TYPES.IMovementOptions) @optional() readonly movementBehavior: IMovementOptions = { allElementsNeedToBeValid: true };
 
     get id(): string {
         return ChangeBoundsTool.ID;

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -89,7 +89,7 @@ export class ChangeBoundsTool extends BaseEditTool {
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
     @inject(TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
     @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
-    @inject(TYPES.IMovementOptions) @optional() readonly movementBehavior: IMovementOptions = { allElementsNeedToBeValid: true };
+    @inject(TYPES.IMovementOptions) @optional() readonly movementOptions: IMovementOptions = { allElementsNeedToBeValid: true };
 
     get id(): string {
         return ChangeBoundsTool.ID;
@@ -267,7 +267,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         const selectedElements = getMatchingElements(target.index, isNonRoutableSelectedMovableBoundsAware);
         const selectionSet: Set<BoundsAwareModelElement> = new Set(selectedElements);
         const elementsToMove = selectedElements.filter(element => this.isValidMove(element, selectionSet));
-        if (this.tool.movementBehavior.allElementsNeedToBeValid && elementsToMove.length !== selectionSet.size) {
+        if (this.tool.movementOptions.allElementsNeedToBeValid && elementsToMove.length !== selectionSet.size) {
             return [];
         }
         return elementsToMove;

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -63,6 +63,10 @@ import {
 import { FeedbackMoveMouseListener } from './change-bounds-tool-move-feedback';
 import { ChangeBoundsTracker, TrackedElementResize, TrackedResize } from './change-bounds-tracker';
 
+export interface IMovementBehavior {
+    readonly allElementsNeedToBeValid: boolean;
+}
+
 /**
  * The change bounds tool has the license to move multiple elements or resize a single element by implementing the ChangeBounds operation.
  * In contrast to Sprotty's implementation this tool only sends a `ChangeBoundsOperationAction` when an operation has finished and does not
@@ -84,6 +88,7 @@ export class ChangeBoundsTool extends BaseEditTool {
     @inject(EdgeRouterRegistry) @optional() readonly edgeRouterRegistry?: EdgeRouterRegistry;
     @inject(TYPES.IMovementRestrictor) @optional() readonly movementRestrictor?: IMovementRestrictor;
     @inject(TYPES.IChangeBoundsManager) readonly changeBoundsManager: IChangeBoundsManager;
+    @inject(TYPES.IMovementBehavior) @optional() readonly movementBehavior: IMovementBehavior = { allElementsNeedToBeValid: true };
 
     get id(): string {
         return ChangeBoundsTool.ID;
@@ -260,7 +265,11 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
     protected getElementsToMove(target: GModelElement): SelectableBoundsAware[] {
         const selectedElements = getMatchingElements(target.index, isNonRoutableSelectedMovableBoundsAware);
         const selectionSet: Set<BoundsAwareModelElement> = new Set(selectedElements);
-        return selectedElements.filter(element => this.isValidMove(element, selectionSet));
+        const elementsToMove = selectedElements.filter(element => this.isValidMove(element, selectionSet));
+        if (this.tool.movementBehavior.allElementsNeedToBeValid && elementsToMove.length !== selectionSet.size) {
+            return [];
+        }
+        return elementsToMove;
     }
 
     protected handleMoveElementsOnServer(elementsToMove: SelectableBoundsAware[]): Operation[] {

--- a/packages/glsp-sprotty/src/types.ts
+++ b/packages/glsp-sprotty/src/types.ts
@@ -30,6 +30,7 @@ export const TYPES = {
     IToolFactory: Symbol('Factory<Tool>'),
     ITypeHintProvider: Symbol('ITypeHintProvider'),
     IMovementRestrictor: Symbol('IMovementRestrictor'),
+    IMovementBehavior: Symbol('IMovementBehavior'),
     ISelectionListener: Symbol('ISelectionListener'),
     /** @deprecated Use {@link TYPES.IGModelRootListener} instead */
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/glsp-sprotty/src/types.ts
+++ b/packages/glsp-sprotty/src/types.ts
@@ -30,7 +30,7 @@ export const TYPES = {
     IToolFactory: Symbol('Factory<Tool>'),
     ITypeHintProvider: Symbol('ITypeHintProvider'),
     IMovementRestrictor: Symbol('IMovementRestrictor'),
-    IMovementBehavior: Symbol('IMovementBehavior'),
+    IMovementOptions: Symbol('IMovementOptions'),
     ISelectionListener: Symbol('ISelectionListener'),
     /** @deprecated Use {@link TYPES.IGModelRootListener} instead */
     // eslint-disable-next-line deprecation/deprecation


### PR DESCRIPTION
#### What it does

Fixes: https://github.com/eclipse-glsp/glsp/issues/1423

Per default change the behavior that all selected elements will be reset to it's origin location when one move is invalid. But add an `IMovementBehavior` type where this can be changed to the old style.

_Question:_ 
- Should also the red border feedback be on both elements?
- Better name for the options type / flag on the type?

#### How to test

Add to the `examples/workflow-standalone/src/di.config.ts`
```ts
export default function createContainer(options: IDiagramOptions): Container {
  ...
  container.bind(TYPES.IMovementRestrictor).to(NoOverlapMovementRestrictor);
  container.bind(TYPES.IMovementBehavior).toConstantValue({ allElementsNeedToBeValid: true }); //or false for the old behavior
  return container;
}
```

_New behavior:_
![Screen Recording 2024-11-20 at 16 02 56](https://github.com/user-attachments/assets/f8d9c4f2-6a17-44de-99b0-22ab358bae24)

_Old behavior:_
![Screen Recording 2024-11-20 at 15 50 45](https://github.com/user-attachments/assets/aa2ecf6a-9ad6-459f-903c-83787e6a42d6)


#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
