### PR TITLE
Fix text selection issues in chrome

### DIFF
--- a/packages/client/css/glsp-sprotty.css
+++ b/packages/client/css/glsp-sprotty.css
@@ -247,6 +247,7 @@
     border-style: solid;
     border-width: 1px;
     border-color: #bbb;
+    user-select: none;
 }
 
 .sprotty text {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Chrome's default selection behavior when pressing the shift key messes with styles/selection hightlighting in the diagram

By setting user-select:none for the diagram svg we can fix this issue. Default html text selection does not work for svg text elements anyways, so this change does not break any existing behavior.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Holding shift an moving the mouse (e.g. using the MarqueeSelectionTool) should not mess up styling/text selection.

This is how it looks like on master using chrome:

https://github.com/user-attachments/assets/e73de25d-9b19-485b-9a26-ab0e9371d848


This if with the PR fix:

https://github.com/user-attachments/assets/2b2c2878-96b0-474e-82e1-946633c19a11



<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
