### PR TITLE
GLSP-1717: Fix bounds computation error after diagram export

### DIFF
--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
@@ -67,74 +67,81 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
     }
 
     override postUpdate(cause?: Action): void {
-        if (cause === undefined || cause.kind !== RequestBoundsAction.KIND) {
-            return;
-        }
+        try {
+            if (cause === undefined || cause.kind !== RequestBoundsAction.KIND) {
+                return;
+            }
 
-        if (LocalRequestBoundsAction.is(cause) && cause.elementIDs) {
-            this.focusOnElements(cause.elementIDs);
-        }
+            if (LocalRequestBoundsAction.is(cause) && cause.elementIDs) {
+                this.focusOnElements(cause.elementIDs);
+            }
 
-        // collect bounds and layout data in element2BoundsData
-        this.getBoundsFromDOM();
-        this.layouter.layout(this.getElement2BoundsData());
+            // collect bounds and layout data in element2BoundsData
+            this.getBoundsFromDOM();
+            this.layouter.layout(this.getElement2BoundsData());
 
-        // prepare data for action
-        const resizes: ElementAndBounds[] = [];
-        const alignments: ElementAndAlignment[] = [];
-        const layoutData: ElementAndLayoutData[] = [];
-        this.getElement2BoundsData().forEach((boundsData, element) => {
-            if (boundsData.boundsChanged && boundsData.bounds !== undefined) {
-                const resize: ElementAndBounds = {
-                    elementId: element.id,
-                    newSize: {
-                        width: boundsData.bounds.width,
-                        height: boundsData.bounds.height
-                    }
-                };
-                // don't copy position if the element is layouted by the server
-                if (element instanceof GChildElement && isLayoutContainer(element.parent)) {
-                    resize.newPosition = {
-                        x: boundsData.bounds.x,
-                        y: boundsData.bounds.y
+            // prepare data for action
+            const resizes: ElementAndBounds[] = [];
+            const alignments: ElementAndAlignment[] = [];
+            const layoutData: ElementAndLayoutData[] = [];
+            this.getElement2BoundsData().forEach((boundsData, element) => {
+                if (boundsData.boundsChanged && boundsData.bounds !== undefined) {
+                    const resize: ElementAndBounds = {
+                        elementId: element.id,
+                        newSize: {
+                            width: boundsData.bounds.width,
+                            height: boundsData.bounds.height
+                        }
                     };
+                    // don't copy position if the element is layouted by the server
+                    if (element instanceof GChildElement && isLayoutContainer(element.parent)) {
+                        resize.newPosition = {
+                            x: boundsData.bounds.x,
+                            y: boundsData.bounds.y
+                        };
+                    }
+                    resizes.push(resize);
                 }
-                resizes.push(resize);
-            }
-            if (boundsData.alignmentChanged && boundsData.alignment !== undefined) {
-                alignments.push({
-                    elementId: element.id,
-                    newAlignment: boundsData.alignment
-                });
-            }
-            if (LayoutAware.is(boundsData)) {
-                layoutData.push({ elementId: element.id, layoutData: boundsData.layoutData });
-            }
-        });
-        const routes = this.element2route.length === 0 ? undefined : this.element2route;
+                if (boundsData.alignmentChanged && boundsData.alignment !== undefined) {
+                    alignments.push({
+                        elementId: element.id,
+                        newAlignment: boundsData.alignment
+                    });
+                }
+                if (LayoutAware.is(boundsData)) {
+                    layoutData.push({ elementId: element.id, layoutData: boundsData.layoutData });
+                }
+            });
+            const routes = this.element2route.length === 0 ? undefined : this.element2route;
 
-        // prepare and dispatch action
-        const responseId = (cause as RequestBoundsAction).requestId;
-        const revision = this.root !== undefined ? this.root.revision : undefined;
-        const canvasBounds = this.editorContext.canvasBounds;
-        const viewport = this.editorContext.viewportData;
-        const computedBoundsAction = ComputedBoundsAction.create(resizes, {
-            revision,
-            alignments,
-            layoutData,
-            routes,
-            responseId,
-            canvasBounds,
-            viewport
-        });
-        if (LocalRequestBoundsAction.is(cause)) {
-            LocalComputedBoundsAction.mark(computedBoundsAction);
+            // prepare and dispatch action
+            const responseId = (cause as RequestBoundsAction).requestId;
+            const revision = this.root !== undefined ? this.root.revision : undefined;
+            const canvasBounds = this.editorContext.canvasBounds;
+            const viewport = this.editorContext.viewportData;
+            const computedBoundsAction = ComputedBoundsAction.create(resizes, {
+                revision,
+                alignments,
+                layoutData,
+                routes,
+                responseId,
+                canvasBounds,
+                viewport
+            });
+            if (LocalRequestBoundsAction.is(cause)) {
+                LocalComputedBoundsAction.mark(computedBoundsAction);
+            }
+            this.actionDispatcher.dispatch(computedBoundsAction);
+        } finally {
+            // always reset collected data so hidden renderings with other causes (e.g. exports/failures) do not leak into the next run
+            this.cleanUp();
         }
-        this.actionDispatcher.dispatch(computedBoundsAction);
+    }
 
-        // cleanup
+    protected cleanUp(): void {
         this.getElement2BoundsData().clear();
         this.element2route = [];
+        this.root = undefined;
     }
 
     protected focusOnElements(elementIDs: string[]): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Exports render the diagram through the hidden viewer, so the `GLSPHiddenBoundsUpdater`
collected bounds and routing points for the export clone but never cleaned them up.
The stale entries leaked into the next `computedBounds` action, causing
`Model element not found` server errors when elements had been deleted in the meantime.

- Always reset the collected bounds data and routing points at the end of `postUpdate`
  (via try/finally), regardless of the rendering cause or errors during the computation

Fixes eclipse-glsp/glsp#1717

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

```bash
pnpm install && pnpm build
pnpm -C examples/workflow-standalone start
```

1. Select a task node **first** (selecting an element after the export triggers a local
   bounds computation that resets the leaked state and masks the bug)
2. Trigger the SVG export with `Ctrl+Shift+E`
3. Delete the selected node with `Del`

Without this fix, the `computedBounds` response contains stale entries for every element
of the export clone (including the deleted one) and the server rejects the update with
`Could not retrieve element with id: 'task_ChkTp_icon'`. With the fix, the update succeeds.

- [x] Verified locally against the workflow example (node server)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

The same early-return-without-cleanup flaw exists upstream in sprotty's
`HiddenBoundsUpdater`, so plain-sprotty adopters are affected too. Worth filing upstream.

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
