### PR TITLE
Properly handle move feedback if mouse up happens outside window

### DIFF
--- a/packages/client/src/features/helper-lines/helper-line-manager-default.ts
+++ b/packages/client/src/features/helper-lines/helper-line-manager-default.ts
@@ -112,9 +112,7 @@ export class HelperLineManager implements IActionHandler, ISelectionListener, IH
             dynamicOptions.minimumMoveDelta = Point.multiplyScalar(this.grid, 2);
         }
         this.options = { ...DEFAULT_HELPER_LINE_OPTIONS, ...dynamicOptions, ...this.userOptions };
-        this.selectionService.onSelectionChanged(change =>
-            this.selectionChanged(change.root, change.selectedElements, change.deselectedElements)
-        );
+        this.selectionService.addListener(this);
     }
 
     handle(action: Action): void {

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -196,14 +196,14 @@ export class FeedbackMoveMouseListener extends DragAwareMouseListener implements
         if (!this.tracker.isTracking()) {
             return [];
         }
-        const elementToMove = this.getElementsToMove(target);
+        const elementsToMove = this.getElementsToMove(target);
         if (!this.tool.movementOptions.allElementsNeedToBeValid) {
             // only reset the move of invalid elements, the others will be handled by the change bounds tool itself
-            elementToMove
+            elementsToMove
                 .filter(element => this.tool.changeBoundsManager.isValid(element))
                 .forEach(element => this.elementId2startPos.delete(element.id));
         } else {
-            if (elementToMove.length > 0 && elementToMove.every(element => this.tool.changeBoundsManager.isValid(element))) {
+            if (elementsToMove.length > 0 && elementsToMove.every(element => this.tool.changeBoundsManager.isValid(element))) {
                 // do not reset any element as all are valid
                 this.elementId2startPos.clear();
             }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -98,21 +98,23 @@ export class ChangeBoundsTool extends BaseEditTool {
     enable(): void {
         // install feedback move mouse listener for client-side move updates
         const feedbackMoveMouseListener = this.createMoveMouseListener();
+        this.toDisposeOnDisable.push(this.mouseTool.registerListener(feedbackMoveMouseListener));
         if (Disposable.is(feedbackMoveMouseListener)) {
             this.toDisposeOnDisable.push(feedbackMoveMouseListener);
+        }
+        if (ISelectionListener.is(feedbackMoveMouseListener)) {
+            this.toDisposeOnDisable.push(this.selectionService.addListener(feedbackMoveMouseListener));
         }
 
         // install change bounds listener for client-side resize updates and server-side updates
         const changeBoundsListener = this.createChangeBoundsListener();
+        this.toDisposeOnDisable.push(this.mouseTool.registerListener(changeBoundsListener));
         if (Disposable.is(changeBoundsListener)) {
             this.toDisposeOnDisable.push(changeBoundsListener);
         }
-
-        this.toDisposeOnDisable.push(
-            this.mouseTool.registerListener(feedbackMoveMouseListener),
-            this.mouseTool.registerListener(changeBoundsListener),
-            this.selectionService.onSelectionChanged(change => changeBoundsListener.selectionChanged(change.root, change.selectedElements))
-        );
+        if (ISelectionListener.is(changeBoundsListener)) {
+            this.toDisposeOnDisable.push(this.selectionService.addListener(changeBoundsListener));
+        }
     }
 
     createChangeBoundsTracker(): ChangeBoundsTracker {
@@ -123,7 +125,7 @@ export class ChangeBoundsTool extends BaseEditTool {
         return new FeedbackMoveMouseListener(this);
     }
 
-    protected createChangeBoundsListener(): MouseListener & ISelectionListener {
+    protected createChangeBoundsListener(): MouseListener {
         return new ChangeBoundsListener(this);
     }
 }

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool.ts
@@ -82,7 +82,7 @@ export class EdgeEditTool extends BaseEditTool {
             this.feedbackEdgeSourceMovingListener,
             this.feedbackEdgeTargetMovingListener,
             this.feedbackMovingListener,
-            this.selectionService.onSelectionChanged(change => this.edgeEditListener.selectionChanged(change.root, change.selectedElements))
+            this.selectionService.addListener(this.edgeEditListener)
         );
     }
 

--- a/packages/client/src/utils/gmodel-util.ts
+++ b/packages/client/src/utils/gmodel-util.ts
@@ -196,6 +196,10 @@ export function isNonRoutableSelectedMovableBoundsAware(element: GModelElement):
     return isNonRoutableSelectedBoundsAware(element) && isMoveable(element);
 }
 
+export function isNonRoutableMovableBoundsAware(element: GModelElement): element is BoundsAwareModelElement {
+    return isNonRoutableBoundsAware(element) && isMoveable(element);
+}
+
 /**
  * A typeguard function to check wether a given {@link GModelElement} implements the {@link BoundsAware} model feature,
  * the {@link Selectable} model feature and is actually selected. In addition, the element must not be a {@link GRoutableElement}.
@@ -203,7 +207,17 @@ export function isNonRoutableSelectedMovableBoundsAware(element: GModelElement):
  * @returns A type predicate indicating wether the element is of type {@link SelectableBoundsAware}.
  */
 export function isNonRoutableSelectedBoundsAware(element: GModelElement): element is SelectableBoundsAware {
-    return isBoundsAware(element) && isSelected(element) && !isRoutable(element);
+    return isNonRoutableBoundsAware(element) && isSelected(element);
+}
+
+/**
+ * A typeguard function to check wether a given {@link GModelElement} implements the {@link BoundsAware} model feature.
+ * In addition, the element must not be a {@link GRoutableElement}.
+ * @param element The element to check.
+ * @returns A type predicate indicating wether the element is of type {@link BoundsAwareModelElement}.
+ */
+export function isNonRoutableBoundsAware(element: GModelElement): element is BoundsAwareModelElement {
+    return isBoundsAware(element) && !isRoutable(element);
 }
 
 /**


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Handle mouse down if we should be dragging as mouse up
- Reset feedback if selection has changed
-- Ensure element does not have to be selected to revert move
-- Add method for listeners to selection service

Fixes https://github.com/eclipse-glsp/glsp/issues/1426

#### How to test

See https://github.com/eclipse-glsp/glsp/issues/1426

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
