### PR TITLE
Remove workaround in GLPSManhattanEdgeRouter

### DIFF
--- a/packages/client/src/features/routing/edge-router.ts
+++ b/packages/client/src/features/routing/edge-router.ts
@@ -22,9 +22,7 @@ import {
     GRoutableElement,
     ManhattanEdgeRouter,
     Point,
-    PolylineEdgeRouter,
-    ResolvedHandleMove,
-    almostEquals
+    PolylineEdgeRouter
 } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 
@@ -84,46 +82,6 @@ export class GLSPManhattanEdgeRouter extends ManhattanEdgeRouter {
         // users may define all kinds of anchors and anchor computers, we want to make sure we return a valid one in any case
         const anchor = super.getTranslatedAnchor(connectable, refPoint, refContainer, edge, anchorCorrection);
         return Point.isValid(anchor) ? anchor : refPoint;
-    }
-
-    protected override applyInnerHandleMoves(edge: GRoutableElement, moves: ResolvedHandleMove[]): void {
-        const route = this.route(edge);
-        const routingPoints = edge.routingPoints;
-        const minimalPointDistance = this.getOptions(edge).minimalPointDistance;
-        moves.forEach(move => {
-            const handle = move.handle;
-            const index = handle.pointIndex;
-            const correctedX = this.correctX(routingPoints, index, move.toPosition.x, minimalPointDistance);
-            const correctedY = this.correctY(routingPoints, index, move.toPosition.y, minimalPointDistance);
-            switch (handle.kind) {
-                case 'manhattan-50%':
-                    if (index < 0) {
-                        if (routingPoints.length === 0) {
-                            routingPoints.push({ x: correctedX, y: correctedY });
-                            move.handle.pointIndex = 0;
-                        } else if (almostEquals(route[0].x, route[1].x)) {
-                            this.alignX(routingPoints, 0, correctedX);
-                        } else {
-                            this.alignY(routingPoints, 0, correctedY);
-                        }
-                    } else if (index < routingPoints.length - 1) {
-                        if (almostEquals(routingPoints[index].x, routingPoints[index + 1].x)) {
-                            this.alignX(routingPoints, index, correctedX);
-                            this.alignX(routingPoints, index + 1, correctedX);
-                        } else {
-                            this.alignY(routingPoints, index, correctedY);
-                            this.alignY(routingPoints, index + 1, correctedY);
-                        }
-                    } else {
-                        if (almostEquals(route[route.length - 2].x, route[route.length - 1].x)) {
-                            this.alignX(routingPoints, routingPoints.length - 1, correctedX);
-                        } else {
-                            this.alignY(routingPoints, routingPoints.length - 1, correctedY);
-                        }
-                    }
-                    break;
-            }
-        });
     }
 
     override cleanupRoutingPoints(edge: GRoutableElement, routingPoints: Point[], updateHandles: boolean, addRoutingPoints: boolean): void {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Remove the override of `applyInnerHandleMoves` in `GLSPManhattanEdgeRouter`. This workaround was introduced as a fix for https://github.com/eclipse-glsp/glsp-client/pull/200 but has since then also been fixed in base sprotty: https://github.com/eclipse-sprotty/sprotty/issues/310 therefore overriding is no longer necessary.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
