### PR TITLE
GLSP-1531: Introduce viewport change event

### DIFF
--- a/packages/client/src/base/command-stack.ts
+++ b/packages/client/src/base/command-stack.ts
@@ -19,6 +19,7 @@ import {
     CommandStack,
     Disposable,
     DisposableCollection,
+    Emitter,
     Event,
     GModelRoot,
     ICommand,
@@ -26,7 +27,6 @@ import {
     LazyInjector
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
-import { Emitter } from 'vscode-jsonrpc';
 import { EditorContextService } from './editor-context-service';
 
 @injectable()

--- a/packages/client/src/base/command-stack.ts
+++ b/packages/client/src/base/command-stack.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2025 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,24 +15,36 @@
  ********************************************************************************/
 import {
     CommandExecutionContext,
+    CommandExecutionData,
     CommandStack,
     Disposable,
     DisposableCollection,
     Event,
     GModelRoot,
     ICommand,
-    LazyInjector,
-    SetModelCommand,
-    UpdateModelCommand
+    ICommandStack,
+    LazyInjector
 } from '@eclipse-glsp/sprotty';
-import { inject, injectable, preDestroy } from 'inversify';
+import { inject, injectable, postConstruct, preDestroy } from 'inversify';
+import { Emitter } from 'vscode-jsonrpc';
 import { EditorContextService } from './editor-context-service';
 
 @injectable()
-export class GLSPCommandStack extends CommandStack implements Disposable {
+export class GLSPCommandStack extends CommandStack implements ICommandStack, Disposable {
     @inject(LazyInjector)
     protected lazyInjector: LazyInjector;
     protected toDispose = new DisposableCollection();
+
+    protected onCommandExecutedEmitter = new Emitter<CommandExecutionData>();
+    get onCommandExecuted(): Event<CommandExecutionData> {
+        return this.onCommandExecutedEmitter.event;
+    }
+
+    @postConstruct()
+    protected override initialize(): void {
+        super.initialize();
+        this.toDispose.push(this.onCommandExecutedEmitter);
+    }
 
     @preDestroy()
     dispose(): void {
@@ -95,13 +107,7 @@ export class GLSPCommandStack extends CommandStack implements Disposable {
     }
     override async execute(command: ICommand): Promise<GModelRoot> {
         const result = await super.execute(command);
-        if (command instanceof SetModelCommand || command instanceof UpdateModelCommand) {
-            this.notifyListeners(result);
-        }
+        this.onCommandExecutedEmitter.fire({ command, newRoot: result });
         return result;
-    }
-
-    protected notifyListeners(root: Readonly<GModelRoot>): void {
-        this.editorContext.notifyModelRootChanged(root, this);
     }
 }

--- a/packages/client/src/base/default.module.ts
+++ b/packages/client/src/base/default.module.ts
@@ -46,6 +46,7 @@ import { FocusStateChangedAction } from './focus/focus-state-change-action';
 import { FocusTracker } from './focus/focus-tracker';
 import { DiagramLoader } from './model/diagram-loader';
 import { GLSPModelSource } from './model/glsp-model-source';
+import { ModelChangeService } from './model/model-change-service';
 import { DefaultModelInitializationConstraint, ModelInitializationConstraint } from './model/model-initialization-constraint';
 import { GModelRegistry } from './model/model-registry';
 import { GLSPMousePositionTracker } from './mouse-position-tracker';
@@ -77,6 +78,7 @@ export const defaultModule = new FeatureModule(
         bind(TYPES.IEditorContextServiceProvider).toProvider<EditorContextService>(
             ctx => async () => ctx.container.get(EditorContextService)
         );
+        bind(TYPES.IModelChangeService).to(ModelChangeService).inSingletonScope();
 
         configureActionHandler(context, SetEditModeAction.KIND, EditorContextService);
         configureActionHandler(context, SetDirtyStateAction.KIND, EditorContextService);

--- a/packages/client/src/base/editor-context-service.ts
+++ b/packages/client/src/base/editor-context-service.ts
@@ -42,7 +42,7 @@ import {
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 import { FocusChange, FocusTracker } from './focus/focus-tracker';
 import { IDiagramOptions, IDiagramStartup } from './model/diagram-loader';
-import { IModelChangeService } from './model/model-change-service';
+import { IModelChangeService, ViewportChange } from './model/model-change-service';
 import { SelectionChange, SelectionService } from './selection-service';
 
 /**
@@ -147,7 +147,7 @@ export class EditorContextService implements IActionHandler, Disposable, IDiagra
      * Event that is fired when the viewport of the diagram changes i.e. after the `CommandStack` has processed a viewport update.
      * By default, this event is only fired if the viewport was changed via a `SetViewportCommand` or `BoundsAwareViewportCommand`
      */
-    get onViewportChanged(): Event<Readonly<Viewport>> {
+    get onViewportChanged(): Event<ViewportChange> {
         return this.modelChangeService.onViewportChanged;
     }
 
@@ -227,6 +227,9 @@ export class EditorContextService implements IActionHandler, Disposable, IDiagra
     }
 
     get modelRoot(): Readonly<GModelRoot> {
+        if (!this.modelChangeService.currentRoot) {
+            throw new Error('Model root not available yet');
+        }
         return this.modelChangeService.currentRoot;
     }
 

--- a/packages/client/src/base/focus/focus-tracker.ts
+++ b/packages/client/src/base/focus/focus-tracker.ts
@@ -13,8 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, Emitter, Event, IActionHandler, ICommand, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
-import { inject, injectable } from 'inversify';
+import { Action, Disposable, Emitter, Event, IActionHandler, ICommand, TYPES, ViewerOptions } from '@eclipse-glsp/sprotty';
+import { inject, injectable, preDestroy } from 'inversify';
 import { FocusStateChangedAction } from './focus-state-change-action';
 
 export interface FocusChange {
@@ -29,7 +29,7 @@ export interface FocusChange {
  * Allows querying of the current focus state and the focused root diagram element and the currently focused element within the diagram.
  */
 @injectable()
-export class FocusTracker implements IActionHandler {
+export class FocusTracker implements IActionHandler, Disposable {
     protected inActiveCssClass = 'inactive';
     protected _hasFocus = true;
     protected _focusElement: HTMLOrSVGElement | null;
@@ -76,5 +76,10 @@ export class FocusTracker implements IActionHandler {
             this._diagramElement.classList.add(this.inActiveCssClass);
         }
         this.onFocusChangedEmitter.fire({ hasFocus: this.hasFocus, focusElement: this.focusElement, diagramElement: this.diagramElement });
+    }
+
+    @preDestroy()
+    dispose(): void {
+        this.onFocusChangedEmitter.dispose();
     }
 }

--- a/packages/client/src/base/model/model-change-service.ts
+++ b/packages/client/src/base/model/model-change-service.ts
@@ -1,0 +1,144 @@
+/********************************************************************************
+ * Copyright (c) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    BoundsAwareViewportCommand,
+    Disposable,
+    DisposableCollection,
+    Emitter,
+    Event,
+    GModelRoot,
+    ICommand,
+    ICommandStack,
+    LazyInjector,
+    SetModelCommand,
+    SetViewportCommand,
+    TYPES,
+    UpdateModelCommand,
+    Viewport,
+    almostEquals,
+    isViewport
+} from '@eclipse-glsp/sprotty';
+import { inject, postConstruct, preDestroy } from 'inversify';
+
+/**
+ * Service that tracks changes to the model root and the viewport.
+ * Allows to register listeners that are notified when the model root or the viewport changes.
+ * The current model root can be queried at any time.
+ */
+export interface IModelChangeService {
+    /** The current model root */
+    readonly currentRoot: Readonly<GModelRoot>;
+    /**
+     * Event that is fired when the model root of the diagram changes i.e. after the `CommandStack` has processed a model update.
+     */
+    onModelRootChanged: Event<Readonly<GModelRoot>>;
+
+    /**
+     * Event that is fired when the viewport of the diagram changes i.e. after the `CommandStack` has processed a viewport update.
+     * By default, this event is only fired if the viewport was changed via a `SetViewportCommand` or `BoundsAwareViewportCommand`
+     */
+    onViewportChanged: Event<Readonly<Viewport>>;
+}
+
+export class ModelChangeService implements IModelChangeService, Disposable {
+    @inject(LazyInjector)
+    protected lazyInjector: LazyInjector;
+    protected _currentRoot: Readonly<GModelRoot>;
+    protected lastViewport?: Readonly<Viewport>;
+    protected toDispose = new DisposableCollection();
+
+    get currentRoot(): Readonly<GModelRoot> {
+        if (!this._currentRoot) {
+            throw new Error('Model root not available yet');
+        }
+        return this._currentRoot;
+    }
+
+    protected get commandStack(): ICommandStack {
+        return this.lazyInjector.get<ICommandStack>(TYPES.ICommandStack);
+    }
+
+    protected onModelRootChangedEmitter = new Emitter<Readonly<GModelRoot>>();
+    get onModelRootChanged(): Event<Readonly<GModelRoot>> {
+        return this.onModelRootChangedEmitter.event;
+    }
+
+    protected onViewportChangedEmitter = new Emitter<Readonly<Viewport>>();
+    get onViewportChanged(): Event<Readonly<Viewport>> {
+        return this.onViewportChangedEmitter.event;
+    }
+
+    @postConstruct()
+    protected initialize(): void {
+        this.toDispose.push(this.onModelRootChangedEmitter, this.onViewportChangedEmitter);
+        this.commandStack.onCommandExecuted(data => this.handleCommandExecution(data.command, data.newRoot), this);
+    }
+
+    @preDestroy()
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    protected handleCommandExecution(command: ICommand, newRoot: GModelRoot): void {
+        if (this.isModelRootChangeCommand(command)) {
+            this.handleModelRootChangeCommand(command, newRoot);
+        }
+        if (this.isViewportChangeCommand(command)) {
+            this.handleViewportChangeCommand(command, newRoot);
+        }
+    }
+
+    protected isModelRootChangeCommand(command: ICommand): boolean {
+        return command instanceof SetModelCommand || command instanceof UpdateModelCommand;
+    }
+
+    protected isViewportChangeCommand(command: ICommand): boolean {
+        return command instanceof SetViewportCommand || command instanceof BoundsAwareViewportCommand;
+    }
+
+    protected handleModelRootChangeCommand(command: ICommand, newRoot: GModelRoot): void {
+        this._currentRoot = newRoot;
+        this.lastViewport = this.toViewport(newRoot);
+        this.onModelRootChangedEmitter.fire(newRoot);
+    }
+
+    protected handleViewportChangeCommand(command: ICommand, newRoot: GModelRoot): void {
+        const viewport = this.toViewport(newRoot);
+        if (!viewport) {
+            return;
+        }
+
+        if (this.hasViewportChanged(viewport)) {
+            this.lastViewport = viewport;
+            this.onViewportChangedEmitter.fire(viewport);
+        }
+    }
+
+    protected hasViewportChanged(newViewport: Readonly<Viewport>): boolean {
+        if (!this.lastViewport) {
+            return true;
+        }
+        return !(
+            almostEquals(newViewport.zoom, this.lastViewport.zoom) &&
+            almostEquals(newViewport.scroll.x, this.lastViewport.scroll.x) &&
+            almostEquals(newViewport.scroll.y, this.lastViewport.scroll.y)
+        );
+    }
+
+    protected toViewport(root: Readonly<GModelRoot>): Readonly<Viewport> | undefined {
+        return isViewport(root) ? { scroll: root.scroll, zoom: root.zoom } : undefined;
+    }
+}

--- a/packages/glsp-sprotty/src/api-override.ts
+++ b/packages/glsp-sprotty/src/api-override.ts
@@ -243,9 +243,13 @@ export interface ICommandStack extends SICommandStack {
     redo(): Promise<GModelRoot>;
 
     /**
-     * Event that is fired after a command has been successfully executed on the stack. (i.e. after the model has been updated).
+     * Event fired after a command has been successfully executed on the stack. (i.e. after the model has been updated).
      */
     onCommandExecuted: Event<CommandExecutionData>;
 }
 
+/**
+ * As part of the event cylce, the ICommandStack should be injected
+ * using a provider to avoid cyclic injection dependencies.
+ */
 export type CommandStackProvider = () => Promise<ICommandStack>;

--- a/packages/glsp-sprotty/src/api-override.ts
+++ b/packages/glsp-sprotty/src/api-override.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, LabeledAction, Point, RequestAction, ResponseAction } from '@eclipse-glsp/protocol';
+import { Action, Event, LabeledAction, Point, RequestAction, ResponseAction } from '@eclipse-glsp/protocol';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import {
@@ -25,6 +25,7 @@ import {
     IActionHandler as SIActionHandler,
     IButtonHandler as SIButtonHandler,
     ICommandPaletteActionProvider as SICommandPaletteActionProvider,
+    ICommandStack as SICommandStack,
     IContextMenuItemProvider as SIContextMenuItemProvider,
     IVNodePostprocessor as SIVNodePostprocessor,
     KeyListener as SKeyListener,
@@ -198,3 +199,53 @@ export interface IActionDispatcher extends SIActionDispatcher {
 }
 
 export type IActionDispatcherProvider = () => Promise<IActionDispatcher>;
+
+/**
+ * Data structure that is passed to the `onCommandExecuted` event.
+ */
+export interface CommandExecutionData {
+    /** The command that has been executed successfully */
+    command: ICommand;
+    /** The new model root after the command execution */
+    newRoot: GModelRoot;
+}
+
+export interface ICommandStack extends SICommandStack {
+    /**
+     * Executes the given command on the current model and returns a
+     * Promise for the new result.
+     *
+     * Unless it is a special command, it is pushed to the undo stack
+     * such that it can be rolled back later and the redo stack is
+     * cleared.
+     */
+    execute(command: ICommand): Promise<GModelRoot>;
+
+    /**
+     * Executes all of the given commands. As opposed to calling
+     * execute() multiple times, the Viewer is only updated once after
+     * the last command has been executed.
+     */
+    executeAll(commands: ICommand[]): Promise<GModelRoot>;
+
+    /**
+     * Client-side undo/redo is not supported in GLSP. The server is responsible for handling undo/redo requests.
+     * This method is required to maintain compatibility with the sprotty API.
+     * Implementation should always be a no-op that returns the current model.
+     */
+    undo(): Promise<GModelRoot>;
+
+    /**
+     * Client-side undo/redo is not supported in GLSP. The server is responsible for handling undo/redo requests.
+     * This method is required to maintain compatibility with the sprotty API.
+     * Implementation should always be a no-op that returns the current model.
+     */
+    redo(): Promise<GModelRoot>;
+
+    /**
+     * Event that is fired after a command has been successfully executed on the stack. (i.e. after the model has been updated).
+     */
+    onCommandExecuted: Event<CommandExecutionData>;
+}
+
+export type CommandStackProvider = () => Promise<ICommandStack>;

--- a/packages/glsp-sprotty/src/re-exports.ts
+++ b/packages/glsp-sprotty/src/re-exports.ts
@@ -44,7 +44,8 @@ export * from 'sprotty/lib/base/animations/easing';
 
 export * from 'sprotty/lib/base/commands/command';
 export * from 'sprotty/lib/base/commands/command-registration';
-export * from 'sprotty/lib/base/commands/command-stack';
+// Exclude ICommandStack and ICommandStackProvider. Exported via api-override module instead
+export { CommandStack, CommandStackState } from 'sprotty/lib/base/commands/command-stack';
 export * from 'sprotty/lib/base/commands/command-stack-options';
 
 export * from 'sprotty/lib/base/features/initialize-canvas';
@@ -268,11 +269,11 @@ export {
     SBezierCreateHandleView as GBezierCreateHandleView,
     SCompartmentView as GCompartmentView,
     SLabelView as GLabelView,
-    SRoutingHandleView,
     JumpingPolylineEdgeView,
     PolylineEdgeView,
     PolylineEdgeViewWithGapsOnIntersections,
-    SGraphView
+    SGraphView,
+    SRoutingHandleView
 } from 'sprotty/lib/graph/views';
 
 // ------------------ Library ------------------

--- a/packages/glsp-sprotty/src/types.ts
+++ b/packages/glsp-sprotty/src/types.ts
@@ -61,6 +61,7 @@ export const TYPES = {
     IDebugManager: Symbol('IDebugManager'),
     Grid: Symbol('Grid'),
     ZoomFactors: Symbol('ZoomFactors'),
+    IModelChangeService: Symbol('IModelChangeService'),
     /**
      * Experimental shortcut manager.
      * The API is not stable yet.


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Refactor our approach to handle model changes and introduce dedicated `IModelChangeService`.

- Extends the `ICommandStack` interface by adding an event to react to successfull command execution
- Introduce dedicated `IModelChangeService` to encapsulate model change handling from the `EditorContextService` similar to how we do it for the selection change and the `SelectionService`
- Refactor editor context, to use/forward to the model change service

In addition:
- Clean up disposal behavior of FokusTrack

Fixes eclipse-glsp/glsp/issues/1531
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

For testing a logger can be configured as event listener e.g:

<img width="1086" height="453" alt="image" src="https://github.com/user-attachments/assets/20a002c7-d3f4-4b5b-823e-c517b9229d1e" />

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
 Potentially breaking changes for Adopters that extend internal API:
 - GLSPCommandStack: 'notifiyListener' method has been removed
 - EditorContextSerivce: 
    - Remove `_modelRoot` and `onModelRootChangedEmitter` properties. Corresponding getters now forward to the ModelChangeService
   - Remove `notifyModelRootChanged` method (Probably no side effect for adopters. Method was only callable from commandstack anyways)
   

