### PR TITLE
GLSP-1245: Fix overflowing issue with command palette

### DIFF
--- a/packages/client/css/command-palette.css
+++ b/packages/client/css/command-palette.css
@@ -15,10 +15,12 @@
  ********************************************************************************/
 
 .command-palette {
+    position: fixed;
     transition: opacity 0.3s linear;
     box-shadow:
         0 4px 8px 0 rgba(0, 0, 0, 0.2),
         0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    overflow: visible;
 }
 
 .command-palette-suggestions {

--- a/packages/client/src/features/command-palette/command-palette.ts
+++ b/packages/client/src/features/command-palette/command-palette.ts
@@ -14,14 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { CommandPalette } from '@eclipse-glsp/sprotty';
+import { Bounds, CommandPalette, getWindowScroll, GModelElement, GModelRoot } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
 import { CSS_HIDDEN_EXTENSION_CLASS, CSS_UI_EXTENSION_CLASS } from '../../base/ui-extension/ui-extension';
+import { getElements, isSelectableAndBoundsAware } from '../../utils/gmodel-util';
 
 @injectable()
 export class GlspCommandPalette extends CommandPalette {
     protected override initializeContents(containerElement: HTMLElement): void {
         super.initializeContents(containerElement);
+        containerElement.style.position = '';
         containerElement.classList.add(CSS_UI_EXTENSION_CLASS);
     }
 
@@ -31,5 +33,43 @@ export class GlspCommandPalette extends CommandPalette {
         } else {
             this.containerElement?.classList.add(CSS_HIDDEN_EXTENSION_CLASS);
         }
+    }
+
+    protected override onBeforeShow(containerElement: HTMLElement, root: Readonly<GModelRoot>, ...selectedElementIds: string[]): void {
+        let x = this.xOffset;
+        let y = this.yOffset;
+
+        const selectedElements = getElements(root.index, selectedElementIds, isSelectableAndBoundsAware);
+        if (selectedElements.length === 1) {
+            const bounds = this.getAbsoluteBounds(selectedElements[0]);
+            x += bounds.x + bounds.width;
+            y += bounds.y;
+        } else {
+            const bounds = this.getAbsoluteBounds(root);
+            x += bounds.x;
+            y += bounds.y;
+        }
+        containerElement.style.left = `${x}px`;
+        containerElement.style.top = `${y}px`;
+        containerElement.style.width = `${this.defaultWidth}px`;
+    }
+
+    protected getAbsoluteBounds(element: Readonly<GModelElement>): Bounds {
+        let x = 0;
+        let y = 0;
+        let width = 0;
+        let height = 0;
+
+        const svgElementId = this.domHelper.createUniqueDOMElementId(element);
+        const svgElement = document.getElementById(svgElementId);
+        if (svgElement) {
+            const rect = svgElement.getBoundingClientRect();
+            const scroll = getWindowScroll();
+            x = rect.left + scroll.x;
+            y = rect.top + scroll.y;
+            width = rect.width;
+            height = rect.height;
+        }
+        return { x, y, width, height };
     }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Adjust CSS styling for the command palette to enable proper overflow without shifting the diagram itself.
Use relative position and absolute diagram bounds to avoid shifting the diagram if the command palette would overflow
Fixes https://github.com/eclipse-glsp/glsp/issues/1245
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Trigger a command palette on an element that is near to the bottom or right edge:

Master:

<img width="641" height="651" alt="image" src="https://github.com/user-attachments/assets/f540ea14-4a88-4e40-9e60-314ce2e66fa0" />


PR:

<img width="641" height="651" alt="image" src="https://github.com/user-attachments/assets/2a428e07-13f4-457e-a5dc-19457e45351e" />

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
