### PR TITLE
GLSP-1441: Fix NavigationTargetResolver uri handling

### DIFF
--- a/packages/client/src/features/navigation/navigation-target-resolver.ts
+++ b/packages/client/src/features/navigation/navigation-target-resolver.ts
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { inject, injectable } from 'inversify';
 import {
     IActionDispatcher,
     ILogger,
@@ -23,6 +22,7 @@ import {
     SetResolvedNavigationTargetAction,
     TYPES
 } from '@eclipse-glsp/sprotty';
+import { inject, injectable } from 'inversify';
 import { IDiagramOptions } from '../../base/model/diagram-loader';
 
 /**
@@ -51,9 +51,12 @@ export class NavigationTargetResolver {
         target: NavigationTarget
     ): Promise<SetResolvedNavigationTargetAction | undefined> {
         const targetUri = decodeURIComponent(target.uri);
-        if (sourceUri && sourceUri !== targetUri && `file://${sourceUri}` !== targetUri) {
+        const normalizedSourceUri = sourceUri?.replace(/^file:\/\//, '');
+        const normalizedTargetUri = targetUri.replace(/^file:\/\//, '');
+
+        if (normalizedSourceUri && normalizedSourceUri !== normalizedTargetUri) {
             // different URI, so we can't resolve it locally
-            this.logger.info("Source and Target URI are different. Can't resolve locally.", sourceUri, targetUri);
+            this.logger.info("Source and Target URI are different. Can't resolve locally.", normalizedSourceUri, normalizedTargetUri);
             return undefined;
         }
         if (NavigationTarget.getElementIds(target).length > 0) {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Normalize source and target uris by striping a potential file:// prefix before comparing
Part of: https://github.com/eclipse-glsp/glsp/issues/1441

#### How to test
This change needs to be tested in the Theia integration.
(local link)
With this fix the go to next/previous node commands/context menu entries should now work as expected.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
