### PR TITLE
GLSP-1427: Improve diagram loading and commmand handling

### DIFF
--- a/packages/client/src/features/accessibility/toast/toast-tool.ts
+++ b/packages/client/src/features/accessibility/toast/toast-tool.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Action, IActionDispatcher, IActionHandler, ICommand, TYPES } from '@eclipse-glsp/sprotty';
+import { Action, IActionDispatcher, IActionHandler, ICommand, SetUIExtensionVisibilityAction, TYPES } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
 import { EditorContextService } from '../../../base/editor-context-service';
 import { IDiagramStartup } from '../../../base/model/diagram-loader';
@@ -99,7 +99,7 @@ export class Toast extends GLSPAbstractUIExtension implements IActionHandler, ID
     }
 
     preInitialize(): void {
-        this.show(this.editorContext.modelRoot);
+        this.actionDispatcher.dispatch(SetUIExtensionVisibilityAction.create({ extensionId: Toast.ID, visible: true }));
     }
 
     values(obj: { [key: symbol]: ToastOptions }): ToastOptions[] {

--- a/packages/client/src/features/status/status-overlay.ts
+++ b/packages/client/src/features/status/status-overlay.ts
@@ -13,9 +13,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { IActionDispatcher, IActionHandler, StatusAction, TYPES, codiconCSSClasses } from '@eclipse-glsp/sprotty';
+import {
+    IActionDispatcher,
+    IActionHandler,
+    SetUIExtensionVisibilityAction,
+    StatusAction,
+    TYPES,
+    codiconCSSClasses
+} from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { EditorContextService } from '../../base/editor-context-service';
 import { IDiagramStartup } from '../../base/model/diagram-loader';
 import { GLSPAbstractUIExtension } from '../../base/ui-extension/ui-extension';
 
@@ -28,9 +34,6 @@ export class StatusOverlay extends GLSPAbstractUIExtension implements IActionHan
 
     @inject(TYPES.IActionDispatcher)
     protected actionDispatcher: IActionDispatcher;
-
-    @inject(EditorContextService)
-    protected editorContext: EditorContextService;
 
     protected statusIconDiv?: HTMLDivElement;
     protected statusMessageDiv?: HTMLDivElement;
@@ -115,7 +118,7 @@ export class StatusOverlay extends GLSPAbstractUIExtension implements IActionHan
         }
     }
 
-    preInitialize(): void {
-        this.show(this.editorContext.modelRoot);
+    preInitialize(): Promise<void> {
+        return this.actionDispatcher.dispatch(SetUIExtensionVisibilityAction.create({ extensionId: this.id(), visible: true }));
     }
 }

--- a/packages/client/src/features/tool-palette/tool-palette.ts
+++ b/packages/client/src/features/tool-palette/tool-palette.ts
@@ -474,15 +474,19 @@ export class ToolPalette extends GLSPAbstractUIExtension implements IActionHandl
         this.createBody();
     }
 
-    async preRequestModel(): Promise<void> {
+    /**
+     *  @deprecated This hook is no longer used by the ToolPalette.
+     *              It is kept for compatibility reasons and will be removed in the future.
+     *              Move initialization logic to the `postRequestModel` method.
+     *              This ensures that tool palette initialization does not block the diagram loading process.
+     */
+    async preRequestModel(): Promise<void> {}
+
+    async postRequestModel(): Promise<void> {
         await this.setPaletteItems();
         if (!this.editorContext.isReadonly) {
             this.show(this.editorContext.modelRoot);
         }
-    }
-
-    async postRequestModel(): Promise<void> {
-        this.reloadPaletteBody();
     }
 
     protected async setPaletteItems(): Promise<void> {
@@ -506,7 +510,7 @@ export class ToolPalette extends GLSPAbstractUIExtension implements IActionHandl
     }
 
     protected async reloadPaletteBody(): Promise<void> {
-        if (this.dynamic) {
+        if (!this.editorContext.isReadonly && this.dynamic) {
             await this.setPaletteItems();
             this.paletteItemsCopy = [];
             this.requestFilterUpdate(this.searchField.value);

--- a/packages/glsp-sprotty/src/api-override.ts
+++ b/packages/glsp-sprotty/src/api-override.ts
@@ -136,6 +136,13 @@ export interface IVNodePostprocessor extends SIVNodePostprocessor {
 
 export interface IActionDispatcher extends SIActionDispatcher {
     /**
+     * Optional method to initialize the action dispatcher.
+     * Implementation can use this as a hook to perform any initialization tasks,
+     * like registering action handlers or setting up the initial diagram.
+     * Called by the `DiagramLoader` when starting the loading process.
+     */
+    initialize?(): Promise<void>;
+    /**
      * Dispatch an action by querying all handlers that are registered for its kind.
      * The returned promise is resolved when all handler results (commands or actions)
      * have been processed.


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
###### Diagram Loader
- Avoid unnecessary dispatch of empty `SetModelAction`. Await the initialize method of the action dispatcher instead (which already dispatches an empty model internally
- Fix behavior of `postRequestModel` hook to actually work as described in the model. Instead of requesting and awaiting the dispatch of the response `SetModelAction` we now simply dispatch the `RequestModelAction` and continue with the`postRequestModelHook`
- Use promise instead of listener for the model initalization constraint. This way we can await the `postModelInitialization` hook . I.e. the DiagramLoader.load methods actually completes once its completely finished (all hooks have been invoked and resolved)

###### UiExtensions
- Fix action of startup UIExtensions. Instead of directly calling their show-Method, a corresponding `SetUIExtensionVisibilityAction` is dispatched. This ensures that the extension only get activated after the initial diagram (empty-model) is available
- Make `preInitialize´ hook of StatusOverlay async. The status overlay is used to print messages during the `loading` phase. By making it async, the loader waits until the overlay is actually visible => now messages get lost.
- Move tool palette initialization into from `preRequest`to`postRequest` hook. This ensures that the server request for retrieving the items is dispatched after the model request => does not block diagram loading
    - Fix unnecessary reload of the palette body if in read-only mode (palette not visible) 

###### CommandStack
- Override methods that populate/manage the internal undo/redo stack to no-ops Commandstack undo/redo is not supported in GLSP. This means managing the stack is just unnecessary overhead

Contributed on behalf of AxonIvy AG
Fixes https://github.com/eclipse-glsp/glsp/issues/1427
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
