### PR TITLE
GLSP-1675: Avoid unnecessary await for sync action handlers

### DIFF
--- a/packages/client/src/base/action-dispatcher.ts
+++ b/packages/client/src/base/action-dispatcher.ts
@@ -22,6 +22,7 @@ import {
     EMPTY_ROOT,
     GModelRoot,
     IActionDispatcher,
+    MaybePromise,
     RejectAction,
     RequestAction,
     ResponseAction,
@@ -184,7 +185,7 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
         const handlerResults: Promise<any>[] = [];
         for (const handler of handlers) {
             const maybeResult = handler.handle(action);
-            const result = this.isPromiseLike(maybeResult) ? await maybeResult : maybeResult;
+            const result = MaybePromise.isPromise(maybeResult) ? await maybeResult : maybeResult;
             if (Action.is(result)) {
                 handlerResults.push(this.dispatch(result));
             } else if (result !== undefined) {
@@ -193,10 +194,6 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
             }
         }
         await Promise.all(handlerResults);
-    }
-
-    protected isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-        return typeof value === 'object' && value !== undefined && typeof (value as any).then === 'function';
     }
 
     override request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res> {

--- a/packages/client/src/base/action-dispatcher.ts
+++ b/packages/client/src/base/action-dispatcher.ts
@@ -183,7 +183,8 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
         this.logger.log(this, 'Handle', action);
         const handlerResults: Promise<any>[] = [];
         for (const handler of handlers) {
-            const result = await handler.handle(action);
+            const maybeResult = handler.handle(action);
+            const result = this.isPromiseLike(maybeResult) ? await maybeResult : maybeResult;
             if (Action.is(result)) {
                 handlerResults.push(this.dispatch(result));
             } else if (result !== undefined) {
@@ -192,6 +193,10 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
             }
         }
         await Promise.all(handlerResults);
+    }
+
+    protected isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+        return typeof value === 'object' && value !== undefined && typeof (value as any).then === 'function';
     }
 
     override request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res> {

--- a/packages/client/src/features/export/export-modules.ts
+++ b/packages/client/src/features/export/export-modules.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable @typescript-eslint/no-deprecated */
 import {
     bindAsService,
     configureActionHandler,

--- a/packages/client/src/features/export/export-svg-action-handler.ts
+++ b/packages/client/src/features/export/export-svg-action-handler.ts
@@ -13,9 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable @typescript-eslint/no-deprecated */
+import { ExportSvgAction, IActionHandler } from '@eclipse-glsp/sprotty';
 import { saveAs } from 'file-saver';
 import { injectable } from 'inversify';
-import { ExportSvgAction, IActionHandler } from '@eclipse-glsp/sprotty';
 
 /**
  * The default handler for {@link ExportSvgAction}s. This generic handler can be used in

--- a/packages/client/src/features/export/glsp-svg-exporter.ts
+++ b/packages/client/src/features/export/glsp-svg-exporter.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable @typescript-eslint/no-deprecated */
 import {
     Action,
     ExportSvgAction,

--- a/packages/protocol/src/action-protocol/model-saving.spec.ts
+++ b/packages/protocol/src/action-protocol/model-saving.spec.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import { expect } from 'chai';
 import {

--- a/packages/protocol/src/action-protocol/model-saving.ts
+++ b/packages/protocol/src/action-protocol/model-saving.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/* eslint-disable @typescript-eslint/no-deprecated */
 import * as sprotty from 'sprotty-protocol/lib/actions';
 import { ProposalString, hasBooleanProp, hasStringProp } from '../utils/type-util';
 import { Action, RequestAction, ResponseAction } from './base-protocol';

--- a/packages/protocol/src/utils/type-util.ts
+++ b/packages/protocol/src/utils/type-util.ts
@@ -67,6 +67,17 @@ export type PropertiesOfType<T, V> = Pick<T, KeysOfType<T, V>>;
  */
 export type MaybePromise<T> = T | PromiseLike<T>;
 
+export namespace MaybePromise {
+    /**
+     * Type guard to check whether a given value is a {@link PromiseLike}.
+     * @param value The value to check.
+     * @returns `true` if the value is a `PromiseLike`.
+     */
+    export function isPromise<T = unknown>(value: MaybePromise<T>): value is PromiseLike<T> {
+        return AnyObject.is(value) && hasFunctionProp(value, 'then');
+    }
+}
+
 /**
  * Utility type to describe typeguard functions.
  */


### PR DESCRIPTION


Fixes https://github.com/eclipse-glsp/glsp/issues/1675

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Only await handler results that are actually promises
- Sync handler results are used directly, preserving sprotty's original microtask timing for the common case
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Test snapping in the deployed example and ensure that it now snaps again as expected.
  Proper execution of sync handlers without microtasking roundtrip should resolve the timing issues)
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
