### PR TITLE
GLSP-1609: Restore parallel-start dispatch for async action handlers

### DIFF
--- a/packages/client/src/base/action-dispatcher.spec.ts
+++ b/packages/client/src/base/action-dispatcher.spec.ts
@@ -13,9 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ActionHandlerRegistry, IActionHandler, RequestAction, ResponseAction, TYPES } from '@eclipse-glsp/sprotty';
+import { ActionHandlerRegistry, Deferred, IActionHandler, RequestAction, ResponseAction, TYPES } from '@eclipse-glsp/sprotty';
 import { expect } from 'chai';
 import { Container } from 'inversify';
+
+/** Yields to the event loop long enough for pending microtasks (and already-queued timers) to run. */
+const flushMicrotasks = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
 
 import { GLSPActionDispatcher } from './action-dispatcher';
 import { defaultModule } from './default.module';
@@ -73,6 +76,21 @@ describe('GLSPActionDispatcher', () => {
             );
             expect(gotRejected, 'Response promise should be rejected').to.be.true;
         });
+        it('should not leak timeout entries once the request settles', async () => {
+            const timeouts = actionDispatcher['timeouts'] as Map<string, unknown>;
+
+            // resolved-within-timeout path
+            testHandlerDelay = 5;
+            await actionDispatcher.requestUntil({ kind: 'request', requestId: '' }, 150);
+            // timed-out path
+            testHandlerDelay = 50;
+            await actionDispatcher.requestUntil({ kind: 'request', requestId: '' }, 5);
+            // missing-handler path: rejects the request, must still clear the timeout
+            await actionDispatcher.requestUntil({ kind: 'noHandlerRequest', requestId: '' }, 50).catch(() => undefined);
+            await flushMicrotasks();
+
+            expect(timeouts.size, 'all timeout entries should be cleared after the requests settle').to.equal(0);
+        });
     });
     describe('request & re-dispatch', () => {
         it('should be possible to re-dispatch the response of a `request` call', async () => {
@@ -101,7 +119,9 @@ describe('GLSPActionDispatcher', () => {
             expect(handlerExecuted).to.be.true;
         });
 
-        it('should execute multiple async handlers sequentially', async () => {
+        it('should invoke all handlers in one synchronous burst (parallel-start), without serializing on async ones', async () => {
+            // asyncHandler1 (registered first) has the longer delay. Serial execution would yield [1, 2];
+            // parallel-start lets the shorter handler finish first, yielding [2, 1].
             const executionOrder: number[] = [];
             const asyncHandler1: IActionHandler = {
                 handle: async () => {
@@ -120,7 +140,87 @@ describe('GLSPActionDispatcher', () => {
             registry.register('multiAsyncTest', asyncHandler2);
             await actionDispatcher.dispatch({ kind: 'multiAsyncTest' });
 
-            expect(executionOrder).to.deep.equal([1, 2]);
+            expect(executionOrder).to.deep.equal([2, 1]);
+        });
+
+        it('should not let a slow async handler starve a synchronous sibling registered after it', async () => {
+            // Sync handler registered after the gated async one must run during the burst, before the
+            // async handler is released.
+            const executionOrder: number[] = [];
+            const gate = new Deferred<void>();
+            const slowAsyncHandler: IActionHandler = {
+                handle: async () => {
+                    await gate.promise;
+                    executionOrder.push(1);
+                }
+            };
+            const syncHandler: IActionHandler = {
+                handle: () => {
+                    executionOrder.push(2);
+                }
+            };
+
+            registry.register('starveTest', slowAsyncHandler);
+            registry.register('starveTest', syncHandler);
+            const dispatched = actionDispatcher.dispatch({ kind: 'starveTest' });
+
+            // Let the invocation burst run; the async handler is still gated.
+            await flushMicrotasks();
+            expect(executionOrder, 'sync sibling must run before the gated async handler resolves').to.deep.equal([2]);
+
+            gate.resolve();
+            await dispatched;
+            expect(executionOrder).to.deep.equal([2, 1]);
+        });
+
+        it('should not let a never-resolving async handler starve a synchronous sibling', async () => {
+            // A handler whose promise never resolves must not prevent other handlers from being invoked.
+            const executionOrder: number[] = [];
+            const stuckHandler: IActionHandler = {
+                handle: () => new Promise<void>(() => undefined) // never resolves
+            };
+            const syncHandler: IActionHandler = {
+                handle: () => {
+                    executionOrder.push(1);
+                }
+            };
+
+            registry.register('stuckTest', stuckHandler);
+            registry.register('stuckTest', syncHandler);
+            // Intentionally not awaited: the dispatch promise never resolves because of the stuck handler.
+            actionDispatcher.dispatch({ kind: 'stuckTest' });
+
+            await flushMicrotasks();
+            expect(executionOrder).to.deep.equal([1]);
+        });
+
+        it('should not deadlock when an async handler awaits a nested dispatch while a sibling is registered after it', async () => {
+            // A serial loop would block the sibling behind the async handler that awaits a nested dispatch,
+            // risking deadlock. Parallel-start invokes the sibling in the burst, so nothing waits its turn.
+            // Order: 'B' (burst) -> 'sub' (nested) -> 'A' (async tail).
+            const executionOrder: string[] = [];
+            registry.register('nestedSub', {
+                handle: () => {
+                    executionOrder.push('sub');
+                }
+            });
+            const nestedDispatchHandler: IActionHandler = {
+                handle: async () => {
+                    await actionDispatcher.dispatch({ kind: 'nestedSub' });
+                    executionOrder.push('A');
+                }
+            };
+            const siblingHandler: IActionHandler = {
+                handle: () => {
+                    executionOrder.push('B');
+                }
+            };
+
+            registry.register('nestedTest', nestedDispatchHandler);
+            registry.register('nestedTest', siblingHandler);
+            await actionDispatcher.dispatch({ kind: 'nestedTest' });
+
+            expect(executionOrder).to.deep.equal(['B', 'sub', 'A']);
         });
 
         it('should handle mixed sync and async handlers correctly', async () => {

--- a/packages/client/src/base/action-dispatcher.ts
+++ b/packages/client/src/base/action-dispatcher.ts
@@ -21,6 +21,7 @@ import {
     Deferred,
     EMPTY_ROOT,
     GModelRoot,
+    HandleActionResult,
     IActionDispatcher,
     MaybePromise,
     RejectAction,
@@ -133,17 +134,15 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
     }
 
     protected async handleResponseAction(action: ResponseAction): Promise<void> {
-        // clear any pending timeout
         const timeout = this.timeouts.get(action.responseId);
         if (timeout !== undefined) {
             clearTimeout(timeout);
             this.timeouts.delete(action.responseId);
         }
 
-        // check for matching request
         const request = this.requests.get(action.responseId);
         if (!request) {
-            // treat no matching request by dispatching action normally
+            // No pending request: re-dispatch as a normal action.
             this.logger.log(this, 'No matching request for response, dispatch normally', action);
             action.responseId = '';
             return this.handleAction(action);
@@ -151,7 +150,6 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
 
         this.requests.delete(action.responseId);
         if (RejectAction.is(action)) {
-            // translation reject action to request rejection
             request.reject(new Error(action.message));
             this.logger.warn(this, `Request with id ${action.responseId} failed.`, action.message, action.detail);
         } else {
@@ -170,35 +168,47 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
         }
         this.logger.warn(this, 'Missing handler for action', action);
         const error = new Error(`Missing handler for action '${action.kind}'`);
-        if (!RequestAction.is(action)) {
-            throw error;
+        if (RequestAction.is(action)) {
+            const request = this.requests.get(action.requestId);
+            if (request !== undefined) {
+                this.requests.delete(action.requestId);
+                request.reject(error);
+            }
         }
-        const request = this.requests.get(action.requestId);
-        if (request !== undefined) {
-            this.requests.delete(action.requestId);
-            request.reject(error);
-        }
+        throw error;
     }
 
     protected async handleActionWithHandler(action: Action, handlers: ActionHandler[]): Promise<void> {
         this.logger.log(this, 'Handle', action);
-        const handlerResults: Promise<any>[] = [];
+        // No `await` inside the loop: invoke handlers in one burst and await their results collectively.
+        const handlerResults: PromiseLike<unknown>[] = [];
         for (const handler of handlers) {
             const maybeResult = handler.handle(action);
-            const result = MaybePromise.isPromise(maybeResult) ? await maybeResult : maybeResult;
-            if (Action.is(result)) {
-                handlerResults.push(this.dispatch(result));
-            } else if (result !== undefined) {
-                this.blockUntil = result.blockUntil;
-                handlerResults.push(this.commandStack.execute(result));
+            if (MaybePromise.isPromise(maybeResult)) {
+                handlerResults.push(maybeResult.then(result => this.processHandlerResult(result)));
+            } else {
+                const resultPromise = this.processHandlerResult(maybeResult);
+                if (resultPromise) {
+                    handlerResults.push(resultPromise);
+                }
             }
         }
         await Promise.all(handlerResults);
     }
 
+    protected processHandlerResult(result: HandleActionResult): Promise<unknown> | undefined {
+        if (Action.is(result)) {
+            return this.dispatch(result);
+        }
+        if (result !== undefined) {
+            this.blockUntil = result.blockUntil;
+            return this.commandStack.execute(result);
+        }
+        return undefined;
+    }
+
     override request<Res extends ResponseAction>(action: RequestAction<Res>): Promise<Res> {
         if (!action.requestId || action.requestId === '') {
-            // No request id has been specified. So we use a generated one.
             action.requestId = RequestAction.generateRequestId();
         }
         return super.request(action);
@@ -220,7 +230,6 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
         rejectOnTimeout = false
     ): Promise<Res | undefined> {
         if (!action.requestId || action.requestId === '') {
-            // No request id has been specified. So we use a generated one.
             action.requestId = RequestAction.generateRequestId();
         }
         // Stamp the effective timeout onto the action so the receiving side
@@ -231,7 +240,6 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
         const timeout = setTimeout(() => {
             const deferred = this.requests.get(requestId);
             if (deferred !== undefined) {
-                // cleanup
                 clearTimeout(timeout);
                 this.requests.delete(requestId);
 
@@ -245,6 +253,18 @@ export class GLSPActionDispatcher extends ActionDispatcher implements IGModelRoo
             }
         }, timeoutMs);
         this.timeouts.set(requestId, timeout);
-        return super.request<Res>(action);
+
+        const result = super.request<Res>(action);
+        // handleResponseAction only clears the timeout on the response path; clear it here on every
+        // other settle path (timeout, rejection, missing handler) so the timer and map entry can't leak.
+        const clearRequestTimeout = (): void => {
+            const pending = this.timeouts.get(requestId);
+            if (pending !== undefined) {
+                clearTimeout(pending);
+                this.timeouts.delete(requestId);
+            }
+        };
+        result.then(clearRequestTimeout, clearRequestTimeout);
+        return result;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Invoke all handlers in one synchronous burst (sprotty parallel-start)
- Await handlers' follow-up work collectively, not each one in the loop
- Stop a slow or stuck async handler from starving siblings or deadlocking
- Extract processHandlerResult; keep blockUntil set during the burst
- Reject dispatch promise for handler-less requests (sprotty parity)
- Clear requestUntil timeouts on all settle paths to fix a timer leak
- Replace the sequential test; add starvation, deadlock and leak tests

Relates to https://github.com/eclipse-glsp/glsp/issues/1609

#### How to test

- Check if all tests run or whether there is a scenario that is missing.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
