### PR TITLE
GLSP-1449: Ensure that codebase is compatible with inversify >= 6.1.3

### DIFF
--- a/packages/client/src/base/action-handler-registry.ts
+++ b/packages/client/src/base/action-handler-registry.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { ActionHandlerRegistration, ActionHandlerRegistry, IActionHandlerInitializer, LazyInjector, TYPES } from '@eclipse-glsp/sprotty';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 @injectable()
 export class GLSPActionHandlerRegistry extends ActionHandlerRegistry {
@@ -24,7 +24,10 @@ export class GLSPActionHandlerRegistry extends ActionHandlerRegistry {
 
     protected initialized = false;
 
-    constructor(@optional() registrations: ActionHandlerRegistration[] = [], @optional() initializers: IActionHandlerInitializer[] = []) {
+    constructor(
+        @inject(TYPES.EmptyArray) registrations: ActionHandlerRegistration[],
+        @inject(TYPES.EmptyArray) initializers: IActionHandlerInitializer[]
+    ) {
         super(registrations, initializers);
     }
     /**

--- a/packages/client/src/base/default.module.ts
+++ b/packages/client/src/base/default.module.ts
@@ -140,6 +140,8 @@ export const defaultModule = new FeatureModule(
         bind(GLSPUIExtensionRegistry).toSelf().inSingletonScope();
         bindOrRebind(context, TYPES.UIExtensionRegistry).toService(GLSPUIExtensionRegistry);
         bind(TYPES.IDiagramStartup).toService(GLSPUIExtensionRegistry);
+
+        bind(TYPES.EmptyArray).toDynamicValue(() => []);
     },
     {
         featureId: Symbol('default')

--- a/packages/client/src/base/ui-extension/ui-extension-registry.ts
+++ b/packages/client/src/base/ui-extension/ui-extension-registry.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { IUIExtension, LazyInjector, MaybePromise, TYPES, UIExtensionRegistry } from '@eclipse-glsp/sprotty';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IDiagramStartup } from '../model/diagram-loader';
 
 @injectable()
@@ -23,7 +23,7 @@ export class GLSPUIExtensionRegistry extends UIExtensionRegistry implements IDia
     @inject(LazyInjector)
     protected lazyInjector: LazyInjector;
 
-    constructor(@optional() extensions: IUIExtension[] = []) {
+    constructor(@inject(TYPES.EmptyArray) extensions: IUIExtension[]) {
         super(extensions);
     }
 

--- a/packages/client/src/base/view/key-tool.ts
+++ b/packages/client/src/base/view/key-tool.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { Disposable, KeyListener, KeyTool, LazyInjector, MaybePromise, TYPES } from '@eclipse-glsp/sprotty';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IDiagramStartup } from '../model/diagram-loader';
 
 @injectable()
@@ -22,7 +22,7 @@ export class GLSPKeyTool extends KeyTool implements IDiagramStartup {
     @inject(LazyInjector)
     protected lazyInjector: LazyInjector;
 
-    constructor(@optional() keyListeners: KeyListener[] = []) {
+    constructor(@inject(TYPES.EmptyArray) keyListeners: KeyListener[]) {
         super(keyListeners);
     }
 

--- a/packages/client/src/base/view/mouse-tool.ts
+++ b/packages/client/src/base/view/mouse-tool.ts
@@ -24,7 +24,7 @@ import {
     MouseTool,
     TYPES
 } from '@eclipse-glsp/sprotty';
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IDiagramStartup } from '../model/diagram-loader';
 import { Ranked } from '../ranked';
 
@@ -41,7 +41,7 @@ export class GLSPMouseTool extends MouseTool implements IDiagramStartup {
 
     protected rankedMouseListeners: Map<number, MouseListener[]>;
 
-    constructor(@optional() mouseListeners: MouseListener[] = []) {
+    constructor(@inject(TYPES.EmptyArray) mouseListeners: MouseListener[]) {
         super(mouseListeners);
     }
 

--- a/packages/glsp-sprotty/src/types.ts
+++ b/packages/glsp-sprotty/src/types.ts
@@ -24,6 +24,10 @@ import { TYPES as SprottyTYPES } from 'sprotty';
 const IGModelRootListener = Symbol('IGModelRootListener');
 export const TYPES = {
     ...SprottyTYPES,
+    // GLSP extends certain sprotty base classes and replaces constructor injection with lazy injection to avoid circular dependencies
+    // To pass inversify base class checks an empty array has to be injected.
+    // This is the purpose of this service identifier. Typically adopters should not have to  use this identifier.
+    EmptyArray: Symbol('EmptyArray'),
     /** @deprecated Using async providers for container service retrieval is discouraged. Use the `LazyInjector` instead */
     ActionHandlerRegistryProvider: SprottyTYPES.ActionHandlerRegistryProvider,
     IAsyncClipboardService: Symbol('IAsyncClipboardService'),

--- a/packages/protocol/src/di/lazy-injector.ts
+++ b/packages/protocol/src/di/lazy-injector.ts
@@ -14,24 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/********************************************************************************
- * Copyright (c) 2024 EclipseSource and others.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- ********************************************************************************/
-
 import { getServiceIdentifierAsString, interfaces } from 'inversify';
-import { NOT_REGISTERED } from 'inversify/lib/constants/error_msgs';
 import { MaybeArray } from '../utils/array-util';
 import { AnyObject } from '../utils/type-util';
 import { BindingContext } from './inversify-util';
@@ -101,7 +84,7 @@ export class DefaultLazyInjector implements LazyInjector {
     get<T extends object>(serviceIdentifier: interfaces.ServiceIdentifier<T>): T {
         const service = this.getOptional(serviceIdentifier);
         if (service === undefined) {
-            throw new Error(NOT_REGISTERED + getServiceIdentifierAsString(serviceIdentifier));
+            throw new Error('No matching bindings found for serviceIdentifier:' + getServiceIdentifierAsString(serviceIdentifier));
         }
         return service;
     }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Remove usage of not-exported constant in lazy injector
- Fix constructor injection of classes that are overwritten to replace constructor injection with lazy injection. To pass the stricter type checks of newer inversify version we need to inject an empty array here.

This ensures that the code base is compatible with all 6.x versions of inversify and we can hard pin/resolve the version required for newer Theia versions while other integrations don't require any change.

Part of https://github.com/eclipse-glsp/glsp/issues/1449
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Add a resolutions block in the root package. json
```ts
"resolutions": { "**/inversify":"^6.1.3"}
```
Build and start the application. Everything should still  work as expected.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
