### PR TITLE
GLSP-1532: Introduce ProposalString utility type

### DIFF
--- a/packages/protocol/src/action-protocol/element-selection.ts
+++ b/packages/protocol/src/action-protocol/element-selection.ts
@@ -61,14 +61,32 @@ export namespace SelectAction {
         };
     }
 
+    /**
+     * Creates a new {@link SelectAction} to add the given elements to the existing selection.
+     * @param selectedElementsIDs The identifiers of the elements to add to the selection.
+     * @returns the corresponding {@link SelectAction}
+     */
     export function addSelection(selectedElementsIDs: string[]): SelectAction {
         return create({ selectedElementsIDs });
     }
 
+    /**
+     * Creates a new {@link SelectAction}
+     * to remove the given elements from the existing selection.
+     * @param deselectedElementsIDs The identifiers of the elements to remove from the selection.
+     * @return the corresponding {@link SelectAction}
+     */
     export function removeSelection(deselectedElementsIDs: string[]): SelectAction {
         return create({ deselectedElementsIDs });
     }
 
+    /**
+     * Creates a new {@link SelectAction}
+     * to set the selection to the given elements.
+     * This replaces the current selection with the given elements.
+     * @param selectedElementsIDs The identifiers of the elements to select.
+     * @returns the corresponding {@link SelectAction}
+     */
     export function setSelection(selectedElementsIDs: string[]): SelectAction {
         return create({ selectedElementsIDs, deselectedElementsIDs: true });
     }

--- a/packages/protocol/src/action-protocol/element-validation.ts
+++ b/packages/protocol/src/action-protocol/element-validation.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { hasArrayProp } from '../utils/type-util';
+import { ProposalString, hasArrayProp } from '../utils/type-util';
 import { Action, RequestAction, ResponseAction } from './base-protocol';
 
 /**
@@ -48,14 +48,16 @@ export namespace MarkerKind {
 }
 
 /**
- * The default reasons for markers.
+ * Utility type for the reason of markers, which offers the default values `batch` and `live` as
+ * proposals. Any other string value can be used as custom reason as well.
  */
-export namespace MarkersReason {
+export type MarkersReason = ProposalString<(typeof MarkersReason)[keyof typeof MarkersReason]>;
+export const MarkersReason = {
     /** Markers resulting from a batch validation */
-    export const BATCH = 'batch';
+    BATCH: 'batch',
     /** Markers resulting from a live validation */
-    export const LIVE = 'live';
-}
+    LIVE: 'live'
+} as const;
 
 /**
  * Action to retrieve markers for the specified model elements. Sent from the client to the server.
@@ -71,7 +73,9 @@ export interface RequestMarkersAction extends RequestAction<SetMarkersAction> {
     elementsIDs: string[];
 
     /**
-     * The reason for this request, such as `batch` or `live` validation. `batch` by default.
+     * The reason for this request.
+     * Default values are `batch` and `live`, but custom reasons can be used as well.
+     * If not specified, the default value is `batch`.
      */
     reason?: string;
 }
@@ -83,7 +87,10 @@ export namespace RequestMarkersAction {
         return RequestAction.hasKind(object, KIND) && hasArrayProp(object, 'elementsIDs');
     }
 
-    export function create(elementsIDs: string[], options: { requestId?: string; reason?: string } = {}): RequestMarkersAction {
+    export function create<R extends MarkersReason>(
+        elementsIDs: string[],
+        options: { requestId?: string; reason?: R } = {}
+    ): RequestMarkersAction {
         return {
             kind: KIND,
             requestId: '',
@@ -112,7 +119,7 @@ export interface SetMarkersAction extends ResponseAction {
     /**
      * The reason for message, such as `batch` or `live` validation.
      */
-    reason?: string;
+    reason?: MarkersReason;
 }
 
 export namespace SetMarkersAction {
@@ -122,7 +129,10 @@ export namespace SetMarkersAction {
         return Action.hasKind(object, KIND) && hasArrayProp(object, 'markers');
     }
 
-    export function create(markers: Marker[], options: { responseId?: string; reason?: string } = {}): SetMarkersAction {
+    export function create<R extends MarkersReason>(
+        markers: Marker[],
+        options: { responseId?: string; reason?: R } = {}
+    ): SetMarkersAction {
         return {
             kind: KIND,
             responseId: '',

--- a/packages/protocol/src/action-protocol/model-edit-mode.ts
+++ b/packages/protocol/src/action-protocol/model-edit-mode.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { hasStringProp } from '../utils/type-util';
+import { ProposalString, hasStringProp } from '../utils/type-util';
 import { Action } from './base-protocol';
 
 /**
@@ -27,6 +27,7 @@ export interface SetEditModeAction extends Action {
 
     /**
      * The new edit mode of the diagram.
+     * Default values are `readonly` and `editable`, but custom modes can be used as well.
      */
     editMode: string;
 }
@@ -38,7 +39,7 @@ export namespace SetEditModeAction {
         return Action.hasKind(object, KIND) && hasStringProp(object, 'editMode');
     }
 
-    export function create(editMode: string): SetEditModeAction {
+    export function create<E extends EditMode>(editMode: E): SetEditModeAction {
         return {
             kind: KIND,
             editMode
@@ -47,9 +48,11 @@ export namespace SetEditModeAction {
 }
 
 /**
- * The potential default values for the `editMode` property of  a {@link SetEditModeAction}.
+ * Utility type for the edit mode, which offers the default values `readonly` and `editable` as
+ * proposals. Any other string value can be used as custom edit mode as well.
  */
-export namespace EditMode {
-    export const READONLY = 'readonly';
-    export const EDITABLE = 'editable';
-}
+export type EditMode = ProposalString<(typeof EditMode)[keyof typeof EditMode]>;
+export const EditMode = {
+    READONLY: 'readonly',
+    EDITABLE: 'editable'
+} as const;

--- a/packages/protocol/src/utils/type-util.ts
+++ b/packages/protocol/src/utils/type-util.ts
@@ -93,13 +93,37 @@ export function toTypeGuard<G>(constructor: Constructor<G>): TypeGuard<G> {
 }
 
 /**
+ * Utility type that represents a string value that is augment with proposals for
+ * default/common values.Code completion in editors can pick up the proposals while
+ * still allowing to also define any other string value.
+ * @template T The type of the string proposal as union.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type ProposalString<T extends string> = T | (string & {});
+
+/**
  * Utility type that represents an arbitrary function. Should be used instead
  * of the default `Function` type which is considered to be unsafe.
  */
 export type SafeFunction<T = any> = (...args: any[]) => T;
 
+/**
+ * Utility type that represents a value that might be a function or a value of type `T`.
+ * This is useful to allow functions to be passed as parameters but also allow
+ * simple values to be passed.
+ * @template T The type of the value that might be returned by the function.
+ */
 export type MaybeFunction<T = any> = T | SafeFunction<T>;
 
+/**
+ * Utility function that calls a given function if it is a function, otherwise returns the value.
+ * This is useful to allow functions to be passed as parameters but also allow
+ * simple values to be passed.
+ * @template T The type of the value that might be returned by the function.
+ * @param maybeFun The value that might be a function or a value of type `T`.
+ * @param args The arguments to pass to the function if it is called.
+ * @returns The result of the function call or the value itself if it is not a function.
+ */
 export function call<T>(maybeFun: MaybeFunction<T>, ...args: any[]): T {
     return typeof maybeFun === 'function' ? (maybeFun as SafeFunction<T>)(...args) : maybeFun;
 }
@@ -107,6 +131,14 @@ export function call<T>(maybeFun: MaybeFunction<T>, ...args: any[]): T {
 export type MaybeActions = MaybeFunction<Action[] | Action | undefined>;
 
 export namespace MaybeActions {
+    /**
+     * Utility function that converts a given `MaybeActions` value into an array of actions.
+     * If the value is a function, it will be called to get the actions.
+     * If the value is an array, it will be returned as is.
+     * If the value is undefined, an empty array will be returned.
+     * @param actions The value that might be a function or an array of actions.
+     * @returns An array of actions.
+     */
     export function asArray(actions?: MaybeActions): Action[] {
         const cleanup = actions ? call(actions) : [];
         return cleanup ? toArray(cleanup) : [];


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Introduce `ProposalType` utility type. This type is an augmented string type that exposes possible default values that can be picked up by content assist and code completion tools. It can be used as replacement for any plain string to provide a better developer experience

- Update protocol actions that have generic string properties with default values to use the new utility type in their create() function
The create function is optionally generic and any type extending string can be used to further narrowing the type. Here is a short demo:

https://github.com/user-attachments/assets/b13c1839-8c26-4d4c-9a2b-5616ec97760d




Also: Extend/improve documentation
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
