### PR TITLE
Update default styling for labels

### DIFF
--- a/examples/workflow-glsp/css/diagram.css
+++ b/examples/workflow-glsp/css/diagram.css
@@ -36,6 +36,7 @@
     font-weight: inherit;
     text-align: inherit;
     font-size: 100%;
+    user-select: none;
 }
 
 .sprotty-label.heading {


### PR DESCRIPTION
Set `user-select` to none to avoid blinking cursors and/or other indication for text selection when clicking on labels. (Default document text selection of svg text elements is not working anyways)

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
