### PR TITLE
GLSP-1525: Fix render error for new categories

### DIFF
--- a/packages/client/src/views/compartments.tsx
+++ b/packages/client/src/views/compartments.tsx
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 /** @jsx svg */
-import { GCompartment, RenderingContext, ShapeView, svg } from '@eclipse-glsp/sprotty';
+import { Dimension, GCompartment, RenderingContext, ShapeView, svg } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 
@@ -24,10 +24,10 @@ export class StructureCompartmentView extends ShapeView {
         if (!this.isVisible(model, context)) {
             return undefined;
         }
-
+        const rectSize = Dimension.isValid(model.size) ? model.size : Dimension.ZERO;
         return (
             <g>
-                <rect class-sprotty-comp={true} x='0' y='0' width={model.size.width} height={model.size.height}></rect>
+                <rect class-sprotty-comp={true} x='0' y='0' width={rectSize.width} height={rectSize.height}></rect>
                 {context.renderChildren(model)}
             </g>
         );


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Update `StructuredCompartmentView` to render a rectangle with size 0,0 if either the width or height of the element is 0. This avoids that size migh end up in negatives (-1) after svg translations are applied.
Fixes https://github.com/eclipse-glsp/glsp/issues/1525
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

- Create a new Category
- Ensure that there are no console errors of the following form:
![image](https://github.com/user-attachments/assets/5cfae63a-7ac3-4bef-ad6f-a51333179e2b)
- Ensure that resizing and adding child nodes still works as expected.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
