### PR TITLE
GLSP-1700: Introduce uuid helper

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,14 @@ export default [
                     name: 'sprotty-protocol',
                     message:
                         "The sprotty-protocol default exports are customized and reexported by GLSP. Please use '@eclipse-glsp/client' instead"
+                },
+                {
+                    name: 'uuid',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/protocol') instead of importing 'uuid' directly."
+                },
+                {
+                    name: 'uuid/*',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/protocol') instead of importing 'uuid' directly."
                 }
             ],
             '@typescript-eslint/no-unused-vars': [
@@ -59,7 +67,7 @@ export default [
             ]
         }
     },
-    // packages/protocol: restrict sprotty and circular @eclipse-glsp/client imports
+    // packages/protocol: restrict sprotty and uuid direct imports
     {
         files: ['packages/protocol/src/**/*.{ts,tsx}'],
         rules: {
@@ -75,14 +83,14 @@ export default [
                     message: "The protocol package should not have any direct 'sprotty' dependencies. Try to use 'sprotty-protocol' instead"
                 },
                 {
-                    name: '@eclipse-glsp/client',
+                    name: 'uuid',
                     message:
-                        "Circular dependency! This package is consumed by '@eclipse-glsp' client. Consider moving the conflicting file into this package."
+                        "Use the 'generateUuid'/'isUuid' helpers (from this package's 'utils/uuid' module) instead of importing 'uuid' directly."
                 },
                 {
-                    name: '@eclipse-glsp/client/*',
+                    name: 'uuid/*',
                     message:
-                        "Circular dependency! This package is consumed by '@eclipse-glsp' client. Consider moving the conflicting file into this package."
+                        "Use the 'generateUuid'/'isUuid' helpers (from this package's 'utils/uuid' module) instead of importing 'uuid' directly."
                 }
             ]
         }
@@ -101,6 +109,14 @@ export default [
                 {
                     name: 'sprotty-protocol/*',
                     message: "Please use '@eclipse-glsp/protocol' instead"
+                },
+                {
+                    name: 'uuid',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/protocol') instead of importing 'uuid' directly."
+                },
+                {
+                    name: 'uuid/*',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/protocol') instead of importing 'uuid' directly."
                 }
             ]
         }
@@ -135,6 +151,65 @@ export default [
                 {
                     name: '@eclipse-glsp/protocol/*',
                     message: 'Please use @eclipse-glsp/sprotty instead'
+                },
+                {
+                    name: 'uuid',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/sprotty') instead of importing 'uuid' directly."
+                },
+                {
+                    name: 'uuid/*',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/sprotty') instead of importing 'uuid' directly."
+                }
+            ]
+        }
+    },
+    // examples: only consume the public '@eclipse-glsp/client' API; the lower layers
+    // (protocol, sprotty, raw sprotty/sprotty-protocol) are re-exported through it.
+    {
+        files: ['examples/*/src/**/*.{ts,tsx}'],
+        rules: {
+            'no-restricted-imports': [
+                'warn',
+                ...restrictedBaseImports,
+                {
+                    name: 'sprotty',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: 'sprotty/*',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: 'sprotty-protocol',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: 'sprotty-protocol/*',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: '@eclipse-glsp/protocol',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: '@eclipse-glsp/protocol/*',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: '@eclipse-glsp/sprotty',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: '@eclipse-glsp/sprotty/*',
+                    message: 'Please use @eclipse-glsp/client instead'
+                },
+                {
+                    name: 'uuid',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/client') instead of importing 'uuid' directly."
+                },
+                {
+                    name: 'uuid/*',
+                    message: "Use the 'generateUuid'/'isUuid' helpers (from '@eclipse-glsp/client') instead of importing 'uuid' directly."
                 }
             ]
         }

--- a/examples/workflow-glsp/src/workflow-startup.ts
+++ b/examples/workflow-glsp/src/workflow-startup.ts
@@ -14,8 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { IDiagramStartup, IGridManager } from '@eclipse-glsp/client';
-import { MaybePromise, TYPES } from '@eclipse-glsp/sprotty';
+import { IDiagramStartup, IGridManager, MaybePromise, TYPES } from '@eclipse-glsp/client';
 import { inject, injectable, optional } from 'inversify';
 
 /**

--- a/packages/client/src/features/copy-paste/copy-paste-handler.ts
+++ b/packages/client/src/features/copy-paste/copy-paste-handler.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@
 import {
     ClipboardData,
     CutOperation,
+    generateUuid,
     IActionDispatcher,
     PasteOperation,
     RequestClipboardDataAction,
@@ -24,7 +25,6 @@ import {
     ViewerOptions
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
-import { v4 as uuid } from 'uuid';
 import { EditorContextService } from '../../base/editor-context-service';
 
 export interface ICopyPasteHandler {
@@ -107,7 +107,7 @@ export class ServerCopyPasteHandler implements ICopyPasteHandler {
 
     handleCopy(event: ClipboardEvent): void {
         if (event.clipboardData && this.shouldCopy(event)) {
-            const clipboardId = uuid();
+            const clipboardId = generateUuid();
             event.clipboardData.setData(CLIPBOARD_DATA_FORMAT, toClipboardId(clipboardId));
             this.actionDispatcher
                 .request<SetClipboardDataAction>(RequestClipboardDataAction.create(this.editorContext.get()))

--- a/packages/client/src/features/export/glsp-svg-exporter.ts
+++ b/packages/client/src/features/export/glsp-svg-exporter.ts
@@ -18,6 +18,7 @@ import {
     Action,
     ExportSvgAction,
     ExportSvgOptions,
+    generateUuid,
     GModelRoot,
     RejectAction,
     RequestAction,
@@ -25,7 +26,6 @@ import {
     SvgExporter
 } from '@eclipse-glsp/sprotty';
 import { injectable } from 'inversify';
-import { v4 as uuid } from 'uuid';
 
 @injectable()
 export class GLSPSvgExporter extends SvgExporter {
@@ -82,7 +82,7 @@ export class GLSPSvgExporter extends SvgExporter {
         // createSvg requires the svg to have a non-empty id, so we generate one if necessary
         const originalId = svgElement.id;
         try {
-            svgElement.id = originalId || uuid();
+            svgElement.id = originalId || generateUuid();
             return super.createSvg(svgElement, root, options, cause);
         } finally {
             svgElement.id = originalId;

--- a/packages/client/src/features/helper-lines/model.ts
+++ b/packages/client/src/features/helper-lines/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Args, Bounds, Direction, GChildElement, GModelElement, GShapeElement, Point, Vector } from '@eclipse-glsp/sprotty';
-import { v4 as uuid } from 'uuid';
+import { Args, Bounds, Direction, GChildElement, GModelElement, GShapeElement, Point, Vector, generateUuid } from '@eclipse-glsp/sprotty';
 import { ArgsAware } from '../../base/args-feature';
 import { ResizeHandleLocation } from '../change-bounds/model';
 
@@ -46,7 +45,7 @@ export class HelperLine extends GChildElement implements ArgsAware {
         readonly lineType: HelperLineType = HelperLineType.Left
     ) {
         super();
-        this.id = uuid();
+        this.id = generateUuid();
         this.type = HELPER_LINE;
     }
 
@@ -86,7 +85,7 @@ export class SelectionBounds extends GShapeElement implements ArgsAware {
 
     constructor(bounds?: Bounds) {
         super();
-        this.id = uuid();
+        this.id = generateUuid();
         this.type = SELECTION_BOUNDS;
         if (bounds) {
             this.bounds = bounds;

--- a/packages/client/src/features/tools/node-creation/insert-indicator.ts
+++ b/packages/client/src/features/tools/node-creation/insert-indicator.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 EclipseSource and others.
+ * Copyright (c) 2024-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Args, Dimension, FeatureSet, GNode, boundsFeature, createFeatureSet, moveFeature } from '@eclipse-glsp/sprotty';
-import { v4 as uuid } from 'uuid';
+import { Args, Dimension, FeatureSet, GNode, boundsFeature, createFeatureSet, generateUuid, moveFeature } from '@eclipse-glsp/sprotty';
 import { ArgsAware, argsFeature } from '../../../base/args-feature';
 
 export const ARG_LENGTH = 'length';
@@ -25,7 +24,7 @@ export class InsertIndicator extends GNode implements ArgsAware {
 
     static TYPE = 'node:insert-indicator';
 
-    override id: string = uuid();
+    override id: string = generateUuid();
     override type: string = InsertIndicator.TYPE;
     override features?: FeatureSet = createFeatureSet(InsertIndicator.DEFAULT_FEATURES);
     override cssClasses: string[] = ['insert-indicator', 'sprotty-node'];

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -46,11 +46,8 @@
   },
   "dependencies": {
     "sprotty-protocol": "1.4.0",
-    "uuid": "~14.0.0",
+    "uuid": "^14.0.0",
     "vscode-jsonrpc": "8.2.0"
-  },
-  "devDependencies": {
-    "@types/uuid": "~9.0.8"
   },
   "peerDependencies": {
     "inversify": "^6.1.3"

--- a/packages/protocol/src/client-server-protocol/glsp-client.ts
+++ b/packages/protocol/src/client-server-protocol/glsp-client.ts
@@ -13,19 +13,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { v4 as uuid } from 'uuid';
-
 import { ActionMessage } from '../action-protocol/base-protocol';
 import { Disposable } from '../utils/disposable';
 import { Event } from '../utils/event';
 import { AnyObject, MaybePromise, hasStringProp } from '../utils/type-util';
+import { generateUuid } from '../utils/uuid';
 import { DisposeClientSessionParameters, InitializeClientSessionParameters, InitializeParameters, InitializeResult } from './types';
 
 export class ApplicationIdProvider {
     private static _applicationId?: string;
     static get(): string {
         if (!ApplicationIdProvider._applicationId) {
-            ApplicationIdProvider._applicationId = uuid();
+            ApplicationIdProvider._applicationId = generateUuid();
         }
         return ApplicationIdProvider._applicationId;
     }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -61,3 +61,4 @@ export * from './utils/geometry-util';
 export * from './utils/geometry-vector';
 export * from './utils/math-util';
 export * from './utils/type-util';
+export * from './utils/uuid';

--- a/packages/protocol/src/utils/uuid.spec.ts
+++ b/packages/protocol/src/utils/uuid.spec.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { expect } from 'chai';
+import { generateUuid, isUuid } from './uuid';
+
+describe('Uuid', () => {
+    describe('isUuid', () => {
+        it('should return true for a valid UUID', () => {
+            expect(isUuid('f47ac10b-58cc-4372-a567-0e02b2c3d479')).to.be.true;
+        });
+        it('should return true for a generated UUID', () => {
+            expect(isUuid(generateUuid())).to.be.true;
+        });
+        it('should return false for a malformed UUID', () => {
+            expect(isUuid('not-a-uuid')).to.be.false;
+            expect(isUuid('')).to.be.false;
+        });
+    });
+});

--- a/packages/protocol/src/utils/uuid.ts
+++ b/packages/protocol/src/utils/uuid.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// eslint-disable-next-line no-restricted-imports -- this helper is the single sanctioned entry point for the 'uuid' dependency
+import { v4, validate } from 'uuid';
+
+/**
+ * Generates a random RFC-4122 v4 UUID.
+ *
+ * This is the single entry point for UUID creation across all GLSP components: routing every
+ * caller through `@eclipse-glsp/protocol` keeps `uuid` an isolated, auditable dependency instead
+ * of letting each package pull in (and pin) its own copy.
+ *
+ * @returns a newly generated v4 UUID
+ */
+export function generateUuid(): string {
+    return v4();
+}
+
+/**
+ * Checks whether the given string is a well-formed RFC-4122 UUID.
+ *
+ * @param value the string to test
+ * @returns `true` if {@link value} is a valid UUID
+ */
+export function isUuid(value: string): boolean {
+    return validate(value);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,11 +1670,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/uuid@~9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
-  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
-
 "@typescript-eslint/eslint-plugin@8.56.0":
   version "8.56.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz#5aec3db807a6b8437ea5d5ebf7bd16b4119aba8d"
@@ -6736,15 +6731,15 @@ uuid@^11.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@~14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
-  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Add shared uuid util to protocol package. Consuming packages should use the helper when needing uuids instead of depending on their own uuid version
- Update code-base to consistently use new helper
- Update eslint config to restrict direct 'uuid' imports and adjust import rules for examples

Fixes eclipse-glsp/glsp#1700
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
