### PR TITLE
Improve wrapping behavior of containers

### DIFF
--- a/packages/client/src/features/change-bounds/model.ts
+++ b/packages/client/src/features/change-bounds/model.ts
@@ -23,11 +23,10 @@ import {
     Point,
     hoverFeedbackFeature,
     isBoundsAware,
-    isMoveable,
     isSelectable
 } from '@eclipse-glsp/sprotty';
 import { CursorCSS } from '../../base/feedback/css-feedback';
-import { BoundsAwareModelElement, MoveableElement, ResizableModelElement } from '../../utils/gmodel-util';
+import type { ResizableModelElement } from '../../utils/gmodel-util';
 
 export const resizeFeature = Symbol('resizeFeature');
 
@@ -103,10 +102,6 @@ export namespace ResizeHandleLocation {
                 return [Direction.Left];
         }
     }
-}
-
-export function isBoundsAwareMoveable(element: GModelElement): element is BoundsAwareModelElement & MoveableElement {
-    return isMoveable(element) && isBoundsAware(element);
 }
 
 export class GResizeHandle extends GChildElement implements Hoverable {

--- a/packages/client/src/features/change-bounds/move-element-handler.ts
+++ b/packages/client/src/features/change-bounds/move-element-handler.ts
@@ -18,7 +18,6 @@ import {
     Action,
     ChangeBoundsOperation,
     ElementAndBounds,
-    ElementMove,
     IActionDispatcher,
     IActionHandler,
     ICommand,
@@ -27,24 +26,42 @@ import {
     MoveViewportAction,
     Point,
     TYPES,
-    isBoundsAware
+    isBoundsAware,
+    type Bounds,
+    type ElementMove,
+    type GModelElement
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional, postConstruct } from 'inversify';
 import { DebouncedFunc, debounce } from 'lodash';
 import { EditorContextService } from '../../base/editor-context-service';
 import { IFeedbackActionDispatcher } from '../../base/feedback/feedback-action-dispatcher';
 import { FeedbackEmitter } from '../../base/feedback/feedback-emitter';
-import { SelectableBoundsAware, getElements, isSelectableAndBoundsAware } from '../../utils/gmodel-util';
+import {
+    SelectableBoundsAware,
+    getElements,
+    isNonRoutableSelectedMovableBoundsAware,
+    isNotUndefined,
+    type MoveableElement
+} from '../../utils/gmodel-util';
 import { isValidMove } from '../../utils/layout-utils';
 import { outsideOfViewport } from '../../utils/viewpoint-util';
 import { IMovementRestrictor } from '../change-bounds/movement-restrictor';
+import type { IChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
+import { TrackedElementResize, type ChangeBoundsTracker } from '../tools/change-bounds/change-bounds-tracker';
+import { GResizeHandle } from './model';
 import { MoveElementRelativeAction } from './move-element-action';
 
 /**
  * Action handler for moving elements.
+ *
+ * Examples: nudging with arrow keys
  */
 @injectable()
 export class MoveElementHandler implements IActionHandler {
+    @inject(TYPES.IChangeBoundsManager)
+    protected readonly changeBoundsManager: IChangeBoundsManager;
+    protected tracker: ChangeBoundsTracker;
+
     @inject(EditorContextService)
     protected editorContextService: EditorContextService;
 
@@ -68,10 +85,12 @@ export class MoveElementHandler implements IActionHandler {
     @postConstruct()
     protected init(): void {
         this.moveFeedback = this.feedbackDispatcher.createEmitter();
+        this.tracker = this.changeBoundsManager.createTracker();
     }
 
     handle(action: Action): void | Action | ICommand {
-        if (MoveElementRelativeAction.is(action)) {
+        if (MoveElementRelativeAction.is(action) && action.elementIds.length > 0) {
+            this.tracker.startTracking(this.editorContextService.modelRoot);
             this.handleMoveElement(action);
         }
     }
@@ -84,7 +103,7 @@ export class MoveElementHandler implements IActionHandler {
 
         const viewportActions: Action[] = [];
         const elementMoves: ElementMove[] = [];
-        const elements = getElements(viewport.index, action.elementIds, isSelectableAndBoundsAware);
+        const elements = getElements(viewport.index, action.elementIds, this.isValidMoveable);
         for (const element of elements) {
             const newPosition = this.getTargetBounds(element, action);
             elementMoves.push({
@@ -103,12 +122,41 @@ export class MoveElementHandler implements IActionHandler {
                 viewportActions.push(MoveViewportAction.create({ moveX: action.moveX, moveY: action.moveY }));
             }
         }
-
         this.dispatcher.dispatchAll(viewportActions);
-        const moveAction = MoveAction.create(elementMoves, { animate: false });
-        this.moveFeedback.add(moveAction).submit();
+        this.moveFeedback.add(this.createMoveAction(elementMoves));
 
-        this.scheduleChangeBounds(this.toElementAndBounds(elementMoves));
+        const newBounds = elementMoves.map(this.toElementAndBounds.bind(this)).filter(isNotUndefined);
+        const wraps = this.tracker.wrap(
+            elements.map(element => {
+                const bounds = newBounds.find(b => b.elementId === element.id)!;
+                const toBounds: Bounds = {
+                    ...element.bounds,
+                    ...bounds.newSize,
+                    ...bounds.newPosition
+                };
+                return {
+                    element: element,
+                    fromBounds: element.bounds,
+                    toBounds
+                };
+            }),
+            {
+                validate: true
+            }
+        );
+
+        this.moveFeedback.add(TrackedElementResize.createFeedbackActions(Object.values(wraps ?? {})));
+        this.moveFeedback.submit();
+
+        if (Object.keys(wraps).length > 0) {
+            newBounds.push(
+                ...Object.values(wraps)
+                    .filter(resize => !action.elementIds.includes(resize.element.id))
+                    .map(TrackedElementResize.toElementAndBounds)
+            );
+        }
+
+        this.scheduleChangeBounds(newBounds);
     }
 
     protected getTargetBounds(element: SelectableBoundsAware, action: MoveElementRelativeAction): Point {
@@ -129,28 +177,35 @@ export class MoveElementHandler implements IActionHandler {
             this.moveFeedback.dispose();
             this.dispatcher.dispatchAll([ChangeBoundsOperation.create(elementAndBounds)]);
             this.debouncedChangeBounds = undefined;
+            this.tracker.dispose();
         }, 300);
         this.debouncedChangeBounds();
     }
 
-    protected toElementAndBounds(elementMoves: ElementMove[]): ElementAndBounds[] {
-        const elementBounds: ElementAndBounds[] = [];
-        for (const elementMove of elementMoves) {
-            const element = this.editorContextService.modelRoot.index.getById(elementMove.elementId);
-            if (element && isBoundsAware(element)) {
-                elementBounds.push({
-                    elementId: elementMove.elementId,
-                    newSize: {
-                        height: element.bounds.height,
-                        width: element.bounds.width
-                    },
-                    newPosition: {
-                        x: elementMove.toPosition.x,
-                        y: elementMove.toPosition.y
-                    }
-                });
-            }
+    protected createMoveAction(moves: ElementMove[]): Action {
+        return MoveAction.create(moves, { animate: false });
+    }
+
+    protected isValidMoveable(element?: GModelElement): element is MoveableElement & SelectableBoundsAware {
+        return !!element && isNonRoutableSelectedMovableBoundsAware(element) && !(element instanceof GResizeHandle);
+    }
+
+    protected toElementAndBounds(elementMove: ElementMove): ElementAndBounds | undefined {
+        const element = this.editorContextService.modelRoot.index.getById(elementMove.elementId);
+        if (element && isBoundsAware(element)) {
+            return {
+                elementId: elementMove.elementId,
+                newSize: {
+                    height: element.bounds.height,
+                    width: element.bounds.width
+                },
+                newPosition: {
+                    x: elementMove.toPosition.x,
+                    y: elementMove.toPosition.y
+                }
+            };
         }
-        return elementBounds;
+
+        return undefined;
     }
 }

--- a/packages/client/src/features/change-bounds/move-element-handler.ts
+++ b/packages/client/src/features/change-bounds/move-element-handler.ts
@@ -92,6 +92,7 @@ export class MoveElementHandler implements IActionHandler {
         if (MoveElementRelativeAction.is(action) && action.elementIds.length > 0) {
             this.tracker.startTracking(this.editorContextService.modelRoot);
             this.handleMoveElement(action);
+            this.tracker.stopTracking();
         }
     }
 

--- a/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
+++ b/packages/client/src/features/element-template/mouse-tracking-element-position-listener.ts
@@ -34,7 +34,7 @@ import { getAbsolutePosition } from '../../utils/viewpoint-util';
 import { FeedbackAwareTool } from '../tools/base-tools';
 import { IChangeBoundsManager } from '../tools/change-bounds/change-bounds-manager';
 import { MoveFinishedEventAction } from '../tools/change-bounds/change-bounds-tool-feedback';
-import { ChangeBoundsTracker, TrackedMove } from '../tools/change-bounds/change-bounds-tracker';
+import { TrackedMove, type ChangeBoundsTracker } from '../tools/change-bounds/change-bounds-tracker';
 
 export interface PositioningTool extends FeedbackAwareTool {
     readonly changeBoundsManager: IChangeBoundsManager;
@@ -76,7 +76,13 @@ export class MouseTrackingElementPositionListener extends DragAwareMouseListener
         if (isInitializing) {
             this.initialize(element, ctx, event);
         }
-        const move = this.tracker.moveElements([element], { snap: event, restrict: event, skipStatic: !isInitializing });
+        const move = this.tracker.moveElements([element], {
+            snap: event,
+            restrict: event,
+            skipStatic: !isInitializing,
+            // Ghost element is feedback-only, so no need to consider wraps
+            wrap: false
+        });
         const elementMove = move.elementMoves[0];
         if (!elementMove) {
             return [];
@@ -94,7 +100,7 @@ export class MouseTrackingElementPositionListener extends DragAwareMouseListener
     }
 
     protected initialize(element: MoveableElement, target: GModelElement, event: MouseEvent): void {
-        this.tracker.startTracking();
+        this.tracker.startTracking(target.root);
         element.position = this.initializeElementPosition(element, target, event);
     }
 

--- a/packages/client/src/features/layout/layout-elements-action.ts
+++ b/packages/client/src/features/layout/layout-elements-action.ts
@@ -34,9 +34,9 @@ import {
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable, optional } from 'inversify';
 import { SelectionService } from '../../base/selection-service';
-import { BoundsAwareModelElement, getElements } from '../../utils/gmodel-util';
+import { BoundsAwareModelElement, getElements, isBoundsAwareMoveable } from '../../utils/gmodel-util';
 import { toValidElementAndBounds, toValidElementMove } from '../../utils/layout-utils';
-import { isBoundsAwareMoveable, isResizable } from '../change-bounds/model';
+import { isResizable } from '../change-bounds/model';
 import { IMovementRestrictor } from '../change-bounds/movement-restrictor';
 
 /**

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -21,12 +21,10 @@ import {
     ChangeBoundsOperation,
     ChangeRoutingPointsOperation,
     CompoundOperation,
-    Dimension,
     Disposable,
     EdgeRouterRegistry,
     ElementAndBounds,
     ElementAndRoutingPoints,
-    GChildElement,
     GConnectableElement,
     GModelElement,
     GModelRoot,
@@ -34,7 +32,6 @@ import {
     KeyListener,
     MouseListener,
     Operation,
-    Point,
     TYPES,
     findParentByFeature
 } from '@eclipse-glsp/sprotty';
@@ -48,8 +45,11 @@ import {
     ResizableModelElement,
     SelectableBoundsAware,
     calcElementAndRoutingPoints,
+    getBoundsChangedAncestorsAndElement,
     getMatchingElements,
+    isDescendant,
     isNonRoutableSelectedMovableBoundsAware,
+    isNotUndefined,
     toElementAndBounds
 } from '../../../utils/gmodel-util';
 import { LocalRequestBoundsAction } from '../../bounds/local-bounds';
@@ -166,7 +166,6 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
     static readonly CSS_CLASS_ACTIVE = CSS_ACTIVE_HANDLE;
 
     // members for calculating the correct position change
-    protected initialBounds: ElementAndBounds | undefined;
     protected tracker: ChangeBoundsTracker;
 
     // members for resize mode
@@ -189,6 +188,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         if (event.button !== 0 || target instanceof GModelRoot) {
             return [];
         }
+        this.tracker.startTracking(target.root);
         // check if we have a resize handle (only single-selection)
         this.updateResizeElement(target, event);
         return [];
@@ -198,14 +198,6 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         this.activeResizeHandle = target instanceof GResizeHandle ? target : undefined;
         this.activeResizeElement = this.activeResizeHandle?.parent ?? this.findResizeElement(target);
         if (this.activeResizeElement) {
-            if (event) {
-                this.tracker.startTracking();
-            }
-            this.initialBounds = {
-                newSize: this.activeResizeElement.bounds,
-                newPosition: this.activeResizeElement.bounds,
-                elementId: this.activeResizeElement.id
-            };
             // we trigger the local bounds calculation once to get the correct layout information for reszing
             // for any sub-sequent calls the layout information will be updated automatically
             this.tool
@@ -235,10 +227,15 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         // rely on the FeedbackMoveMouseListener to update the element bounds of selected elements
         // consider resize handles ourselves
         if (this.activeResizeHandle && this.tracker.isTracking()) {
-            const resize = this.tracker.resizeElements(this.activeResizeHandle, { snap: event, symmetric: event, restrict: event });
+            const resize = this.tracker.resizeElements(this.activeResizeHandle, {
+                snap: event,
+                symmetric: event,
+                restrict: event
+            });
             const resizeAction = this.resizeBoundsAction(resize);
             if (resizeAction.bounds.length > 0) {
-                this.resizeFeedback.add(resizeAction, () => this.resetBounds());
+                this.resizeFeedback.add(resizeAction, () => this.resetResizeBounds());
+                this.resizeFeedback.add(this.createWrapAction(resize));
                 this.tracker.updateTrackingPosition(resize.handleMove.moveVector);
                 this.addResizeFeedback(resize, target, event);
                 this.resizeFeedback.submit();
@@ -253,6 +250,10 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         return SetBoundsFeedbackAction.create(elementResizes.map(elementResize => this.toElementAndBounds(elementResize)));
     }
 
+    protected createWrapAction(tracked: TrackedResize): SetBoundsFeedbackAction {
+        return TrackedElementResize.createFeedbackActions(Object.values(tracked.wrapResizes ?? {}));
+    }
+
     protected toElementAndBounds(elementResize: TrackedElementResize): ElementAndBounds {
         return {
             elementId: elementResize.element.id,
@@ -265,11 +266,26 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         this.tool.changeBoundsManager.addResizeFeedback(this.resizeFeedback, resize, target, event);
     }
 
-    protected resetBounds(): Action[] {
+    /**
+     * Reset the bounds of all resized elements' ancestors and themselves that have changed their bounds during the resize.
+     *
+     * If one of the affected elements is invalid, then all resize operations will be reset.
+     * Otherwise no action is returned.
+     */
+    protected resetResizeBounds(): Action[] {
+        const initialBounds = this.tracker.getInitialBoundsTracker();
+
+        if (!this.activeResizeElement || initialBounds.isEmpty) {
+            return [MoveFinishedEventAction.create()];
+        }
+
         // reset the bounds to the initial bounds and ensure that we do not show helper line feedback anymore (MoveFinishedEventAction)
-        return this.initialBounds
-            ? [SetBoundsFeedbackAction.create([this.initialBounds]), MoveFinishedEventAction.create()]
-            : [MoveFinishedEventAction.create()];
+        const affectedElements = getBoundsChangedAncestorsAndElement(this.activeResizeElement, initialBounds.get());
+        const elementsAndBounds: ElementAndBounds[] = affectedElements
+            .map(element => initialBounds.getElementAndBoundsById(element.id))
+            .filter(isNotUndefined);
+
+        return [SetBoundsFeedbackAction.create(elementsAndBounds), MoveFinishedEventAction.create()];
     }
 
     override draggingMouseUp(target: GModelElement, event: MouseEvent): Action[] {
@@ -281,11 +297,13 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
             actions.push(...this.handleMoveOnServer(target));
         }
         this.disposeResize({ keepHandles: true });
+        this.disposeTracker();
         return actions;
     }
 
     override nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {
         this.disposeResize({ keepHandles: true });
+        this.disposeTracker();
         return super.nonDraggingMouseUp(element, event);
     }
 
@@ -300,11 +318,22 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
     protected getElementsToMove(target: GModelElement): SelectableBoundsAware[] {
         const selectedElements = getMatchingElements(target.index, isNonRoutableSelectedMovableBoundsAware);
         const selectionSet: Set<BoundsAwareModelElement> = new Set(selectedElements);
-        const elementsToMove = selectedElements.filter(element => this.isValidMove(element, selectionSet));
-        if (this.tool.movementOptions.allElementsNeedToBeValid && elementsToMove.length !== selectionSet.size) {
+        // filter out children of selected elements to avoid duplicate move operations
+        // only the top-most selected elements are considered for move operations
+        const topElements = selectedElements.filter(element => !this.isChildOfSelected(selectionSet, element));
+        const affectedElementSet: Set<BoundsAwareModelElement> = new Set();
+
+        const initialBounds = this.tracker.getInitialBoundsTracker().get();
+        for (const topElement of topElements) {
+            const affectedElements = getBoundsChangedAncestorsAndElement(topElement, initialBounds);
+            affectedElements.forEach(element => affectedElementSet.add(element));
+        }
+
+        const elementsToMove = Array.from(affectedElementSet).filter(element => this.isValidMove(element));
+        if (this.tool.movementOptions.allElementsNeedToBeValid && elementsToMove.length !== affectedElementSet.size) {
             return [];
         }
-        return elementsToMove;
+        return elementsToMove as any[];
     }
 
     protected handleMoveElementsOnServer(elementsToMove: SelectableBoundsAware[]): Operation[] {
@@ -312,20 +341,17 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         return newBounds.length > 0 ? [ChangeBoundsOperation.create(newBounds)] : [];
     }
 
-    protected isValidMove(element: BoundsAwareModelElement, selectedElements: Set<BoundsAwareModelElement> = new Set()): boolean {
-        return this.tool.changeBoundsManager.hasValidPosition(element) && !this.isChildOfSelected(selectedElements, element);
+    protected isValidMove(element: BoundsAwareModelElement): boolean {
+        return this.tool.changeBoundsManager.hasValidPosition(element);
     }
 
     protected isChildOfSelected(selectedElements: Set<GModelElement>, element: GModelElement): boolean {
-        if (selectedElements.size === 0) {
-            return false;
-        }
-        while (element instanceof GChildElement) {
-            element = element.parent;
-            if (selectedElements.has(element)) {
+        for (const selectedElement of selectedElements) {
+            if (isDescendant(element, selectedElement)) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -349,20 +375,14 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
     }
 
     protected handleResizeOnServer(activeResizeHandle: GResizeHandle): Action[] {
-        if (this.initialBounds && this.isValidResize(activeResizeHandle.parent)) {
-            const elementAndBounds = toElementAndBounds(activeResizeHandle.parent);
-            if (!this.initialBounds.newPosition || !elementAndBounds.newPosition) {
-                return [];
-            }
-            if (
-                !Point.equals(this.initialBounds.newPosition, elementAndBounds.newPosition) ||
-                !Dimension.equals(this.initialBounds.newSize, elementAndBounds.newSize)
-            ) {
-                // UX: we do not want the element positions to be reset to their start as they will be moved to their start and
-                // only afterwards moved by the move action again, leading to a ping-pong movement.
-                // We therefore clear our element map so that they cannot be reset.
-                this.initialBounds = undefined;
-                return [ChangeBoundsOperation.create([elementAndBounds])];
+        const initialBounds = this.tracker.getInitialBoundsTracker();
+        if (!initialBounds.isEmpty) {
+            const affectedElements = getBoundsChangedAncestorsAndElement(activeResizeHandle.parent, initialBounds.get());
+
+            if (affectedElements.length > 0 && affectedElements.every(this.isValidResize.bind(this))) {
+                initialBounds.clear();
+                const newBounds: ElementAndBounds[] = affectedElements.map(toElementAndBounds);
+                return [ChangeBoundsOperation.create(newBounds)];
             }
         }
         return [];
@@ -397,14 +417,17 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
             this.handleFeedback.dispose();
         }
         this.resizeFeedback.dispose();
-        this.tracker.dispose();
         this.activeResizeElement = undefined;
         this.activeResizeHandle = undefined;
-        this.initialBounds = undefined;
+    }
+
+    protected disposeTracker(): void {
+        this.tracker.dispose();
     }
 
     override dispose(): void {
         this.disposeResize();
+        this.disposeTracker();
         super.dispose();
     }
 }

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool.ts
@@ -333,7 +333,7 @@ export class ChangeBoundsListener extends DragAwareMouseListener implements ISel
         if (this.tool.movementOptions.allElementsNeedToBeValid && elementsToMove.length !== affectedElementSet.size) {
             return [];
         }
-        return elementsToMove as any[];
+        return elementsToMove as SelectableBoundsAware[];
     }
 
     protected handleMoveElementsOnServer(elementsToMove: SelectableBoundsAware[]): Operation[] {

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
@@ -272,7 +272,7 @@ export class FeedbackEdgeRouteMovingMouseListener extends DragAwareMouseListener
             const routingHandle = findParentByFeature(target, isRoutingHandle);
             if (routingHandle !== undefined) {
                 result.push(SwitchRoutingModeAction.create({ elementsToActivate: [target.id] }));
-                this.tracker.startTracking();
+                this.tracker.startTracking(target.root);
             } else {
                 this.tracker.dispose();
             }
@@ -290,7 +290,7 @@ export class FeedbackEdgeRouteMovingMouseListener extends DragAwareMouseListener
 
     protected moveRoutingHandles(target: GModelElement, event: MouseEvent): Action[] {
         const routingHandlesToMove = this.getRoutingHandlesToMove(target);
-        const move = this.tracker.moveElements(routingHandlesToMove, { snap: event, restrict: event });
+        const move = this.tracker.moveElements(routingHandlesToMove, { snap: event, restrict: event, wrap: false });
         if (move.elementMoves.length === 0) {
             return [];
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Works on https://github.com/eclipse-glsp/glsp/issues/1384.

This PR is the initial contribution to provide visual feedback that a container/parent wraps a child even while the child is currently moving. In subsequent PR's those containers will be extended and changing the parent itself of children will be implemented.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Move single/multiple selected child elements around or resize them (also with the keyboard). The parent will wrap it.

https://github.com/user-attachments/assets/482a449f-9792-4f86-bf53-6fa3e36f2941

I will revert the changes to the example file before merging.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)

- `tracker` variables in the change-bounds files have been renamed to `moveTracker` and `resizeTracker`
- `ChangeBoundsTracker#startTracking` requires the root node as argument