### PR TITLE
GLSP-1438: Improve GLSPClient default implementations

### DIFF
--- a/packages/client/src/base/action-dispatcher.ts
+++ b/packages/client/src/base/action-dispatcher.ts
@@ -16,12 +16,14 @@
 import {
     Action,
     ActionDispatcher,
+    ActionHandlerRegistry,
     EMPTY_ROOT,
     GModelRoot,
     IActionDispatcher,
     RequestAction,
     ResponseAction,
-    SetModelAction
+    SetModelAction,
+    TYPES
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
 import { GLSPActionHandlerRegistry } from './action-handler-registry';
@@ -37,6 +39,12 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
     @inject(ModelInitializationConstraint)
     protected initializationConstraint: ModelInitializationConstraint;
 
+    @inject(ActionHandlerRegistry)
+    protected override actionHandlerRegistry: ActionHandlerRegistry;
+
+    /** @deprecated No longer in used. The {@link ActionHandlerRegistry} is now directly injected */
+    // eslint-disable-next-line deprecation/deprecation
+    @inject(TYPES.ActionHandlerRegistryProvider) protected override actionHandlerRegistryProvider: () => Promise<ActionHandlerRegistry>;
     protected postUpdateQueue: Action[] = [];
 
     override initialize(): Promise<void> {
@@ -47,10 +55,8 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
     }
 
     protected async doInitialize(): Promise<void> {
-        const registry = await this.actionHandlerRegistryProvider();
-        this.actionHandlerRegistry = registry;
-        if (registry instanceof GLSPActionHandlerRegistry) {
-            registry.initialize();
+        if (this.actionHandlerRegistry instanceof GLSPActionHandlerRegistry) {
+            this.actionHandlerRegistry.initialize();
         }
         this.handleAction(SetModelAction.create(EMPTY_ROOT)).catch(() => {
             /* Logged in handleAction method */

--- a/packages/protocol/src/client-server-protocol/glsp-client.ts
+++ b/packages/protocol/src/client-server-protocol/glsp-client.ts
@@ -74,6 +74,10 @@ export interface GLSPClient {
      * Current client state.
      */
     readonly currentState: ClientState;
+    /**
+     * Event that is fired whenever the client state changes.
+     */
+    readonly onCurrentStateChanged: Event<ClientState>;
 
     /**
      * Initializes the client and the server connection. During the start procedure the client is in the
@@ -134,6 +138,7 @@ export interface GLSPClient {
     /**
      * Stops the client and disposes unknown resources. During the stop procedure the client is in the `Stopping` state and will
      * transition to either `Stopped` or `ServerError`.
+     * Calling the method if client is already stopped has no effect.
      *
      * @returns A promise that resolves after the server was stopped and disposed.
      */

--- a/packages/protocol/src/utils/event.spec.ts
+++ b/packages/protocol/src/utils/event.spec.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Emitter, Event } from './event';
+
+describe('Event', () => {
+    let emitter: Emitter<string>;
+
+    beforeEach(() => {
+        emitter = new Emitter<string>();
+    });
+
+    describe('once', () => {
+        it('should invoke the listener when the event is fired', () => {
+            const listener = sinon.spy((e: string) => {});
+            Event.once(emitter.event, listener);
+            emitter.fire('test');
+            expect(listener.calledOnce).to.be.true;
+            expect(listener.calledWith('test')).to.be.true;
+        });
+        it('should invoke the listener only once when the event is fired multiple times', () => {
+            const listener = sinon.spy((e: string) => {});
+            Event.once(emitter.event, listener);
+            emitter.fire('test');
+            emitter.fire('test1');
+            expect(listener.calledOnce).to.be.true;
+            expect(listener.calledWith('test')).to.be.true;
+        });
+        it('should not invoke the listener when its disposed before the event fired', () => {
+            const listener = sinon.spy((e: string) => {});
+            const disposable = Event.once(emitter.event, listener);
+            disposable.dispose();
+            emitter.fire('test');
+            expect(listener.called).to.be.false;
+        });
+    });
+
+    describe('waitUntil', () => {
+        it('should resolve the promise when the event is fired', async () => {
+            const promise = Event.waitUntil(emitter.event);
+            emitter.fire('test');
+            const result = await promise;
+            expect(result).to.equal('test');
+        });
+
+        it('should resolve the promise only when the predicate matches', async () => {
+            const predicate = (e: string): boolean => e === 'match';
+            const promise = Event.waitUntil(emitter.event, predicate);
+            emitter.fire('no-match');
+            emitter.fire('match');
+            const result = await promise;
+            expect(result).to.equal('match');
+        });
+    });
+});


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Introduce `onCurrentStateChanged` event for `GLSPClient`
- Ensure that `start` and `initializeServer` behave as expected if they are called  again while the previous promise is still pending.
- Restructure members of the default implementations so that get/setters and their _property are grouped together
- Introduce a dedicated namespace for the `Event` interface with utility functions to
  - listen on a certain event exactly once
   - waitUntil a certain event is fired the next time
- Adapt test cases to verify new behavior

Also:
- Update `GLSPActionDispatcher` to use direct injection for registry instead of async provider
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
