### PR TITLE
GLSP-1530: Fix hGrab/vGrab layout calculation

### DIFF
--- a/packages/client/src/features/bounds/hbox-layout.ts
+++ b/packages/client/src/features/bounds/hbox-layout.ts
@@ -26,6 +26,7 @@ import {
     Point,
     StatefulLayouter,
     isBoundsAware,
+    isLayoutContainer,
     isLayoutableChild
 } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
@@ -215,7 +216,13 @@ export class HBoxLayouterExt extends HBoxLayouter {
     }
 
     protected override getChildLayoutOptions(child: GChildElement, containerOptions: HBoxLayoutOptionsExt): HBoxLayoutOptionsExt {
-        return super.getChildLayoutOptions(child, this.filterContainerOptions(containerOptions)) as HBoxLayoutOptionsExt;
+        const filteredOptions = this.filterContainerOptions(containerOptions);
+
+        if (!isLayoutableChild(child) && !isLayoutContainer(child)) {
+            return filteredOptions;
+        }
+
+        return super.getChildLayoutOptions(child, filteredOptions) as HBoxLayoutOptionsExt;
     }
 
     protected override getLayoutOptions(element: GModelElement): HBoxLayoutOptionsExt {

--- a/packages/client/src/features/bounds/vbox-layout.ts
+++ b/packages/client/src/features/bounds/vbox-layout.ts
@@ -26,6 +26,7 @@ import {
     VBoxLayoutOptions,
     VBoxLayouter,
     isBoundsAware,
+    isLayoutContainer,
     isLayoutableChild
 } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
@@ -215,7 +216,13 @@ export class VBoxLayouterExt extends VBoxLayouter {
     }
 
     protected override getChildLayoutOptions(child: GChildElement, containerOptions: VBoxLayoutOptionsExt): VBoxLayoutOptionsExt {
-        return super.getChildLayoutOptions(child, this.filterContainerOptions(containerOptions)) as VBoxLayoutOptionsExt;
+        const filteredOptions = this.filterContainerOptions(containerOptions);
+
+        if (!isLayoutableChild(child) && !isLayoutContainer(child)) {
+            return filteredOptions;
+        }
+
+        return super.getChildLayoutOptions(child, filteredOptions) as VBoxLayoutOptionsExt;
     }
 
     protected override getLayoutOptions(element: GModelElement): VBoxLayoutOptionsExt {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Ensure that child layout options are only retrieved if the child has a layout feature

Fixes eclipse-glsp/glsp/issues/1530

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
