### PR TITLE
Add host and port configuration

### DIFF
--- a/examples/workflow-standalone/scripts/start-example-server.ts
+++ b/examples/workflow-standalone/scripts/start-example-server.ts
@@ -23,8 +23,12 @@ const serverDirPath = path.resolve(__dirname, '..', 'server');
 async function run() {
     const serverFile = await downloadIfNecessary();
     console.log();
+
+    const port = parsePortArg();
+    const host = parseHostArg();
+
     sh.cd(serverDirPath);
-    sh.exec(`node ${serverFile} -w -p 8081`);
+    sh.exec(`node ${serverFile} -w --port ${port} --host ${host}`);
 }
 
 async function downloadIfNecessary(): Promise<string> {
@@ -70,6 +74,32 @@ async function downloadIfNecessary(): Promise<string> {
     fs.rmSync(tempDir, { force: true, recursive: true });
     fs.rmSync(path.resolve(serverDirPath, tarBall), { force: true });
     return `${config.fileName}-${version}.js`;
+}
+
+function parsePortArg(): number {
+    let port = 8081;
+    const portIndex = process.argv.indexOf('--port');
+    if (portIndex >= 0) {
+        port = parseInt(process.argv[portIndex + 1]);
+    }
+    if(isNaN(port)) {
+        console.error('Invalid port number');
+        process.exit(1);
+    }
+    return port;
+}
+
+function parseHostArg(): string {
+    let host = 'localhost';
+    const hostIndex = process.argv.indexOf('--host');
+    if(hostIndex >= 0) {
+        host = process.argv[hostIndex + 1];
+    }
+    if(typeof host !== 'string') {
+        console.error('Invalid host');
+        process.exit(1);
+    }
+    return host;
 }
 
 run();

--- a/examples/workflow-standalone/src/app.ts
+++ b/examples/workflow-standalone/src/app.ts
@@ -28,7 +28,8 @@ import { Container } from 'inversify';
 import { join, resolve } from 'path';
 import { MessageConnection } from 'vscode-jsonrpc';
 import createContainer from './di.config';
-const port = 8081;
+const host = GLSP_SERVER_HOST;
+const port = GLSP_SERVER_PORT;
 const id = 'workflow';
 const diagramType = 'workflow-diagram';
 
@@ -37,7 +38,7 @@ const currentDir = loc.substring(0, loc.lastIndexOf('/'));
 const examplePath = resolve(join(currentDir, '../app/example1.wf'));
 const clientId = 'sprotty';
 
-const webSocketUrl = `ws://localhost:${port}/${id}`;
+const webSocketUrl = `ws://${host}:${port}/${id}`;
 
 let glspClient: GLSPClient;
 let container: Container;

--- a/examples/workflow-standalone/src/globals.d.ts
+++ b/examples/workflow-standalone/src/globals.d.ts
@@ -1,0 +1,2 @@
+declare const GLSP_SERVER_HOST: string;
+declare const GLSP_SERVER_PORT: string;

--- a/examples/workflow-standalone/webpack.config.js
+++ b/examples/workflow-standalone/webpack.config.js
@@ -70,6 +70,10 @@ module.exports = {
         new webpack.ProvidePlugin({
             process: 'process/browser'
         }),
-        new webpack.WatchIgnorePlugin({ paths: [/\.js$/, /\.d\.ts$/] })
+        new webpack.WatchIgnorePlugin({ paths: [/\.js$/, /\.d\.ts$/] }),
+        new webpack.DefinePlugin({
+            GLSP_SERVER_HOST: JSON.stringify(process.env.GLSP_SERVER_HOST || 'localhost'),
+            GLSP_SERVER_PORT: JSON.stringify(process.env.GLSP_SERVER_PORT || '8081'),
+        })
     ]
 };


### PR DESCRIPTION
#### What it does

This PR is for including host and port configuration to the example/standalone server start script, as well as to the standalone frontend app. Defaults are specified such that original operation should be unchanged.

I opted to parse the relevant command line arguments myself as opposed to with a library, because I felt it is a bit of overkill to introduce an extra dependency for parsing command line arguments. 

closes https://github.com/eclipse-glsp/glsp/issues/1410

#### How to test

From the `examples/workflow-standalone` dir, start the example server with something like `yarn ts-node scripts/start-example-server.ts --port 1234 --host 127.0.0.1` or similar, and build the frontend app with `GLSP_SERVER_PORT=1234 GLSP_SERVER_HOST=127.0.0.1 yarn build`.

The server should listen on the port and host specified, and the frontend should attempt to connect to the same.
Observe that default configuration has not changed

#### Follow-ups

-

#### Changelog

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)