### PR TITLE
Enrich LayoutOperation with canvas bounds and Viewport information

### DIFF
--- a/packages/client/src/features/layout/layout-module.ts
+++ b/packages/client/src/features/layout/layout-module.ts
@@ -13,19 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { FeatureModule, configureActionHandler } from '@eclipse-glsp/sprotty';
+import { FeatureModule, RequestLayoutAction, configureActionHandler } from '@eclipse-glsp/sprotty';
 import {
     AlignElementsAction,
     AlignElementsActionHandler,
     ResizeElementsAction,
     ResizeElementsActionHandler
 } from './layout-elements-action';
+import { RequestLayoutActionHandler } from './request-layout-action-handler';
 
 export const layoutModule = new FeatureModule(
     (bind, _unbind, isBound) => {
         const context = { bind, isBound };
         configureActionHandler(context, ResizeElementsAction.KIND, ResizeElementsActionHandler);
         configureActionHandler(context, AlignElementsAction.KIND, AlignElementsActionHandler);
+        configureActionHandler(context, RequestLayoutAction.KIND, RequestLayoutActionHandler);
     },
     { featureId: Symbol('layout') }
 );

--- a/packages/client/src/features/layout/request-layout-action-handler.ts
+++ b/packages/client/src/features/layout/request-layout-action-handler.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Action, isViewport, LayoutOperation, RequestLayoutAction } from '@eclipse-glsp/sprotty';
+import { inject, injectable } from 'inversify';
+import { EditorContextService } from '../../base/editor-context-service';
+
+/**
+ * The handler for {@link RequestLayoutAction}s.
+ * This handler returns an enriched LayoutOperation with the canvasBounds and viewport information.
+ */
+@injectable()
+export class RequestLayoutActionHandler {
+    @inject(EditorContextService)
+    protected editorContext?: EditorContextService;
+
+    handle(action: RequestLayoutAction): Action | void {
+        if (this.editorContext) {
+            const root = this.editorContext.modelRoot;
+            if (isViewport(root)) {
+                return LayoutOperation.create([], root.canvasBounds, root);
+            }
+        }
+
+        return LayoutOperation.create();
+    }
+}

--- a/packages/protocol/src/action-protocol/model-layout.ts
+++ b/packages/protocol/src/action-protocol/model-layout.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import * as sprotty from 'sprotty-protocol/lib/actions';
+import { Bounds, Viewport } from 'sprotty-protocol';
 import { GModelRootSchema } from '../model/model-schema';
 import { hasArrayProp, hasObjectProp } from '../utils/type-util';
 import { Action, Operation, RequestAction, ResponseAction } from './base-protocol';
@@ -124,6 +125,16 @@ export interface LayoutOperation extends Operation, Omit<sprotty.LayoutAction, '
      * The identifiers of the elements that should be layouted, will default to the root element if not defined.
      */
     elementIds?: string[];
+
+    /**
+     * The current bounds of the canvas at time of layout.
+     */
+    canvasBounds?: Bounds;
+
+    /**
+     * The current viewport information at time of layout.
+     */
+    viewport?: Viewport;
 }
 
 export namespace LayoutOperation {
@@ -133,11 +144,44 @@ export namespace LayoutOperation {
         return Action.hasKind(object, KIND) && hasArrayProp(object, 'elementIds');
     }
 
-    export function create(elementIds?: string[], options: { args?: Args } = {}): LayoutOperation {
+    export function create(
+        elementIds?: string[],
+        canvasBounds?: Bounds,
+        viewport?: Viewport,
+        options: { args?: Args } = {}
+    ): LayoutOperation {
         return {
             kind: KIND,
             isOperation: true,
             elementIds,
+            canvasBounds,
+            viewport,
+            ...options
+        };
+    }
+}
+
+/**
+ * Request a layout of the diagram or the selected elements only.
+ * Used to tell the client to enrich the LayoutOperation before sending to the server.
+ * The corresponding namespace declares the action kind as constant and offers helper functions for type guard checks
+ * and creating new `RequestLayoutActions`.
+ */
+export interface RequestLayoutAction extends Action {
+    kind: typeof RequestLayoutAction.KIND;
+    options?: Args;
+}
+
+export namespace RequestLayoutAction {
+    export const KIND = 'requestLayout';
+
+    export function is(action: Action): action is RequestLayoutAction {
+        return Action.hasKind(action, KIND);
+    }
+
+    export function create(options?: Args): RequestLayoutAction {
+        return {
+            kind: KIND,
             ...options
         };
     }


### PR DESCRIPTION
https://github.com/eclipse-glsp/glsp/issues/1561

- Add canvasBounds and viewport information as optional parameters on LayoutOperation
- Add RequestLayoutAction and corresponding RequestLayoutActionHandler to allow the client to enrich LayoutOperation before it is send to the server.


<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
