### PR TITLE
Simplify PR preview workflows with pr-preview-action

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Deploy to gh-pages
         working-directory: gh-pages
         run: |
-          rsync -a --delete --exclude='pr' ../examples/workflow-standalone/app/ ./
+          rsync -a --delete --exclude='.git' --exclude='pr-previews' ../examples/workflow-standalone/app/ ./
           git add -A
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -5,41 +5,28 @@ name: PR Preview Deploy
 # This workflow only processes build artifacts and never executes PR-controlled code.
 
 on:
-  workflow_dispatch:
-    inputs:
-      run-id:
-        description: 'Build workflow run ID (for artifact download)'
-        required: true
-      pr-number:
-        description: 'PR number to deploy'
-        required: true
   workflow_run:
     workflows: ['PR Preview Build']
     types: [completed]
-  pull_request_target:
-    types: [closed]
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: pr-preview-deploy
   cancel-in-progress: false
 
 jobs:
-  resolve-pr:
-    name: Resolve PR Number
+  deploy:
+    name: Deploy Preview
     if: >
-      github.event_name == 'workflow_dispatch' || (
-      github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request')
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-22.04
-    permissions:
-      actions: read
-    outputs:
-      pr-number: ${{ steps.pr.outputs.number }}
-      run-id: ${{ steps.pr.outputs.run-id }}
     steps:
       - name: Download PR metadata
-        if: github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-metadata
@@ -49,162 +36,33 @@ jobs:
       - name: Read PR number
         id: pr
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ inputs.pr-number }}" >> "$GITHUB_OUTPUT"
-            echo "run-id=${{ inputs.run-id }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=$(cat ./pr-metadata/pr-number)" >> "$GITHUB_OUTPUT"
-            echo "run-id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
-          fi
-
-  deploy:
-    name: Deploy Preview
-    needs: resolve-pr
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      deployments: write
-      pull-requests: write
-    steps:
+          echo "number=$(cat ./pr-metadata/pr-number)" >> "$GITHUB_OUTPUT"
+          echo "short-sha=$(echo '${{ github.event.workflow_run.head_sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Download preview site
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: preview-site
           path: ./preview-site
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ needs.resolve-pr.outputs.run-id }}
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        id: preview
         with:
-          ref: gh-pages
-          path: gh-pages
-      - name: Prepare deployment
-        id: prepare
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+          source-dir: ./preview-site
+          preview-branch: gh-pages
+          umbrella-dir: pr-previews
+          pr-number: ${{ steps.pr.outputs.number }}
+          action: deploy
+          comment: false
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
-          script: |
-            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+          header: pr-preview
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            **Preview:** [Open browser example](${{ steps.preview.outputs.deployment-url }}/diagram.html)
 
-            // Mark existing comment as redeploying
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
-            const existing = comments.find(c => c.body.includes('**Preview:**'));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: '**Preview:** Redeploying...' });
-            }
-
-            // Create deployment targeting the PR head SHA
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
-            const { data: deployment } = await github.rest.repos.createDeployment({
-              owner, repo,
-              ref: pr.head.sha,
-              environment: 'pr-preview',
-              auto_merge: false,
-              required_contexts: [],
-              transient_environment: true
-            });
-            await github.rest.repos.createDeploymentStatus({
-              owner, repo,
-              deployment_id: deployment.id,
-              state: 'in_progress',
-              log_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
-            });
-
-            core.setOutput('deployment-id', deployment.id);
-            core.setOutput('head-sha', pr.head.sha);
-      - name: Deploy to gh-pages
-        working-directory: gh-pages
-        run: |
-          PR_NUMBER=${{ needs.resolve-pr.outputs.pr-number }}
-          mkdir -p "pr/${PR_NUMBER}"
-          cp -r ../preview-site/* "pr/${PR_NUMBER}/"
-          git add "pr/${PR_NUMBER}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --cached --quiet && echo "No changes to deploy" || {
-            git commit -m "Deploy PR #${PR_NUMBER} preview"
-            git push
-          }
-      - name: Finalize deployment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const prNumber = ${{ needs.resolve-pr.outputs.pr-number }};
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const previewUrl = `https://eclipse-glsp.github.io/glsp-client/pr/${prNumber}/diagram.html`;
-
-            // Wait for GitHub Pages to serve the content
-            for (let i = 1; i <= 30; i++) {
-              const res = await fetch(previewUrl);
-              if (res.ok) { core.info('Page is live'); break; }
-              if (i === 30) { core.warning('Page did not become available within 5 minutes'); break; }
-              core.info(`Waiting for GitHub Pages... (attempt ${i}/30)`);
-              await new Promise(r => setTimeout(r, 10000));
-            }
-
-            // Mark deployment as success
-            await github.rest.repos.createDeploymentStatus({
-              owner, repo,
-              deployment_id: ${{ steps.prepare.outputs.deployment-id }},
-              state: 'success',
-              environment_url: previewUrl,
-              log_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
-            });
-
-            // Create or update PR comment
-            const headSha = '${{ steps.prepare.outputs.head-sha }}';
-            const body = [
-              `**Preview:** [Open browser example](${previewUrl})`,
-              '',
-              `Deployed from commit ${headSha.substring(0, 7)}.`
-            ].join('\n');
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
-            const existing = comments.find(c => c.body.includes('**Preview:**'));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
-            }
-
-  cleanup:
-    name: Cleanup Preview
-    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Cleanup
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.payload.pull_request.number;
-
-            // Remove pr/<number>/ from gh-pages via the Git Data API
-            const { data: ref } = await github.rest.git.getRef({ owner, repo, ref: 'heads/gh-pages' });
-            const { data: baseCommit } = await github.rest.git.getCommit({ owner, repo, commit_sha: ref.object.sha });
-            const { data: tree } = await github.rest.git.getTree({ owner, repo, tree_sha: baseCommit.tree.sha, recursive: true });
-
-            const prefix = `pr/${prNumber}/`;
-            const kept = tree.tree
-              .filter(item => item.type !== 'tree' && !item.path.startsWith(prefix))
-              .map(({ path, mode, type, sha }) => ({ path, mode, type, sha }));
-
-            const { data: newTree } = await github.rest.git.createTree({ owner, repo, tree: kept });
-            const { data: newCommit } = await github.rest.git.createCommit({
-              owner, repo,
-              message: `Remove PR #${prNumber} preview`,
-              tree: newTree.sha,
-              parents: [ref.object.sha]
-            });
-            await github.rest.git.updateRef({ owner, repo, ref: 'heads/gh-pages', sha: newCommit.sha });
-
-            // Update PR comment
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber });
-            const existing = comments.find(c => c.body.includes('**Preview:**'));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: '**Preview:** Removed (PR closed).' });
-            }
+            Deployed from commit ${{ steps.pr.outputs.short-sha }}.

--- a/.github/workflows/pr-preview-remove.yml
+++ b/.github/workflows/pr-preview-remove.yml
@@ -1,0 +1,39 @@
+name: PR Preview Remove
+
+# SECURITY: This workflow uses pull_request_target which has access to secrets.
+# It is safe because:
+# 1. It only triggers on PR close (not open/sync)
+# 2. It only checks out the base branch (not PR code)
+# 3. It never executes any PR-controlled scripts
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-deploy
+  cancel-in-progress: false
+
+jobs:
+  remove:
+    name: Remove Preview
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-previews
+          action: remove
+      - name: Update PR comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: pr-preview
+          number: ${{ github.event.pull_request.number }}
+          message: '**Preview:** Removed (PR closed).'

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ node_modules/
 lib/
 artifacts/
 
-examples/workflow-standalone/app
+examples/workflow-standalone/app/*
 !examples/workflow-standalone/app/diagram.html
 !examples/workflow-standalone/app/example1.wf
 


### PR DESCRIPTION
## Summary
- Replace ~170 lines of custom `github-script` (manual git tree manipulation, Deployments API management, comment find-and-update) with [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action) (v1.8.1) and [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment) (v3.0.4)
- Rewrite `pr-preview-deploy.yml` to delegate deployment to `pr-preview-action` instead of manual gh-pages git operations
- Extract cleanup into dedicated `pr-preview-remove.yml` using `pr-preview-action` with `action: remove`
- Update `main-deploy.yml` rsync exclude for new umbrella dir (`pr-previews`) and add `--exclude='.git'` to prevent deleting the gh-pages checkout's `.git` directory
- Drop `workflow_dispatch` trigger and GitHub Deployments API tracking
