### PR TITLE
Improve GitHub Pages deployments and update dependencies

### DIFF
--- a/.github/workflows/gh-pages-cleanup.yml
+++ b/.github/workflows/gh-pages-cleanup.yml
@@ -1,0 +1,26 @@
+name: GH Pages Cleanup
+
+on:
+  schedule:
+    - cron: '0 3 1 * *' # monthly, 1st day 3am UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Squash History
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: gh-pages
+      - name: Squash gh-pages history
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan temp
+          git add -A
+          git commit -m "Squash gh-pages history" --allow-empty
+          git branch -M gh-pages
+          git push --force origin gh-pages

--- a/.github/workflows/gh-pages-cleanup.yml
+++ b/.github/workflows/gh-pages-cleanup.yml
@@ -12,15 +12,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: gh-pages
       - name: Squash gh-pages history
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout --orphan temp
-          git add -A
-          git commit -m "Squash gh-pages history" --allow-empty
-          git branch -M gh-pages
-          git push --force origin gh-pages
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: ref } = await github.rest.git.getRef({ owner, repo, ref: 'heads/gh-pages' });
+            const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: ref.object.sha });
+
+            // Create an orphan commit (no parents) reusing the current tree
+            const { data: newCommit } = await github.rest.git.createCommit({
+              owner, repo,
+              message: 'Squash gh-pages history',
+              tree: commit.tree.sha,
+              parents: []
+            });
+            await github.rest.git.updateRef({ owner, repo, ref: 'heads/gh-pages', sha: newCommit.sha, force: true });

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -1,0 +1,48 @@
+name: Main Deploy
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'packages/**'
+      - 'examples/**'
+  workflow_dispatch:
+
+concurrency:
+  group: main-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      deployments: write
+    environment:
+      name: main
+      url: https://eclipse-glsp.github.io/glsp-client/diagram.html
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.x
+      - name: Install & Build
+        run: yarn install
+      - name: Bundle browser example
+        run: yarn standalone bundle:browser
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Deploy to gh-pages
+        run: |
+          cd gh-pages
+          rsync -a --delete --exclude='pr' ../examples/workflow-standalone/app/ ./
+          git add -A
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --cached --quiet && echo "No changes to deploy" || {
+            git commit -m "Deploy main (${GITHUB_SHA::7})"
+            git push
+          }

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -65,9 +65,6 @@ jobs:
       contents: write
       deployments: write
       pull-requests: write
-    environment:
-      name: pr-preview
-      url: https://eclipse-glsp.github.io/glsp-client/pr/${{ needs.resolve-pr.outputs.pr-number }}/diagram.html
     steps:
       - name: Download preview site
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4
@@ -80,6 +77,35 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
+      - name: Create deployment
+        id: deployment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pr.head.sha,
+              environment: 'pr-preview',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'in_progress',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+            core.setOutput('id', deployment.id);
+            core.setOutput('head-sha', pr.head.sha);
       - name: Deploy to gh-pages
         run: |
           PR_NUMBER=${{ needs.resolve-pr.outputs.pr-number }}
@@ -93,6 +119,20 @@ jobs:
             git commit -m "Deploy PR #${PR_NUMBER} preview"
             git push
           }
+      - name: Update deployment status
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
+            const previewUrl = `https://eclipse-glsp.github.io/glsp-client/pr/${prNumber}/diagram.html`;
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'success',
+              environment_url: previewUrl,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
       - name: Comment on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -102,7 +142,7 @@ jobs:
             const body = [
               `**Preview:** [Open browser example](${previewUrl})`,
               '',
-              `Deployed from commit ${context.sha.substring(0, 7)}.`
+              `Deployed from commit ${{ steps.deployment.outputs.head-sha }}.`
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -119,6 +119,18 @@ jobs:
             git commit -m "Deploy PR #${PR_NUMBER} preview"
             git push
           }
+      - name: Wait for GitHub Pages
+        run: |
+          URL="https://eclipse-glsp.github.io/glsp-client/pr/${{ needs.resolve-pr.outputs.pr-number }}/diagram.html"
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null "$URL"; then
+              echo "Page is live"
+              exit 0
+            fi
+            echo "Waiting for GitHub Pages... (attempt $i/30)"
+            sleep 10
+          done
+          echo "::warning::Page did not become available within 5 minutes"
       - name: Update deployment status
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -77,39 +77,26 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
-      - name: Update PR comment (deploying)
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - name: Prepare deployment
+        id: prepare
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Mark existing comment as redeploying
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
             const existing = comments.find(c => c.body.includes('**Preview:**'));
             if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: '**Preview:** Redeploying...'
-              });
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: '**Preview:** Redeploying...' });
             }
-      - name: Create deployment
-        id: deployment
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
+
+            // Create deployment targeting the PR head SHA
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const { data: deployment } = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner, repo,
               ref: pr.head.sha,
               environment: 'pr-preview',
               auto_merge: false,
@@ -117,13 +104,13 @@ jobs:
               transient_environment: true
             });
             await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner, repo,
               deployment_id: deployment.id,
               state: 'in_progress',
-              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              log_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
             });
-            core.setOutput('id', deployment.id);
+
+            core.setOutput('deployment-id', deployment.id);
             core.setOutput('head-sha', pr.head.sha);
       - name: Deploy to gh-pages
         run: |
@@ -138,63 +125,46 @@ jobs:
             git commit -m "Deploy PR #${PR_NUMBER} preview"
             git push
           }
-      - name: Wait for GitHub Pages
-        run: |
-          URL="https://eclipse-glsp.github.io/glsp-client/pr/${{ needs.resolve-pr.outputs.pr-number }}/diagram.html"
-          for i in $(seq 1 30); do
-            if curl -sf -o /dev/null "$URL"; then
-              echo "Page is live"
-              exit 0
-            fi
-            echo "Waiting for GitHub Pages... (attempt $i/30)"
-            sleep 10
-          done
-          echo "::warning::Page did not become available within 5 minutes"
-      - name: Update deployment status
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - name: Finalize deployment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
             const previewUrl = `https://eclipse-glsp.github.io/glsp-client/pr/${prNumber}/diagram.html`;
+
+            // Wait for GitHub Pages to serve the content
+            for (let i = 1; i <= 30; i++) {
+              const res = await fetch(previewUrl);
+              if (res.ok) { core.info('Page is live'); break; }
+              if (i === 30) { core.warning('Page did not become available within 5 minutes'); break; }
+              core.info(`Waiting for GitHub Pages... (attempt ${i}/30)`);
+              await new Promise(r => setTimeout(r, 10000));
+            }
+
+            // Mark deployment as success
             await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment.outputs.id }},
+              owner, repo,
+              deployment_id: ${{ steps.prepare.outputs.deployment-id }},
               state: 'success',
               environment_url: previewUrl,
-              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              log_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
             });
-      - name: Comment on PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
-            const previewUrl = `https://eclipse-glsp.github.io/glsp-client/pr/${prNumber}/diagram.html`;
+
+            // Create or update PR comment
+            const headSha = '${{ steps.prepare.outputs.head-sha }}';
             const body = [
               `**Preview:** [Open browser example](${previewUrl})`,
               '',
-              `Deployed from commit ${{ steps.deployment.outputs.head-sha }}.`
+              `Deployed from commit ${headSha.substring(0, 7)}.`
             ].join('\n');
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
             const existing = comments.find(c => c.body.includes('**Preview:**'));
             if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body
-              });
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
             }
 
   cleanup:
@@ -205,33 +175,36 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: gh-pages
-      - name: Remove preview directory
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git rm -rf "pr/${PR_NUMBER}" || true
-          git commit -m "Remove PR #${PR_NUMBER} preview" --allow-empty
-          git push
-      - name: Update PR comment
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - name: Cleanup
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const prNumber = ${{ github.event.pull_request.number }};
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // Remove pr/<number>/ from gh-pages via the Git Data API
+            const { data: ref } = await github.rest.git.getRef({ owner, repo, ref: 'heads/gh-pages' });
+            const { data: baseCommit } = await github.rest.git.getCommit({ owner, repo, commit_sha: ref.object.sha });
+            const { data: tree } = await github.rest.git.getTree({ owner, repo, tree_sha: baseCommit.tree.sha, recursive: true });
+
+            const prefix = `pr/${prNumber}/`;
+            const kept = tree.tree
+              .filter(item => item.type !== 'tree' && !item.path.startsWith(prefix))
+              .map(({ path, mode, type, sha }) => ({ path, mode, type, sha }));
+
+            const { data: newTree } = await github.rest.git.createTree({ owner, repo, tree: kept });
+            const { data: newCommit } = await github.rest.git.createCommit({
+              owner, repo,
+              message: `Remove PR #${prNumber} preview`,
+              tree: newTree.sha,
+              parents: [ref.object.sha]
             });
+            await github.rest.git.updateRef({ owner, repo, ref: 'heads/gh-pages', sha: newCommit.sha });
+
+            // Update PR comment
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
             const existing = comments.find(c => c.body.includes('**Preview:**'));
             if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: '**Preview:** Removed (PR closed).'
-              });
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: '**Preview:** Removed (PR closed).' });
             }

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -77,6 +77,25 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
+      - name: Update PR comment (deploying)
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+            const existing = comments.find(c => c.body.includes('**Preview:**'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: '**Preview:** Redeploying...'
+              });
+            }
       - name: Create deployment
         id: deployment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project is built with `yarn` and is available from npm via [@eclipse-glsp/p
 
 ## Workflow Diagram Example
 
+> **[Try it online](https://eclipse-glsp.github.io/glsp-client/diagram.html)** – a live deployment of the browser example running on GitHub Pages.
+
 The workflow diagram is a consistent example provided by all GLSP components. The example implements a simple flow chart diagram editor with different types of nodes and edges (see screenshot below).
 The example can be used to try out different GLSP features, as well as several available integrations with IDE platforms (Theia, VSCode, Eclipse, Standalone).
 As the example is fully open source, you can also use it as a blueprint for a custom implementation of a GLSP diagram editor.

--- a/examples/workflow-standalone/scripts/dev.ts
+++ b/examples/workflow-standalone/scripts/dev.ts
@@ -19,11 +19,11 @@ const isBrowser = process.argv.includes('--browser');
 
 const commands = isBrowser
     ? [
-          { command: 'tsc -w', name: 'tsc' },
+          { command: 'tsc -b -w', name: 'tsc' },
           { command: 'webpack serve --env mode=browser', name: 'web' }
       ]
     : [
-          { command: 'tsc -w', name: 'tsc' },
+          { command: 'tsc -b -w', name: 'tsc' },
           { command: 'yarn ts-node ./scripts/start-example-server.ts', name: 'server' },
           { command: 'webpack serve', name: 'web' }
       ];

--- a/examples/workflow-standalone/webpack.config.js
+++ b/examples/workflow-standalone/webpack.config.js
@@ -36,12 +36,17 @@ module.exports = (env = {}) => {
 
     if (isBrowser) {
         const CopyWebpackPlugin = require('copy-webpack-plugin');
+        const serverBundlePath = require.resolve('@eclipse-glsp-examples/workflow-server-bundled-web');
         plugins.push(
             new CopyWebpackPlugin({
                 patterns: [
                     {
-                        from: require.resolve('@eclipse-glsp-examples/workflow-server-bundled-web'),
+                        from: serverBundlePath,
                         to: path.resolve(appRoot, 'wf-glsp-server-webworker.js')
+                    },
+                    {
+                        from: serverBundlePath + '.map',
+                        to: path.resolve(appRoot, 'wf-glsp-server-webworker.js.map')
                     }
                 ]
             })

--- a/packages/client/src/base/shortcuts/available-shortcuts-extension.ts
+++ b/packages/client/src/base/shortcuts/available-shortcuts-extension.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2025 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2026 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/base/view/mouse-tool.ts
+++ b/packages/client/src/base/view/mouse-tool.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/change-bounds/move-element-handler.ts
+++ b/packages/client/src/features/change-bounds/move-element-handler.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2025 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2026 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/change-bounds/resize/resize-handler.ts
+++ b/packages/client/src/features/change-bounds/resize/resize-handler.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2025 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2026 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/helper-lines/helper-line-feedback.ts
+++ b/packages/client/src/features/helper-lines/helper-line-feedback.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2025 EclipseSource and others.
+ * Copyright (c) 2023-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/search-palette/search-palette.ts
+++ b/packages/client/src/features/search-palette/search-palette.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2025 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023-2026 Business Informatics Group (TU Wien) and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
+++ b/packages/client/src/features/tools/change-bounds/change-bounds-tool-move-feedback.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024-2025 EclipseSource and others.
+ * Copyright (c) 2024-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/protocol/src/utils/array-util.ts
+++ b/packages/protocol/src/utils/array-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,22 +250,22 @@
   integrity sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==
 
 "@eclipse-glsp-examples/workflow-server-bundled-web@next":
-  version "2.7.0-next.6"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled-web/-/workflow-server-bundled-web-2.7.0-next.6.tgz#c2bc510bedb9429f06ea721f81b354d4c970d720"
-  integrity sha512-8booMnS9StnhuJzVJ0HqRVsjk2LSvP1+dTQZgSptN3bhgJq5wZ2BtJJxwvztn0Ls+Oz6djYISdsKr6dhkQuDmQ==
+  version "2.7.0-next.7"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled-web/-/workflow-server-bundled-web-2.7.0-next.7.tgz#e163ac8b339953e14003494b2b890ef2a158d261"
+  integrity sha512-ZqmjsnrIKpjQLxD+RVzy8N0+hO3UUHKQ3hGHU+Ed0kubJrhXJJc9bWk2l7hJLgTn956fxiq+5lCPpib90j+3rA==
 
-"@eclipse-glsp/cli@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.7.0-next.10.tgz#75cf853feb77396b534495fd50f31b26b271db0d"
-  integrity sha512-/r8TGvp8jE0Tdzp4Sl7QJxyGL8OmaCBOcwl6V53F6xnay9WmO/U6LNDDc4RLDXLXzNiUEFy4J2V5+nPcdTa2jg==
+"@eclipse-glsp/cli@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.7.0-next.13.tgz#03d49ae55bb551631154d114e03e7ab32df87faf"
+  integrity sha512-5Rj+J5ikKDnjpkoYZc2LCIP9KaP09SXF3Ftefj3XYc3BD44/GJdngBe2uKNAxM71rSmBihBmbLoF/LxL0nr+Ow==
 
-"@eclipse-glsp/config-test@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.7.0-next.10.tgz#aea5b8d3c86027c76b9ee06c42dfbb71746dc22c"
-  integrity sha512-xhgO3MnDJ5d/xhicXxIQgC6Q5EMXg7pqZfZNdhrhMTmLgx4iR292WAMGNAA8qSVETxddNTaw7zOb8gFoOYXeRA==
+"@eclipse-glsp/config-test@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.7.0-next.13.tgz#f190f3f08e7d7b0ac54c851e1d2ce411a9ddbbfd"
+  integrity sha512-8iYAhMfEfCSVPVndqfyRCAexuXEUpdyic1zbXwuiAfAYlH5kAGVAkzCqyeXdo71Be4eX4bS43iRbi91Nmks6Dg==
   dependencies:
-    "@eclipse-glsp/mocha-config" "2.7.0-next.10+743aad5"
-    "@eclipse-glsp/nyc-config" "2.7.0-next.10+743aad5"
+    "@eclipse-glsp/mocha-config" "2.7.0-next.13+90c0040"
+    "@eclipse-glsp/nyc-config" "2.7.0-next.13+90c0040"
     "@istanbuljs/nyc-config-typescript" "^1.0.2"
     "@types/chai" "^4.3.7"
     "@types/mocha" "^10.0.2"
@@ -278,14 +278,14 @@
     sinon "^15.1.0"
     ts-node "^10.9.1"
 
-"@eclipse-glsp/config@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.7.0-next.10.tgz#e6aa4ab50057f828facd521cd2dee198aaf973e9"
-  integrity sha512-ZqIcL8nPAKLduPsoyOYvUrCb6kRv8YQQ7JXcp831YDzj1Ay3vlOq9yG2My6ytyQvR3hs9MFD09467elgYq9xrw==
+"@eclipse-glsp/config@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.7.0-next.13.tgz#56f615c0a4520d5cec48200200649d6c9d52c36d"
+  integrity sha512-mkqntgl3ARfHx3jMhTYSEPUlHyJ8NJaPfSu0nGiUrmOE8qcgrmc76fdynXymeSlkmbnWgS3iFmR28/kdzyAXUw==
   dependencies:
-    "@eclipse-glsp/eslint-config" "2.7.0-next.10+743aad5"
-    "@eclipse-glsp/prettier-config" "2.7.0-next.10+743aad5"
-    "@eclipse-glsp/ts-config" "2.7.0-next.10+743aad5"
+    "@eclipse-glsp/eslint-config" "2.7.0-next.13+90c0040"
+    "@eclipse-glsp/prettier-config" "2.7.0-next.13+90c0040"
+    "@eclipse-glsp/ts-config" "2.7.0-next.13+90c0040"
     "@eslint/js" "^9.0.0"
     "@stylistic/eslint-plugin" "^2.0.0"
     "@tony.ganchev/eslint-plugin-header" "^3.1.1"
@@ -302,40 +302,40 @@
     typescript-eslint "^8.0.0"
 
 "@eclipse-glsp/dev@next":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.7.0-next.10.tgz#81b1b86c2e17d21074c3e6c8fccaf0d396270fad"
-  integrity sha512-lsYYLkLoj35Q3Q8Uet+WCHJQQANHFGFR9/o6DcSIMdUrRhUkyX1uS7XezQr7u9+GJ76yIwp5Q1yMYrcEBpCuzg==
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.7.0-next.13.tgz#cd29d7f8fc130602433c05b7e39c14f669aebc06"
+  integrity sha512-xnMKsqBtq1BZUPI2gC7/o5Le7mFP5KDZLm+tCZV08RNDkNs9o60Ijf+j8s02nLmo/IV8i0U5+dqh8SC15oUf+w==
   dependencies:
-    "@eclipse-glsp/cli" "2.7.0-next.10+743aad5"
-    "@eclipse-glsp/config" "2.7.0-next.10+743aad5"
-    "@eclipse-glsp/config-test" "2.7.0-next.10+743aad5"
+    "@eclipse-glsp/cli" "2.7.0-next.13+90c0040"
+    "@eclipse-glsp/config" "2.7.0-next.13+90c0040"
+    "@eclipse-glsp/config-test" "2.7.0-next.13+90c0040"
 
-"@eclipse-glsp/eslint-config@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.7.0-next.10.tgz#c3a0bd614f52ca3d3c25f1512b8bd28c30777b9a"
-  integrity sha512-3bUCnz/qPQbABYimg0Bfo2TFMV5Qsk5tcy2uxs6ZTefX+7+AkUHOc57/A9XgRt/o3ngt3wCD+XdRkosBO/N6vw==
+"@eclipse-glsp/eslint-config@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.7.0-next.13.tgz#8d5ff34651a397afe5a491ba53be94ca40bb440c"
+  integrity sha512-qaUVaG4ymXXuyPr+7UTq2X5Dbh6Jp4wIYkCwN8YxDZtPdoZKWo5AW7wNTUOpG+P1z8ishSIQI7ZzHpkyqDMXaw==
 
-"@eclipse-glsp/mocha-config@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.7.0-next.10.tgz#a804c7d3f60974b3df2dc6893efda2e6b1d97c5b"
-  integrity sha512-mHQh6XCDnSYloOtON4qN1w8N1mSu9siZi32lfXclh2oVRu16ykUn2oaSQ8aXS6HgMK8FoWaItj5HWNP82qmfwg==
+"@eclipse-glsp/mocha-config@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.7.0-next.13.tgz#0faa95ca78b61e999d37b512b26f56a0ec3f9dc8"
+  integrity sha512-oxTPOmn45TYJvG6GszXy9BZHRJprZuFDWRYRHhUasFd4HPNIGrchyxtxeXm8qRaVhR0bbKKTfvu14RcWx4AuCQ==
 
-"@eclipse-glsp/nyc-config@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.7.0-next.10.tgz#c8cf5a3e00020fefb4d8cd2368bc6da458b9dabb"
-  integrity sha512-aYHgC8vgdGw8iK9ncNUkHgeHi6xaFso+8dECzeoQ+zLAx8aKqmh1//iyHXSWCIzwg1GsU0LkFX8FWdvX866jUg==
+"@eclipse-glsp/nyc-config@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.7.0-next.13.tgz#19e8e28e3914a0a20008136906267600f02dc632"
+  integrity sha512-HY6AN3eiIM5gHCGnWnKAlGRoSh8JV1094caXw6aKfJ9BlD2lLFfK/G97Z//rlyTB2I+CIGyHPo46m65qh0FPKQ==
 
-"@eclipse-glsp/prettier-config@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.7.0-next.10.tgz#da3c8b84b033b4c2c0ee809c29fc650386527d62"
-  integrity sha512-ovjSsvyt487lbrJ1+s2bTX4X2L5vZHW8gMUT9w18YjzPUQPAN6wCfmCVa5NqA+NP9U9DeDOSFp9G5g+YePdUqA==
+"@eclipse-glsp/prettier-config@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.7.0-next.13.tgz#b819c1c384ca9a0cc662727f8fa15b35ab488c59"
+  integrity sha512-8nbWre4W/t6gbVbVE7yz1Cf883pRA1rnWlkgtMF9OtwfhzEBeJxgpFWIe6I+nBlU8WQ+qxdZ0GOge0eJNMTSfg==
   dependencies:
     prettier-plugin-packagejson "~2.4.6"
 
-"@eclipse-glsp/ts-config@2.7.0-next.10+743aad5":
-  version "2.7.0-next.10"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.7.0-next.10.tgz#b3e4443d720318408ff299b7613521f226b0a2f2"
-  integrity sha512-Parige4p4pLPt2mlBnH9AKUXOqAQcOSjjQYVJZJ5vVpVIcuVJr7+q8PVyezlQ/8MmHIrCaJ4o+/xcs6Oft+8cg==
+"@eclipse-glsp/ts-config@2.7.0-next.13+90c0040":
+  version "2.7.0-next.13"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.7.0-next.13.tgz#9891d9dbe75dcaf099de44186b4dba6af836bb8d"
+  integrity sha512-EQEoM982uyxRQyjnnX5AVs54WnhcG7DiDu4cGF+2PWNZRn609wCgxYGz/SXEQCBZMJ2zGhsLX7AVmwEQZHn7Dw==
 
 "@emnapi/core@^1.1.0":
   version "1.5.0"


### PR DESCRIPTION
## Summary
- Fix PR preview deployments not appearing in the PR deploy section by creating deployments via the API with the PR head SHA
- Add main branch deployment workflow (on merge to master and manual trigger)
- Add monthly gh-pages history cleanup workflow that squashes the branch history
- Add live demo link to README
- Fix dev script to use `tsc -b -w` for project references
- Copy source map for bundled web worker server in webpack config
- Update copyright headers to 2026
- Bump `@eclipse-glsp/dev` and related dependency versions
