### PR TITLE
Fix deploy step failing when preview is unchanged

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -60,8 +60,10 @@ jobs:
           git add "pr/${PR_NUMBER}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "Deploy PR #${PR_NUMBER} preview"
-          git push
+          git diff --cached --quiet && echo "No changes to deploy" || {
+            git commit -m "Deploy PR #${PR_NUMBER} preview"
+            git push
+          }
 
   cleanup:
     name: Cleanup Preview


### PR DESCRIPTION
## Summary

- Skip git commit/push when the preview files haven't changed
- Fixes the deploy job failing on re-runs with identical build output

The previous run deployed PR #490 successfully, but the rebase re-triggered the build with identical output, causing `git commit` to fail with "nothing to commit".