### PR TITLE
Issues/1725 client side feedback element bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 - [layout] Fix bounds computation error after diagram export [#525](https://github.com/eclipse-glsp/glsp-client/pull/525)
-- [layout] Keep client-side feedback elements, such as validation markers, out of the bounds reported to the server [#1725](https://github.com/eclipse-glsp/glsp/issues/1725)
+- [layout] Keep client-side feedback elements, such as validation markers, out of the bounds reported to the server [#531](https://github.com/eclipse-glsp/glsp-client/pull/531)
     - Adds the `enableFeatures` model utility to enable model features on a single element without modifying the feature set shared by its element type
 
 ### Potentially Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changes
 
+- [layout] Fix bounds computation error after diagram export [#525](https://github.com/eclipse-glsp/glsp-client/pull/525)
+- [layout] Keep client-side feedback elements, such as validation markers, out of the bounds reported to the server [#1725](https://github.com/eclipse-glsp/glsp/issues/1725)
+    - Adds the `enableFeatures` model utility to enable model features on a single element without modifying the feature set shared by its element type
+
 ### Potentially Breaking Changes
 
 ## [v2.7.0 - 01/06/2026](https://github.com/eclipse-glsp/glsp-client/releases/tag/v2.7.0)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,22 +10,22 @@ If you think you have found a vulnerability in this repository, please report it
 
 Instead, report it using one of the following ways:
 
-* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
-* Report a [vulnerability](https://github.com/eclipse-glsp/glsp-client/security/advisories/new) directly via private vulnerability reporting on GitHub
+- Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+- Report a [vulnerability](https://github.com/eclipse-glsp/glsp-client/security/advisories/new) directly via private vulnerability reporting on GitHub
 
 You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 
 Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 
-* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
-* Affected version(s)
-* Impact of the issue, including how an attacker might exploit the issue
-* Step-by-step instructions to reproduce the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Full paths of source file(s) related to the manifestation of the issue
-* Configuration required to reproduce the issue
-* Log files that are related to this issue (if possible)
-* Proof-of-concept or exploit code (if possible)
+- The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+- Affected version(s)
+- Impact of the issue, including how an attacker might exploit the issue
+- Step-by-step instructions to reproduce the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Full paths of source file(s) related to the manifestation of the issue
+- Configuration required to reproduce the issue
+- Log files that are related to this issue (if possible)
+- Proof-of-concept or exploit code (if possible)
 
 This information will help us triage your report more quickly.
 

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
@@ -289,6 +289,24 @@ describe('GLSPHiddenBoundsUpdater', () => {
         expect(computedRouteIds(dispatcher)).not.toContain(feedbackEdge.id);
     });
 
+    it('leaves out the routes an overridden calcElementRoute declines', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new (class extends TestHiddenBoundsUpdater {
+            protected override calcElementRoute(): undefined {
+                return undefined;
+            }
+        })(dispatcher);
+
+        const model = createRoot('node0');
+        addFeedbackEdge(model);
+
+        updater.renderHidden(model);
+        updater.postUpdate(LocalRequestBoundsAction.create(model));
+
+        // a local request reports feedback routes, so an empty result is down to the override alone
+        expect(computedBounds(dispatcher).routes).toBeUndefined();
+    });
+
     it('reports the route of a feedback edge for a local bounds request', () => {
         const dispatcher = new RecordingActionDispatcher();
         const updater = new TestHiddenBoundsUpdater(dispatcher);

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
@@ -17,7 +17,10 @@ import {
     Action,
     Bounds,
     ComputedBoundsAction,
+    DefaultTypes,
     GModelElement,
+    GModelElementRegistration,
+    GModelFactory,
     GModelRoot,
     GModelRootSchema,
     GNode,
@@ -30,17 +33,24 @@ import {
     RequestBoundsAction,
     RequestExportAction,
     ResponseAction,
+    TYPES,
     Viewport,
     createFeatureSet
 } from '@eclipse-glsp/sprotty';
+import { Container } from 'inversify';
+import 'reflect-metadata';
 import { h } from 'snabbdom';
 import { describe, expect, it } from 'vitest';
 import { EditorContextService } from '../../base/editor-context-service';
 import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
 import { ServerAction } from '../../base/model/glsp-model-source';
+import { GModelRegistry } from '../../base/model/model-registry';
 import { GEdge, GGraph } from '../../model';
 import { enableFeatures } from '../../utils/gmodel-util';
-import { getOrCreateGIssueMarker } from '../validation/issue-marker';
+import { MARQUEE } from '../tools/marquee-selection/marquee-tool-feedback';
+import { MarqueeNode } from '../tools/marquee-selection/model';
+import { InsertIndicator } from '../tools/node-creation/insert-indicator';
+import { GIssueMarker, getOrCreateGIssueMarker } from '../validation/issue-marker';
 import { GLSPHiddenBoundsUpdater } from './glsp-hidden-bounds-updater';
 import { LocalRequestBoundsAction } from './local-bounds';
 
@@ -150,6 +160,25 @@ function createRoot(nodeId: string): GModelRoot {
     return root;
 }
 
+/**
+ * Wires the real model factory the way the client does, so a model built through it is subject to
+ * the same feature handling as in production, i.e. every element of a type shares the feature set
+ * derived from its registration.
+ */
+function createModelFactory(): GModelFactory {
+    const container = new Container();
+    const registrations: GModelElementRegistration[] = [
+        { type: DefaultTypes.GRAPH, constr: GGraph },
+        { type: DefaultTypes.NODE, constr: GNode },
+        { type: DefaultTypes.ISSUE_MARKER, constr: GIssueMarker },
+        { type: MARQUEE, constr: MarqueeNode }
+    ];
+    registrations.forEach(registration => container.bind(TYPES.SModelElementRegistration).toConstantValue(registration));
+    container.bind(TYPES.SModelRegistry).to(GModelRegistry).inSingletonScope();
+    container.bind(TYPES.IModelFactory).to(GModelFactory).inSingletonScope();
+    return container.get<GModelFactory>(TYPES.IModelFactory);
+}
+
 /** Stand-in for the dangling edge the edge-creation tool draws while the user is connecting. */
 function addFeedbackEdge(root: GModelRoot): GEdge {
     const edge = new GEdge();
@@ -201,6 +230,45 @@ describe('GLSPHiddenBoundsUpdater', () => {
         const model = createRoot('node0');
         const marker = getOrCreateGIssueMarker(model.children[0] as GNode);
         marker.issues.push({ message: 'invalid', severity: 'error' });
+
+        updater.renderHidden(model);
+        updater.postUpdate(serverBoundsRequest(model));
+
+        expect(computedBoundsIds(dispatcher)).toEqual(['node0']);
+    });
+
+    it('does not report issue marker bounds of a factory-built hidden model for a server bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const liveModel = createRoot('node0');
+        const marker = getOrCreateGIssueMarker(liveModel.children[0] as GNode);
+        marker.issues.push({ message: 'invalid', severity: 'error' });
+
+        // the hidden rendering runs on a factory copy of the live root, and the marker registration
+        // contributes no feedback feature, so the marking only survives because the factory takes
+        // over the features of the element it is handed
+        const hiddenModel = createModelFactory().createRoot(liveModel);
+        const copiedMarker = (hiddenModel.children[0] as GParentElement).children.find(child => child instanceof GIssueMarker);
+        expect(copiedMarker?.hasFeature(feedbackFeature)).toBe(true);
+
+        updater.renderHidden(hiddenModel);
+        updater.postUpdate(serverBoundsRequest(hiddenModel));
+
+        expect(computedBoundsIds(dispatcher)).toEqual(['node0']);
+    });
+
+    it('does not report the bounds of the client-only elements the tools add for a server bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const model = createRoot('node0');
+        const indicator = new InsertIndicator();
+        indicator.id = 'insert-indicator';
+        model.add(indicator);
+        // the marquee gets its features from its registration, just like in a running client
+        const marquee = createModelFactory().createElement({ type: MARQUEE, id: 'marquee' });
+        model.add(marquee);
 
         updater.renderHidden(model);
         updater.postUpdate(serverBoundsRequest(model));

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
@@ -18,6 +18,7 @@ import {
     Bounds,
     ComputedBoundsAction,
     DefaultTypes,
+    EdgeRouterRegistry,
     GModelElement,
     GModelElementRegistration,
     GModelFactory,
@@ -47,6 +48,7 @@ import { ServerAction } from '../../base/model/glsp-model-source';
 import { GModelRegistry } from '../../base/model/model-registry';
 import { GEdge, GGraph } from '../../model';
 import { enableFeatures } from '../../utils/gmodel-util';
+import { routingModule } from '../routing/routing-module';
 import { MARQUEE } from '../tools/marquee-selection/marquee-tool-feedback';
 import { MarqueeNode } from '../tools/marquee-selection/model';
 import { InsertIndicator } from '../tools/node-creation/insert-indicator';
@@ -146,18 +148,45 @@ class TestHiddenBoundsUpdater extends GLSPHiddenBoundsUpdater {
     }
 }
 
+/** Bounds updater wired with the real routers, so an edge is routed as it is in a running client. */
+class RoutingTestHiddenBoundsUpdater extends TestHiddenBoundsUpdater {
+    protected override readonly edgeRouterRegistry = createRouterRegistry();
+}
+
 function createRoot(nodeId: string): GModelRoot {
     const root = new GGraph();
     root.id = 'root';
     root.type = 'graph';
     root.features = new Set<symbol>(GGraph.DEFAULT_FEATURES);
+    addNode(root, nodeId);
+    return root;
+}
+
+function addNode(root: GModelRoot, nodeId: string, position: Point = Point.ORIGIN): GNode {
     const node = new GNode();
     node.id = nodeId;
     node.type = 'node';
     node.features = new Set<symbol>(GNode.DEFAULT_FEATURES);
-    node.bounds = { x: 0, y: 0, width: 10, height: 10 };
+    node.bounds = { ...position, width: 10, height: 10 };
     root.add(node);
-    return root;
+    return node;
+}
+
+function addEdge(root: GModelRoot, sourceId: string, targetId: string): GEdge {
+    const edge = new GEdge();
+    edge.id = `${sourceId}-${targetId}`;
+    edge.type = 'edge';
+    edge.features = createFeatureSet(GEdge.DEFAULT_FEATURES);
+    edge.sourceId = sourceId;
+    edge.targetId = targetId;
+    root.add(edge);
+    return edge;
+}
+
+function createRouterRegistry(): EdgeRouterRegistry {
+    const container = new Container();
+    container.load(routingModule);
+    return container.get<EdgeRouterRegistry>(EdgeRouterRegistry);
 }
 
 /**
@@ -287,6 +316,34 @@ describe('GLSPHiddenBoundsUpdater', () => {
         updater.postUpdate(serverBoundsRequest(model));
 
         expect(computedRouteIds(dispatcher)).not.toContain(feedbackEdge.id);
+    });
+
+    it('leaves out the route of an edge the router cannot route', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new RoutingTestHiddenBoundsUpdater(dispatcher);
+
+        const model = createRoot('node0');
+        // the target is not part of the model, so the router reports an empty route
+        const edge = addEdge(model, 'node0', 'missing');
+
+        updater.renderHidden(model);
+        updater.postUpdate(serverBoundsRequest(model));
+
+        expect(computedRouteIds(dispatcher)).not.toContain(edge.id);
+    });
+
+    it('reports the route of an edge the router can route', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new RoutingTestHiddenBoundsUpdater(dispatcher);
+
+        const model = createRoot('node0');
+        addNode(model, 'node1', { x: 100, y: 100 });
+        const edge = addEdge(model, 'node0', 'node1');
+
+        updater.renderHidden(model);
+        updater.postUpdate(serverBoundsRequest(model));
+
+        expect(computedRouteIds(dispatcher)).toContain(edge.id);
     });
 
     it('leaves out the routes an overridden calcElementRoute declines', () => {

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
@@ -30,13 +30,16 @@ import {
     RequestBoundsAction,
     RequestExportAction,
     ResponseAction,
-    Viewport
+    Viewport,
+    createFeatureSet
 } from '@eclipse-glsp/sprotty';
 import { h } from 'snabbdom';
 import { describe, expect, it } from 'vitest';
 import { EditorContextService } from '../../base/editor-context-service';
+import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
 import { ServerAction } from '../../base/model/glsp-model-source';
-import { GGraph } from '../../model';
+import { GEdge, GGraph } from '../../model';
+import { enableFeatures } from '../../utils/gmodel-util';
 import { getOrCreateGIssueMarker } from '../validation/issue-marker';
 import { GLSPHiddenBoundsUpdater } from './glsp-hidden-bounds-updater';
 import { LocalRequestBoundsAction } from './local-bounds';
@@ -147,6 +150,17 @@ function createRoot(nodeId: string): GModelRoot {
     return root;
 }
 
+/** Stand-in for the dangling edge the edge-creation tool draws while the user is connecting. */
+function addFeedbackEdge(root: GModelRoot): GEdge {
+    const edge = new GEdge();
+    edge.id = 'feedback_edge';
+    edge.type = 'edge';
+    edge.features = createFeatureSet(GEdge.DEFAULT_FEATURES);
+    enableFeatures(edge, feedbackFeature);
+    root.add(edge);
+    return edge;
+}
+
 function serverBoundsRequest(root: GModelRoot): RequestBoundsAction {
     const action = RequestBoundsAction.create(root as unknown as GModelRootSchema);
     // the model source marks every inbound action, which is what makes it a non-local request
@@ -154,10 +168,18 @@ function serverBoundsRequest(root: GModelRoot): RequestBoundsAction {
     return action;
 }
 
+function computedBounds(dispatcher: RecordingActionDispatcher): ComputedBoundsAction {
+    const dispatched = dispatcher.dispatched.filter(ComputedBoundsAction.is);
+    expect(dispatched).toHaveLength(1);
+    return dispatched[0];
+}
+
 function computedBoundsIds(dispatcher: RecordingActionDispatcher): string[] {
-    const computedBounds = dispatcher.dispatched.filter(ComputedBoundsAction.is);
-    expect(computedBounds).toHaveLength(1);
-    return computedBounds[0].bounds.map(bounds => bounds.elementId);
+    return computedBounds(dispatcher).bounds.map(bounds => bounds.elementId);
+}
+
+function computedRouteIds(dispatcher: RecordingActionDispatcher): string[] {
+    return (computedBounds(dispatcher).routes ?? []).map(route => route.elementId);
 }
 
 describe('GLSPHiddenBoundsUpdater', () => {
@@ -184,6 +206,32 @@ describe('GLSPHiddenBoundsUpdater', () => {
         updater.postUpdate(serverBoundsRequest(model));
 
         expect(computedBoundsIds(dispatcher)).toEqual(['node0']);
+    });
+
+    it('does not report the route of a feedback edge for a server bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const model = createRoot('node0');
+        const feedbackEdge = addFeedbackEdge(model);
+
+        updater.renderHidden(model);
+        updater.postUpdate(serverBoundsRequest(model));
+
+        expect(computedRouteIds(dispatcher)).not.toContain(feedbackEdge.id);
+    });
+
+    it('reports the route of a feedback edge for a local bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const model = createRoot('node0');
+        const feedbackEdge = addFeedbackEdge(model);
+
+        updater.renderHidden(model);
+        updater.postUpdate(LocalRequestBoundsAction.create(model));
+
+        expect(computedRouteIds(dispatcher)).toContain(feedbackEdge.id);
     });
 
     it('does not report client-side issue marker bounds to the server after an export (GLSP-1717)', () => {

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
@@ -1,0 +1,285 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    Action,
+    Bounds,
+    ComputedBoundsAction,
+    GModelElement,
+    GModelRoot,
+    GModelRootSchema,
+    GNode,
+    GParentElement,
+    IActionDispatcher,
+    Layouter,
+    NullLogger,
+    Point,
+    RequestAction,
+    RequestBoundsAction,
+    RequestExportAction,
+    ResponseAction,
+    Viewport
+} from '@eclipse-glsp/sprotty';
+import { h } from 'snabbdom';
+import { describe, expect, it } from 'vitest';
+import { EditorContextService } from '../../base/editor-context-service';
+import { ServerAction } from '../../base/model/glsp-model-source';
+import { GGraph } from '../../model';
+import { getOrCreateGIssueMarker } from '../validation/issue-marker';
+import { GLSPHiddenBoundsUpdater } from './glsp-hidden-bounds-updater';
+import { LocalRequestBoundsAction } from './local-bounds';
+
+class RecordingActionDispatcher implements IActionDispatcher {
+    readonly dispatched: Action[] = [];
+
+    async dispatch(action: Action): Promise<void> {
+        this.dispatched.push(action);
+    }
+
+    async dispatchAll(actions: Action[]): Promise<void> {
+        this.dispatched.push(...actions);
+    }
+
+    // the remaining API is not exercised by the bounds pass
+
+    async request<Res extends ResponseAction>(_action: RequestAction<Res>): Promise<Res> {
+        throw new Error('not used in this spec');
+    }
+
+    async requestUntil<Res extends ResponseAction>(_action: RequestAction<Res>): Promise<Res | undefined> {
+        throw new Error('not used in this spec');
+    }
+
+    dispatchOnceModelInitialized(...actions: Action[]): void {
+        this.dispatched.push(...actions);
+    }
+
+    async onceModelInitialized(): Promise<void> {
+        // nothing to wait for
+    }
+
+    dispatchAfterNextUpdate(...actions: Action[]): void {
+        this.dispatched.push(...actions);
+    }
+}
+
+class NoopLayouter extends Layouter {
+    failNext = false;
+
+    override layout(): void {
+        // the leak is about which elements are reported, not about their layout
+        if (this.failNext) {
+            this.failNext = false;
+            throw new Error('layout failed');
+        }
+    }
+}
+
+class StubEditorContextService extends EditorContextService {
+    override get viewportData(): Readonly<Viewport> {
+        return { scroll: Point.ORIGIN, zoom: 1 };
+    }
+
+    override get canvasBounds(): Readonly<Bounds> {
+        return Bounds.EMPTY;
+    }
+}
+
+class TestHiddenBoundsUpdater extends GLSPHiddenBoundsUpdater {
+    readonly noopLayouter = new NoopLayouter();
+
+    constructor(readonly recordingDispatcher: RecordingActionDispatcher) {
+        super();
+        this.logger = new NullLogger();
+        this.layouter = this.noopLayouter;
+        this.actionDispatcher = recordingDispatcher;
+        this.editorContext = new StubEditorContextService();
+    }
+
+    /** Stand-in for the real DOM measurement: every registered element reports a changed size. */
+    protected override getBoundsFromDOM(): void {
+        this.getElement2BoundsData().forEach(boundsData => {
+            boundsData.bounds = { x: 0, y: 0, width: 20, height: 20 };
+            boundsData.boundsChanged = true;
+        });
+    }
+
+    /**
+     * Mimics a hidden rendering. The real viewer decorates bottom-up, so children come first and
+     * the root last, which is what we replicate here.
+     */
+    renderHidden(root: GModelRoot): void {
+        root.children.forEach(child => this.decorateRecursively(child));
+        this.decorate(h('g'), root);
+    }
+
+    protected decorateRecursively(element: GModelElement): void {
+        if (element instanceof GParentElement) {
+            element.children.forEach(child => this.decorateRecursively(child));
+        }
+        this.decorate(h('g'), element);
+    }
+}
+
+function createRoot(nodeId: string): GModelRoot {
+    const root = new GGraph();
+    root.id = 'root';
+    root.type = 'graph';
+    root.features = new Set<symbol>(GGraph.DEFAULT_FEATURES);
+    const node = new GNode();
+    node.id = nodeId;
+    node.type = 'node';
+    node.features = new Set<symbol>(GNode.DEFAULT_FEATURES);
+    node.bounds = { x: 0, y: 0, width: 10, height: 10 };
+    root.add(node);
+    return root;
+}
+
+function serverBoundsRequest(root: GModelRoot): RequestBoundsAction {
+    const action = RequestBoundsAction.create(root as unknown as GModelRootSchema);
+    // the model source marks every inbound action, which is what makes it a non-local request
+    ServerAction.mark(action);
+    return action;
+}
+
+function computedBoundsIds(dispatcher: RecordingActionDispatcher): string[] {
+    const computedBounds = dispatcher.dispatched.filter(ComputedBoundsAction.is);
+    expect(computedBounds).toHaveLength(1);
+    return computedBounds[0].bounds.map(bounds => bounds.elementId);
+}
+
+describe('GLSPHiddenBoundsUpdater', () => {
+    it('reports the bounds of the elements of the rendered model', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+        const serverModel = createRoot('node0');
+
+        updater.renderHidden(serverModel);
+        updater.postUpdate(serverBoundsRequest(serverModel));
+
+        expect(computedBoundsIds(dispatcher)).toEqual(['node0']);
+    });
+
+    it('does not report issue marker bounds for a server bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const model = createRoot('node0');
+        const marker = getOrCreateGIssueMarker(model.children[0] as GNode);
+        marker.issues.push({ message: 'invalid', severity: 'error' });
+
+        updater.renderHidden(model);
+        updater.postUpdate(serverBoundsRequest(model));
+
+        expect(computedBoundsIds(dispatcher)).toEqual(['node0']);
+    });
+
+    it('does not report client-side issue marker bounds to the server after an export (GLSP-1717)', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        // the client model carries a validation marker that only exists client-side
+        const clientModel = createRoot('node0');
+        const marker = getOrCreateGIssueMarker(clientModel.children[0] as GNode);
+        marker.issues.push({ message: 'invalid', severity: 'error' });
+        expect(marker.id).toBeTruthy();
+
+        // 1) the export renders the client model (including the marker) through the hidden viewer
+        updater.renderHidden(clientModel);
+        updater.postUpdate(RequestExportAction.create('svg'));
+        expect(dispatcher.dispatched.filter(ComputedBoundsAction.is)).toHaveLength(0);
+
+        // 2) the server then asks for the bounds of a model that has no marker in it
+        const serverModel = createRoot('node0');
+        updater.renderHidden(serverModel);
+        updater.postUpdate(serverBoundsRequest(serverModel));
+
+        const reportedIds = computedBoundsIds(dispatcher);
+        expect(reportedIds).not.toContain(marker.id);
+        expect(reportedIds).toEqual(['node0']);
+    });
+
+    it('does not report issue marker bounds to the server after a successful local bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const clientModel = createRoot('node0');
+        const marker = getOrCreateGIssueMarker(clientModel.children[0] as GNode);
+        marker.issues.push({ message: 'invalid', severity: 'error' });
+
+        // 1) a local bounds request measures the live model, markers included
+        updater.renderHidden(clientModel);
+        updater.postUpdate(LocalRequestBoundsAction.create(clientModel));
+        const localComputedBounds = dispatcher.dispatched.filter(ComputedBoundsAction.is);
+        expect(localComputedBounds).toHaveLength(1);
+        expect(localComputedBounds[0].bounds.map(bounds => bounds.elementId)).toContain(marker.id);
+        // it stays local, so it is never forwarded to the server
+        expect(ServerAction.is(localComputedBounds[0])).toBe(true);
+
+        // 2) the next server request must not inherit anything from it
+        dispatcher.dispatched.length = 0;
+        const serverModel = createRoot('node0');
+        updater.renderHidden(serverModel);
+        updater.postUpdate(serverBoundsRequest(serverModel));
+
+        expect(computedBoundsIds(dispatcher)).toEqual(['node0']);
+    });
+
+    it('does not report issue marker bounds to the server after an interrupted hidden rendering', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const clientModel = createRoot('node0');
+        const marker = getOrCreateGIssueMarker(clientModel.children[0] as GNode);
+        marker.issues.push({ message: 'invalid', severity: 'error' });
+
+        // 1) a hidden rendering that dies in the viewer, e.g. in a view or in the snabbdom patch,
+        // before `HiddenModelViewer.update` gets to call `postUpdate`
+        updater.renderHidden(clientModel);
+
+        // 2) the server then asks for the bounds of a model that has no marker in it
+        const serverModel = createRoot('node0');
+        updater.renderHidden(serverModel);
+        updater.postUpdate(serverBoundsRequest(serverModel));
+
+        const reportedIds = computedBoundsIds(dispatcher);
+        expect(reportedIds).not.toContain(marker.id);
+        expect(reportedIds).toEqual(['node0']);
+    });
+
+    it('does not report issue marker bounds to the server after a failed local bounds request', () => {
+        const dispatcher = new RecordingActionDispatcher();
+        const updater = new TestHiddenBoundsUpdater(dispatcher);
+
+        const clientModel = createRoot('node0');
+        const marker = getOrCreateGIssueMarker(clientModel.children[0] as GNode);
+        marker.issues.push({ message: 'invalid', severity: 'error' });
+
+        // 1) a local bounds request that fails while computing, e.g. in the layouter
+        updater.renderHidden(clientModel);
+        updater.noopLayouter.failNext = true;
+        expect(() => updater.postUpdate(LocalRequestBoundsAction.create(clientModel))).toThrow('layout failed');
+        expect(dispatcher.dispatched.filter(ComputedBoundsAction.is)).toHaveLength(0);
+
+        // 2) the server then asks for the bounds of a model that has no marker in it
+        const serverModel = createRoot('node0');
+        updater.renderHidden(serverModel);
+        updater.postUpdate(serverBoundsRequest(serverModel));
+
+        const reportedIds = computedBoundsIds(dispatcher);
+        expect(reportedIds).not.toContain(marker.id);
+        expect(reportedIds).toEqual(['node0']);
+    });
+});

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
@@ -60,13 +60,15 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
 
     /**
      * Ids of the routable elements of {@link element2route} that only exist as client-side feedback.
-     * Recorded while decorating, where the element itself is at hand, because the routes outlive the
-     * root they were collected from.
+     * Recorded while decorating, as the routes outlive the root they were collected from.
      */
     protected feedbackRouteIds = new Set<string>();
 
-    /** Root of the hidden rendering currently being collected, used to detect the start of the next one. */
-    protected collectingForRoot?: GModelRoot;
+    /**
+     * Root of the hidden rendering currently being collected, used to detect the start of the next
+     * one. Referenced weakly, as a hidden root is a throwaway copy of the whole model.
+     */
+    protected collectingForRoot?: WeakRef<GModelRoot>;
 
     protected getElement2BoundsData(): Map<BoundsAwareModelElement, BoundsDataExt> {
         return this['element2boundsData'];
@@ -89,32 +91,29 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
 
     /**
      * The route reported for the given element, or `undefined` to leave it out of the
-     * {@link ComputedBoundsAction} of this rendering.
+     * {@link ComputedBoundsAction} of this rendering. Override to substitute or to skip a route,
+     * which a later rendering reports again as soon as the edge can be routed.
      *
-     * Override to substitute or to skip a route. Skipping is lossless as long as a later rendering
-     * reports it, which is what makes this the place to opt out of routing an element whose geometry
-     * has not been measured yet: the first hidden rendering of a model still carries the placeholder
-     * size `Dimension.EMPTY`, so a router either declines to route at all or works from geometry that
-     * the visible rendering immediately supersedes. `Dimension.isValid` on the endpoint sizes detects
-     * that state.
+     * A route of fewer than two points, which is how a router reports an edge it cannot route, is
+     * skipped: approximating it from the endpoint positions would overwrite the route on the server.
      */
     protected calcElementRoute(element: GRoutableElement): ElementAndRoutingPoints | undefined {
-        return calcElementAndRoute(element, this.edgeRouterRegistry);
+        const elementAndRoute = calcElementAndRoute(element, this.edgeRouterRegistry);
+        return (elementAndRoute.newRoutingPoints?.length ?? 0) < 2 ? undefined : elementAndRoute;
     }
 
     /**
      * Drops the data collected for the previous hidden rendering as soon as a new one starts.
-     * {@link postUpdate} cleans up on its way out, but it is not guaranteed to be reached at all:
-     * a failing view or vdom patch aborts the rendering before the viewer calls it, which would
-     * leave the collected bounds behind and report them with the next `ComputedBoundsAction`.
+     * {@link postUpdate} cleans up on its way out, but a failing view or vdom patch aborts the
+     * rendering before the viewer gets there, leaving the collected bounds behind.
      *
-     * Elements are decorated bottom-up, so the root cannot serve as the marker for a new rendering.
-     * Instead every element reports the root it belongs to, which changes with the rendering.
+     * Elements are decorated bottom-up, so the rendering is recognized by the root of the element
+     * at hand rather than by the root element itself.
      */
     protected resetOnNewRendering(element: GModelElement): void {
-        if (this.collectingForRoot !== element.root) {
+        if (this.collectingForRoot?.deref() !== element.root) {
             this.cleanUp();
-            this.collectingForRoot = element.root;
+            this.collectingForRoot = new WeakRef(element.root);
         }
     }
 
@@ -203,6 +202,7 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
         this.getElement2BoundsData().clear();
         this.element2route = [];
         this.feedbackRouteIds.clear();
+        this.collectingForRoot = undefined;
         this.root = undefined;
     }
 

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
@@ -25,6 +25,7 @@ import {
     ElementAndRoutingPoints,
     GChildElement,
     GModelElement,
+    GModelRoot,
     HiddenBoundsUpdater,
     LayoutData,
     ModelIndexImpl,
@@ -34,6 +35,8 @@ import {
 import { inject, injectable, optional } from 'inversify';
 import { VNode } from 'snabbdom';
 import { EditorContextService } from '../../base/editor-context-service';
+import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
+import { ServerAction } from '../../base/model/glsp-model-source';
 import { BoundsAwareModelElement, calcElementAndRoute, getDescendantIds, isRoutable } from '../../utils/gmodel-util';
 import { LayoutAware } from './layout-data';
 import { LocalComputedBoundsAction, LocalRequestBoundsAction } from './local-bounds';
@@ -54,16 +57,36 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
 
     protected element2route: ElementAndRoutingPoints[] = [];
 
+    /** Root of the hidden rendering currently being collected, used to detect the start of the next one. */
+    protected collectingForRoot?: GModelRoot;
+
     protected getElement2BoundsData(): Map<BoundsAwareModelElement, BoundsDataExt> {
         return this['element2boundsData'];
     }
 
     override decorate(vnode: VNode, element: GModelElement): VNode {
+        this.resetOnNewRendering(element);
         super.decorate(vnode, element);
         if (isRoutable(element)) {
             this.element2route.push(calcElementAndRoute(element, this.edgeRouterRegistry));
         }
         return vnode;
+    }
+
+    /**
+     * Drops the data collected for the previous hidden rendering as soon as a new one starts.
+     * {@link postUpdate} cleans up on its way out, but it is not guaranteed to be reached at all:
+     * a failing view or vdom patch aborts the rendering before the viewer calls it, which would
+     * leave the collected bounds behind and report them with the next `ComputedBoundsAction`.
+     *
+     * Elements are decorated bottom-up, so the root cannot serve as the marker for a new rendering.
+     * Instead every element reports the root it belongs to, which changes with the rendering.
+     */
+    protected resetOnNewRendering(element: GModelElement): void {
+        if (this.collectingForRoot !== element.root) {
+            this.cleanUp();
+            this.collectingForRoot = element.root;
+        }
     }
 
     override postUpdate(cause?: Action): void {
@@ -80,11 +103,17 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
             this.getBoundsFromDOM();
             this.layouter.layout(this.getElement2BoundsData());
 
+            // the server can only resolve elements it sent us itself
+            const skipFeedback = ServerAction.is(cause);
+
             // prepare data for action
             const resizes: ElementAndBounds[] = [];
             const alignments: ElementAndAlignment[] = [];
             const layoutData: ElementAndLayoutData[] = [];
             this.getElement2BoundsData().forEach((boundsData, element) => {
+                if (skipFeedback && this.isFeedbackElement(element)) {
+                    return;
+                }
                 if (boundsData.boundsChanged && boundsData.bounds !== undefined) {
                     const resize: ElementAndBounds = {
                         elementId: element.id,
@@ -112,7 +141,10 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
                     layoutData.push({ elementId: element.id, layoutData: boundsData.layoutData });
                 }
             });
-            const routes = this.element2route.length === 0 ? undefined : this.element2route;
+            const relevantRoutes = skipFeedback
+                ? this.element2route.filter(route => !this.isFeedbackElementId(route.elementId))
+                : this.element2route;
+            const routes = relevantRoutes.length === 0 ? undefined : relevantRoutes;
 
             // prepare and dispatch action
             const responseId = (cause as RequestBoundsAction).requestId;
@@ -142,6 +174,20 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
         this.getElement2BoundsData().clear();
         this.element2route = [];
         this.root = undefined;
+    }
+
+    /**
+     * Whether the given element only exists as client-side feedback, such as a validation marker.
+     * Those elements are not part of the graphical model the server sent us, so reporting their
+     * bounds would make the server fail to resolve their ids.
+     */
+    protected isFeedbackElement(element: GModelElement): boolean {
+        return element.hasFeature(feedbackFeature);
+    }
+
+    protected isFeedbackElementId(elementId: string): boolean {
+        const element = this.root?.index.getById(elementId);
+        return element !== undefined && this.isFeedbackElement(element);
     }
 
     protected focusOnElements(elementIDs: string[]): void {

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
@@ -26,6 +26,7 @@ import {
     GChildElement,
     GModelElement,
     GModelRoot,
+    GRoutableElement,
     HiddenBoundsUpdater,
     LayoutData,
     ModelIndexImpl,
@@ -75,12 +76,30 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
         this.resetOnNewRendering(element);
         super.decorate(vnode, element);
         if (isRoutable(element)) {
-            this.element2route.push(calcElementAndRoute(element, this.edgeRouterRegistry));
-            if (this.isFeedbackElement(element)) {
-                this.feedbackRouteIds.add(element.id);
+            const route = this.calcElementRoute(element);
+            if (route) {
+                this.element2route.push(route);
+                if (this.isFeedbackElement(element)) {
+                    this.feedbackRouteIds.add(element.id);
+                }
             }
         }
         return vnode;
+    }
+
+    /**
+     * The route reported for the given element, or `undefined` to leave it out of the
+     * {@link ComputedBoundsAction} of this rendering.
+     *
+     * Override to substitute or to skip a route. Skipping is lossless as long as a later rendering
+     * reports it, which is what makes this the place to opt out of routing an element whose geometry
+     * has not been measured yet: the first hidden rendering of a model still carries the placeholder
+     * size `Dimension.EMPTY`, so a router either declines to route at all or works from geometry that
+     * the visible rendering immediately supersedes. `Dimension.isValid` on the endpoint sizes detects
+     * that state.
+     */
+    protected calcElementRoute(element: GRoutableElement): ElementAndRoutingPoints | undefined {
+        return calcElementAndRoute(element, this.edgeRouterRegistry);
     }
 
     /**

--- a/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
+++ b/packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts
@@ -57,6 +57,13 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
 
     protected element2route: ElementAndRoutingPoints[] = [];
 
+    /**
+     * Ids of the routable elements of {@link element2route} that only exist as client-side feedback.
+     * Recorded while decorating, where the element itself is at hand, because the routes outlive the
+     * root they were collected from.
+     */
+    protected feedbackRouteIds = new Set<string>();
+
     /** Root of the hidden rendering currently being collected, used to detect the start of the next one. */
     protected collectingForRoot?: GModelRoot;
 
@@ -69,6 +76,9 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
         super.decorate(vnode, element);
         if (isRoutable(element)) {
             this.element2route.push(calcElementAndRoute(element, this.edgeRouterRegistry));
+            if (this.isFeedbackElement(element)) {
+                this.feedbackRouteIds.add(element.id);
+            }
         }
         return vnode;
     }
@@ -142,7 +152,7 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
                 }
             });
             const relevantRoutes = skipFeedback
-                ? this.element2route.filter(route => !this.isFeedbackElementId(route.elementId))
+                ? this.element2route.filter(route => !this.feedbackRouteIds.has(route.elementId))
                 : this.element2route;
             const routes = relevantRoutes.length === 0 ? undefined : relevantRoutes;
 
@@ -173,21 +183,12 @@ export class GLSPHiddenBoundsUpdater extends HiddenBoundsUpdater {
     protected cleanUp(): void {
         this.getElement2BoundsData().clear();
         this.element2route = [];
+        this.feedbackRouteIds.clear();
         this.root = undefined;
     }
 
-    /**
-     * Whether the given element only exists as client-side feedback, such as a validation marker.
-     * Those elements are not part of the graphical model the server sent us, so reporting their
-     * bounds would make the server fail to resolve their ids.
-     */
     protected isFeedbackElement(element: GModelElement): boolean {
         return element.hasFeature(feedbackFeature);
-    }
-
-    protected isFeedbackElementId(elementId: string): boolean {
-        const element = this.root?.index.getById(elementId);
-        return element !== undefined && this.isFeedbackElement(element);
     }
 
     protected focusOnElements(elementIDs: string[]): void {

--- a/packages/client/src/features/element-template/add-template-element.spec.ts
+++ b/packages/client/src/features/element-template/add-template-element.spec.ts
@@ -1,0 +1,162 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    Action,
+    AnimationFrameSyncer,
+    CommandExecutionContext,
+    ConsoleLogger,
+    DefaultTypes,
+    GModelElementRegistration,
+    GModelElementSchema,
+    GModelFactory,
+    GNode,
+    GParentElement,
+    IActionDispatcher,
+    RequestAction,
+    ResponseAction,
+    TYPES
+} from '@eclipse-glsp/sprotty';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
+import { GModelRegistry } from '../../base/model/model-registry';
+import { GGraph } from '../../model';
+import { AddTemplateElementsAction, AddTemplateElementsFeedbackCommand } from './add-template-element';
+
+const CHILD_ID = 'template_child';
+const TEMPLATE_ID = 'template';
+
+class StubActionDispatcher implements IActionDispatcher {
+    readonly dispatched: Action[] = [];
+
+    async dispatch(action: Action): Promise<void> {
+        this.dispatched.push(action);
+    }
+
+    async dispatchAll(actions: Action[]): Promise<void> {
+        this.dispatched.push(...actions);
+    }
+
+    // the remaining API is not exercised by the feedback command
+
+    async request<Res extends ResponseAction>(_action: RequestAction<Res>): Promise<Res> {
+        throw new Error('not used in this spec');
+    }
+
+    async requestUntil<Res extends ResponseAction>(_action: RequestAction<Res>): Promise<Res | undefined> {
+        throw new Error('not used in this spec');
+    }
+
+    dispatchOnceModelInitialized(...actions: Action[]): void {
+        this.dispatched.push(...actions);
+    }
+
+    async onceModelInitialized(): Promise<void> {
+        // nothing to wait for
+    }
+
+    dispatchAfterNextUpdate(...actions: Action[]): void {
+        this.dispatched.push(...actions);
+    }
+}
+
+class TestAddTemplateElementsFeedbackCommand extends AddTemplateElementsFeedbackCommand {
+    constructor(action: AddTemplateElementsAction, dispatcher: IActionDispatcher) {
+        super(action);
+        this.actionDispatcher = dispatcher;
+    }
+}
+
+/**
+ * Wires the real model factory so template elements are built the way the client builds them, i.e.
+ * every element of a type shares the feature set derived from its registration.
+ */
+function createModelFactory(): GModelFactory {
+    const container = new Container();
+    const registrations: GModelElementRegistration[] = [
+        { type: DefaultTypes.GRAPH, constr: GGraph },
+        { type: DefaultTypes.NODE, constr: GNode }
+    ];
+    registrations.forEach(registration => container.bind(TYPES.SModelElementRegistration).toConstantValue(registration));
+    container.bind(TYPES.SModelRegistry).to(GModelRegistry).inSingletonScope();
+    container.bind(TYPES.IModelFactory).to(GModelFactory).inSingletonScope();
+    return container.get<GModelFactory>(TYPES.IModelFactory);
+}
+
+/** A template with a child, which is the shape the node-creation tool uses for its ghost elements. */
+function nestedTemplate(): GModelElementSchema {
+    return {
+        type: DefaultTypes.NODE,
+        id: TEMPLATE_ID,
+        children: [{ type: DefaultTypes.NODE, id: CHILD_ID }]
+    };
+}
+
+describe('AddTemplateElementsFeedbackCommand', () => {
+    let factory: GModelFactory;
+    let context: CommandExecutionContext;
+
+    beforeEach(() => {
+        const root = new GGraph();
+        root.id = 'root';
+        root.type = DefaultTypes.GRAPH;
+        root.features = new Set<symbol>(GGraph.DEFAULT_FEATURES);
+
+        factory = createModelFactory();
+        context = {
+            root,
+            modelFactory: factory,
+            duration: 0,
+            modelChanged: undefined!,
+            logger: new ConsoleLogger(),
+            syncer: new AnimationFrameSyncer()
+        };
+    });
+
+    function execute(): void {
+        const action = AddTemplateElementsAction.create({ templates: [nestedTemplate()] });
+        new TestAddTemplateElementsFeedbackCommand(action, new StubActionDispatcher()).execute(context);
+    }
+
+    it('marks the added template element as feedback so it is not reported to the server', () => {
+        execute();
+
+        expect(context.root.index.getById(TEMPLATE_ID)?.hasFeature(feedbackFeature)).toBe(true);
+    });
+
+    it('marks the children of the added template element as well', () => {
+        execute();
+
+        expect(context.root.index.getById(CHILD_ID)?.hasFeature(feedbackFeature)).toBe(true);
+    });
+
+    it('leaves the feature set shared with the other elements of that type untouched', () => {
+        execute();
+
+        // a regular node of the same type must not turn into a feedback element
+        const regularNode = factory.createElement({ type: DefaultTypes.NODE, id: 'node0' });
+        expect(regularNode.hasFeature(feedbackFeature)).toBe(false);
+    });
+
+    it('adds the template element and its children to the root', () => {
+        execute();
+
+        const templateElement = context.root.children.find(child => child.id === TEMPLATE_ID);
+        expect(templateElement).toBeDefined();
+        expect((templateElement as GParentElement).children.map(child => child.id)).toEqual([CHILD_ID]);
+    });
+});

--- a/packages/client/src/features/element-template/add-template-element.ts
+++ b/packages/client/src/features/element-template/add-template-element.ts
@@ -78,9 +78,8 @@ export class AddTemplateElementsFeedbackCommand extends FeedbackCommand {
     }
 
     /**
-     * Marks the given template element as client-side feedback so it is kept out of the bounds
-     * reported to the server, which cannot resolve its id. A template is a tree and the bounds pass
-     * tests every element on its own, so the whole subtree is marked rather than just its root.
+     * Marks the given template element as feedback to keep it out of the bounds reported to the
+     * server. The bounds pass tests every element on its own, so the whole subtree is marked.
      */
     protected markAsFeedback(element: GChildElement): GChildElement {
         enableFeatures(element, feedbackFeature);

--- a/packages/client/src/features/element-template/add-template-element.ts
+++ b/packages/client/src/features/element-template/add-template-element.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2024 EclipseSource and others.
+ * Copyright (c) 2023-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,14 +21,16 @@ import {
     ElementTemplate,
     GChildElement,
     GModelElementSchema,
+    GParentElement,
     IActionDispatcher,
     TYPES,
     distinctAdd,
     remove
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
+import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../base/feedback/feedback-command';
-import { isNotUndefined } from '../../utils/gmodel-util';
+import { enableFeatures, isNotUndefined } from '../../utils/gmodel-util';
 import { LocalRequestBoundsAction } from '../bounds/local-bounds';
 
 export interface AddTemplateElementsAction extends Action {
@@ -68,10 +70,24 @@ export class AddTemplateElementsFeedbackCommand extends FeedbackCommand {
             .map(template => templateToSchema(template, context))
             .filter(isNotUndefined)
             .map(schema => context.modelFactory.createElement(schema))
+            .map(element => this.markAsFeedback(element))
             .map(element => this.applyRootCssClasses(element, this.action.addClasses, this.action.removeClasses));
         templateElements.forEach(templateElement => context.root.add(templateElement));
         const templateElementIDs = templateElements.map(element => element.id);
         return LocalRequestBoundsAction.fromCommand(context, this.actionDispatcher, this.action, templateElementIDs);
+    }
+
+    /**
+     * Marks the given template element as client-side feedback so it is kept out of the bounds
+     * reported to the server, which cannot resolve its id. A template is a tree and the bounds pass
+     * tests every element on its own, so the whole subtree is marked rather than just its root.
+     */
+    protected markAsFeedback(element: GChildElement): GChildElement {
+        enableFeatures(element, feedbackFeature);
+        if (element instanceof GParentElement) {
+            element.children.forEach(child => this.markAsFeedback(child));
+        }
+        return element;
     }
 
     protected applyRootCssClasses(element: GChildElement, addClasses?: string[], removeClasses?: string[]): GChildElement {

--- a/packages/client/src/features/tools/edge-creation/dangling-edge-feedback.spec.ts
+++ b/packages/client/src/features/tools/edge-creation/dangling-edge-feedback.spec.ts
@@ -1,0 +1,96 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    AnimationFrameSyncer,
+    CommandExecutionContext,
+    ConsoleLogger,
+    GChildElement,
+    GModelElement,
+    GModelElementSchema,
+    GModelFactory,
+    GNode,
+    GParentElement,
+    createFeatureSet
+} from '@eclipse-glsp/sprotty';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { feedbackFeature } from '../../../base/feedback/feedback-action-dispatcher';
+import { GEdge, GGraph } from '../../../model';
+import { drawFeedbackEdge } from './dangling-edge-feedback';
+
+const EDGE_TYPE = 'edge';
+
+/**
+ * Creates edges the way the real factory does, i.e. every element of a type is handed the very same
+ * feature set instance.
+ */
+class SharedFeatureSetModelFactory extends GModelFactory {
+    readonly sharedEdgeFeatures = createFeatureSet(GEdge.DEFAULT_FEATURES);
+
+    override createElement(schema: GModelElementSchema | GModelElement): GChildElement {
+        const edge = new GEdge();
+        edge.id = schema.id!;
+        edge.type = schema.type;
+        edge.features = this.sharedEdgeFeatures;
+        return edge;
+    }
+}
+
+describe('drawFeedbackEdge', () => {
+    let factory: SharedFeatureSetModelFactory;
+    let context: CommandExecutionContext;
+
+    beforeEach(() => {
+        const root = new GGraph();
+        root.id = 'root';
+        root.type = 'graph';
+        root.features = new Set<symbol>(GGraph.DEFAULT_FEATURES);
+        const source = new GNode();
+        source.id = 'node0';
+        source.type = 'node';
+        source.features = new Set<symbol>(GNode.DEFAULT_FEATURES);
+        source.bounds = { x: 0, y: 0, width: 10, height: 10 };
+        root.add(source);
+
+        factory = new SharedFeatureSetModelFactory();
+        context = {
+            root,
+            modelFactory: factory,
+            duration: 0,
+            modelChanged: undefined!,
+            logger: new ConsoleLogger(),
+            syncer: new AnimationFrameSyncer()
+        };
+    });
+
+    function feedbackEdgeOf(root: GParentElement): GEdge {
+        const edge = root.children.find(child => child instanceof GEdge);
+        expect(edge).toBeDefined();
+        return edge as GEdge;
+    }
+
+    it('marks the drawn edge as feedback so it is not reported to the server', () => {
+        drawFeedbackEdge(context, 'node0', EDGE_TYPE);
+
+        expect(feedbackEdgeOf(context.root).hasFeature(feedbackFeature)).toBe(true);
+    });
+
+    it('leaves the feature set shared with the other elements of that type untouched', () => {
+        drawFeedbackEdge(context, 'node0', EDGE_TYPE);
+
+        // a regular edge of the same type must not turn into a feedback element
+        expect(factory.sharedEdgeFeatures.has(feedbackFeature)).toBe(false);
+    });
+});

--- a/packages/client/src/features/tools/edge-creation/dangling-edge-feedback.ts
+++ b/packages/client/src/features/tools/edge-creation/dangling-edge-feedback.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -34,7 +34,7 @@ import {
 import { inject, injectable } from 'inversify';
 import { feedbackFeature } from '../../../base/feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../../base/feedback/feedback-command';
-import { isRoutable } from '../../../utils/gmodel-util';
+import { enableFeatures, isRoutable } from '../../../utils/gmodel-util';
 import { toAbsolutePosition } from '../../../utils/viewpoint-util';
 import { FeedbackEdgeEndView } from './view';
 
@@ -162,6 +162,9 @@ export function drawFeedbackEdge(
 
     const feedbackEdge = context.modelFactory.createElement(edgeSchema);
     if (isRoutable(feedbackEdge)) {
+        // the edge is created from the adopter's own edge type, so it needs to be marked explicitly
+        // to be recognizable as client-side feedback
+        enableFeatures(feedbackEdge, feedbackFeature);
         edgeEnd.feedbackEdge = feedbackEdge;
         root.add(edgeEnd);
         root.add(feedbackEdge);

--- a/packages/client/src/features/tools/edge-creation/dangling-edge-feedback.ts
+++ b/packages/client/src/features/tools/edge-creation/dangling-edge-feedback.ts
@@ -162,8 +162,7 @@ export function drawFeedbackEdge(
 
     const feedbackEdge = context.modelFactory.createElement(edgeSchema);
     if (isRoutable(feedbackEdge)) {
-        // the edge is created from the adopter's own edge type, so it needs to be marked explicitly
-        // to be recognizable as client-side feedback
+        // created from the adopter's own edge type, so it needs to be marked as feedback explicitly
         enableFeatures(feedbackEdge, feedbackFeature);
         edgeEnd.feedbackEdge = feedbackEdge;
         root.add(edgeEnd);

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.spec.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.spec.ts
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    AnimationFrameSyncer,
+    CommandExecutionContext,
+    ConsoleLogger,
+    GChildElement,
+    GModelElement,
+    GModelElementSchema,
+    GModelFactory,
+    GNode,
+    GParentElement,
+    createFeatureSet
+} from '@eclipse-glsp/sprotty';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { feedbackFeature } from '../../../base/feedback/feedback-action-dispatcher';
+import { GEdge, GGraph } from '../../../model';
+import { drawFeedbackEdgeSource } from './edge-edit-tool-feedback';
+
+const EDGE_TYPE = 'edge';
+
+/** Creates edges the way the real factory does, i.e. all elements of a type share one feature set. */
+class SharedFeatureSetModelFactory extends GModelFactory {
+    readonly sharedEdgeFeatures = createFeatureSet(GEdge.DEFAULT_FEATURES);
+
+    override createElement(schema: GModelElementSchema | GModelElement): GChildElement {
+        const edge = new GEdge();
+        edge.id = schema.id!;
+        edge.type = schema.type;
+        edge.features = this.sharedEdgeFeatures;
+        return edge;
+    }
+}
+
+describe('drawFeedbackEdgeSource', () => {
+    let factory: SharedFeatureSetModelFactory;
+    let context: CommandExecutionContext;
+
+    beforeEach(() => {
+        const root = new GGraph();
+        root.id = 'root';
+        root.type = 'graph';
+        root.features = new Set<symbol>(GGraph.DEFAULT_FEATURES);
+        const target = new GNode();
+        target.id = 'node0';
+        target.type = 'node';
+        target.features = new Set<symbol>(GNode.DEFAULT_FEATURES);
+        target.bounds = { x: 0, y: 0, width: 10, height: 10 };
+        root.add(target);
+
+        factory = new SharedFeatureSetModelFactory();
+        context = {
+            root,
+            modelFactory: factory,
+            duration: 0,
+            modelChanged: undefined!,
+            logger: new ConsoleLogger(),
+            syncer: new AnimationFrameSyncer()
+        };
+    });
+
+    function feedbackEdgeOf(root: GParentElement): GEdge {
+        const edge = root.children.find(child => child instanceof GEdge);
+        expect(edge).toBeDefined();
+        return edge as GEdge;
+    }
+
+    it('marks the drawn edge as feedback so it is not reported to the server', () => {
+        drawFeedbackEdgeSource(context, 'node0', EDGE_TYPE);
+
+        expect(feedbackEdgeOf(context.root).hasFeature(feedbackFeature)).toBe(true);
+    });
+
+    it('leaves the feature set shared with the other elements of that type untouched', () => {
+        drawFeedbackEdgeSource(context, 'node0', EDGE_TYPE);
+
+        expect(factory.sharedEdgeFeatures.has(feedbackFeature)).toBe(false);
+    });
+});

--- a/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
+++ b/packages/client/src/features/tools/edge-edit/edge-edit-tool-feedback.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,10 +42,10 @@ import {
 } from '@eclipse-glsp/sprotty';
 import { inject, injectable } from 'inversify';
 import { DragAwareMouseListener } from '../../../base/drag-aware-mouse-listener';
-import { IFeedbackActionDispatcher } from '../../../base/feedback/feedback-action-dispatcher';
+import { IFeedbackActionDispatcher, feedbackFeature } from '../../../base/feedback/feedback-action-dispatcher';
 import { FeedbackCommand } from '../../../base/feedback/feedback-command';
 import { FeedbackEmitter } from '../../../base/feedback/feedback-emitter';
-import { forEachElement, getMatchingElements, isRoutable, isRoutingHandle } from '../../../utils/gmodel-util';
+import { enableFeatures, forEachElement, getMatchingElements, isRoutable, isRoutingHandle } from '../../../utils/gmodel-util';
 import { getAbsolutePosition, toAbsoluteBounds } from '../../../utils/viewpoint-util';
 import { addReconnectHandles, removeReconnectHandles } from '../../reconnect/model';
 import { IChangeBoundsManager } from '../change-bounds/change-bounds-manager';
@@ -375,6 +375,8 @@ export function drawFeedbackEdgeSource(context: CommandExecutionContext, targetI
 
     const feedbackEdge = context.modelFactory.createElement(feedbackEdgeSchema);
     if (isRoutable(feedbackEdge)) {
+        // created from the adopter's own edge type, so it needs to be marked as feedback explicitly
+        enableFeatures(feedbackEdge, feedbackFeature);
         edgeEnd.feedbackEdge = feedbackEdge;
         root.add(edgeEnd);
         root.add(feedbackEdge);

--- a/packages/client/src/features/tools/marquee-selection/model.ts
+++ b/packages/client/src/features/tools/marquee-selection/model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2023 EclipseSource and others.
+ * Copyright (c) 2021-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,9 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { boundsFeature, Point, RectangularNode } from '@eclipse-glsp/sprotty';
+import { feedbackFeature } from '../../../base/feedback/feedback-action-dispatcher';
 
 export class MarqueeNode extends RectangularNode {
-    static override readonly DEFAULT_FEATURES = [boundsFeature];
+    static override readonly DEFAULT_FEATURES = [boundsFeature, feedbackFeature];
     startPoint: Point;
     endPoint: Point;
 }

--- a/packages/client/src/features/tools/node-creation/insert-indicator.ts
+++ b/packages/client/src/features/tools/node-creation/insert-indicator.ts
@@ -16,11 +16,12 @@
 
 import { Args, Dimension, FeatureSet, GNode, boundsFeature, createFeatureSet, generateUuid, moveFeature } from '@eclipse-glsp/sprotty';
 import { ArgsAware, argsFeature } from '../../../base/args-feature';
+import { feedbackFeature } from '../../../base/feedback/feedback-action-dispatcher';
 
 export const ARG_LENGTH = 'length';
 
 export class InsertIndicator extends GNode implements ArgsAware {
-    static override readonly DEFAULT_FEATURES = [boundsFeature, moveFeature, argsFeature];
+    static override readonly DEFAULT_FEATURES = [boundsFeature, moveFeature, argsFeature, feedbackFeature];
 
     static TYPE = 'node:insert-indicator';
 

--- a/packages/client/src/features/validation/issue-marker.ts
+++ b/packages/client/src/features/validation/issue-marker.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,11 +25,14 @@ import {
     SIssueMarkerImpl,
     isBoundsAware
 } from '@eclipse-glsp/sprotty';
+import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
 
 export class GIssueMarker extends SIssueMarkerImpl implements Projectable {
     constructor() {
         super();
-        this.features = new Set<symbol>(GDecoration.DEFAULT_FEATURES);
+        // markers are established as client-side feedback and are unknown to the server,
+        // so they are marked as such to keep them out of server-bound requests
+        this.features = new Set<symbol>([...GDecoration.DEFAULT_FEATURES, feedbackFeature]);
     }
     projectionCssClasses: string[];
     projectedBounds?: Bounds;

--- a/packages/client/src/features/validation/issue-marker.ts
+++ b/packages/client/src/features/validation/issue-marker.ts
@@ -26,13 +26,12 @@ import {
     isBoundsAware
 } from '@eclipse-glsp/sprotty';
 import { feedbackFeature } from '../../base/feedback/feedback-action-dispatcher';
+import { enableFeatures } from '../../utils/gmodel-util';
 
 export class GIssueMarker extends SIssueMarkerImpl implements Projectable {
     constructor() {
         super();
-        // markers are established as client-side feedback and are unknown to the server,
-        // so they are marked as such to keep them out of server-bound requests
-        this.features = new Set<symbol>([...GDecoration.DEFAULT_FEATURES, feedbackFeature]);
+        this.features = new Set<symbol>(GDecoration.DEFAULT_FEATURES);
     }
     projectionCssClasses: string[];
     projectedBounds?: Bounds;
@@ -48,7 +47,7 @@ export class GIssueMarker extends SIssueMarkerImpl implements Projectable {
 /**
  * Retrieves the `GIssueMarker` contained by the provided model element as
  * direct child or a newly instantiated `GIssueMarker` if no child
- * `GIssueMarker` exists.
+ * `GIssueMarker` exists. A newly created marker is marked as client-side feedback.
  * @param modelElement for which the `GIssueMarker` should be retrieved or created.
  * @returns the child `GIssueMarker` or a new `GIssueMarker` if no such child exists.
  */
@@ -59,6 +58,9 @@ export function getOrCreateGIssueMarker(modelElement: GParentElement): GIssueMar
 
     if (issueMarker === undefined) {
         issueMarker = new GIssueMarker();
+        // a marker created here is unknown to the server, so it is kept out of server-bound
+        // requests. markers the server sends as part of the model keep reporting their bounds
+        enableFeatures(issueMarker, feedbackFeature);
         if (isBoundsAware(modelElement)) {
             issueMarker.projectedBounds = modelElement.parentToLocal(modelElement.bounds);
         }

--- a/packages/client/src/utils/gmodel-util.spec.ts
+++ b/packages/client/src/utils/gmodel-util.spec.ts
@@ -27,7 +27,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import { Container } from 'inversify';
 import { routingModule } from '../features/routing/routing-module';
-import { ALL_ROUTING_POINTS, ROUTE_KINDS, ROUTING_POINT_KINDS, calcRoute } from './gmodel-util';
+import { ALL_ROUTING_POINTS, ROUTE_KINDS, ROUTING_POINT_KINDS, calcElementAndRoute, calcRoute } from './gmodel-util';
 import { GEdge, GGraph } from '../model';
 
 class TestRouter extends AbstractEdgeRouter {
@@ -67,6 +67,36 @@ class TestRouter extends AbstractEdgeRouter {
     }
 
     protected applyInnerHandleMoves(edge: GRoutableElement, moves: ResolvedHandleMove[]): void {
+        // do nothing
+    }
+}
+
+/** Router that reports whatever route the test needs, including the empty one of an unroutable edge. */
+class DegenerateRouter extends AbstractEdgeRouter {
+    kind = 'degenerate-router';
+    nextRoute: RoutedPoint[] = [];
+
+    route(): RoutedPoint[] {
+        return this.nextRoute;
+    }
+
+    createRoutingHandles(): void {
+        // do nothing
+    }
+
+    protected getOptions(): LinearRouteOptions {
+        return {
+            minimalPointDistance: 0,
+            selfEdgeOffset: 0,
+            standardDistance: 0
+        };
+    }
+
+    protected getInnerHandlePosition(): Point | undefined {
+        return undefined;
+    }
+
+    protected applyInnerHandleMoves(): void {
         // do nothing
     }
 }
@@ -215,6 +245,66 @@ describe('SModel Util', () => {
                 { x: 20, y: 20, kind: 'linear', pointIndex: 0 },
                 { x: 30, y: 30, kind: 'linear', pointIndex: 1 },
                 { x: 40, y: 40, kind: 'linear', pointIndex: 2 }
+            ]);
+        });
+    });
+
+    describe('calcElementAndRoute', () => {
+        const graph = new GGraph();
+
+        const source = new GNode();
+        source.id = 'node0';
+        source.position = { x: 10, y: 10 };
+        source.size = { width: 0, height: 0 };
+        graph.add(source);
+
+        const target = new GNode();
+        target.id = 'node1';
+        target.position = { x: 200, y: 200 };
+        target.size = { width: 0, height: 0 };
+        graph.add(target);
+
+        const edge = new GEdge();
+        edge.id = 'edge0';
+        edge.sourceId = 'node0';
+        edge.targetId = 'node1';
+        edge.routerKind = 'degenerate-router';
+        graph.add(edge);
+
+        const router = new DegenerateRouter();
+        const container = new Container();
+        container.load(routingModule);
+
+        const routerRegistry = container.get<EdgeRouterRegistry>(EdgeRouterRegistry);
+        routerRegistry.register('degenerate-router', router);
+
+        it('should fall back to source and target if the edge cannot be routed', () => {
+            router.nextRoute = [];
+
+            expect(calcElementAndRoute(edge, routerRegistry).newRoutingPoints).toEqual([
+                { x: 10, y: 10 },
+                { x: 200, y: 200 }
+            ]);
+        });
+
+        it('should fall back to source and target if the route has a single point', () => {
+            router.nextRoute = [{ kind: 'source', x: 10, y: 10 }];
+
+            expect(calcElementAndRoute(edge, routerRegistry).newRoutingPoints).toEqual([
+                { x: 10, y: 10 },
+                { x: 200, y: 200 }
+            ]);
+        });
+
+        it('should keep a route that describes an edge', () => {
+            router.nextRoute = [
+                { kind: 'source', x: 10, y: 10 },
+                { kind: 'target', x: 200, y: 200 }
+            ];
+
+            expect(calcElementAndRoute(edge, routerRegistry).newRoutingPoints).toEqual([
+                { x: 10, y: 10, kind: 'source' },
+                { x: 200, y: 200, kind: 'target' }
             ]);
         });
     });

--- a/packages/client/src/utils/gmodel-util.spec.ts
+++ b/packages/client/src/utils/gmodel-util.spec.ts
@@ -27,7 +27,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import { Container } from 'inversify';
 import { routingModule } from '../features/routing/routing-module';
-import { ALL_ROUTING_POINTS, ROUTE_KINDS, ROUTING_POINT_KINDS, calcElementAndRoute, calcRoute } from './gmodel-util';
+import { ALL_ROUTING_POINTS, ROUTE_KINDS, ROUTING_POINT_KINDS, calcRoute } from './gmodel-util';
 import { GEdge, GGraph } from '../model';
 
 class TestRouter extends AbstractEdgeRouter {
@@ -67,36 +67,6 @@ class TestRouter extends AbstractEdgeRouter {
     }
 
     protected applyInnerHandleMoves(edge: GRoutableElement, moves: ResolvedHandleMove[]): void {
-        // do nothing
-    }
-}
-
-/** Router that reports whatever route the test needs, including the empty one of an unroutable edge. */
-class DegenerateRouter extends AbstractEdgeRouter {
-    kind = 'degenerate-router';
-    nextRoute: RoutedPoint[] = [];
-
-    route(): RoutedPoint[] {
-        return this.nextRoute;
-    }
-
-    createRoutingHandles(): void {
-        // do nothing
-    }
-
-    protected getOptions(): LinearRouteOptions {
-        return {
-            minimalPointDistance: 0,
-            selfEdgeOffset: 0,
-            standardDistance: 0
-        };
-    }
-
-    protected getInnerHandlePosition(): Point | undefined {
-        return undefined;
-    }
-
-    protected applyInnerHandleMoves(): void {
         // do nothing
     }
 }
@@ -245,66 +215,6 @@ describe('SModel Util', () => {
                 { x: 20, y: 20, kind: 'linear', pointIndex: 0 },
                 { x: 30, y: 30, kind: 'linear', pointIndex: 1 },
                 { x: 40, y: 40, kind: 'linear', pointIndex: 2 }
-            ]);
-        });
-    });
-
-    describe('calcElementAndRoute', () => {
-        const graph = new GGraph();
-
-        const source = new GNode();
-        source.id = 'node0';
-        source.position = { x: 10, y: 10 };
-        source.size = { width: 0, height: 0 };
-        graph.add(source);
-
-        const target = new GNode();
-        target.id = 'node1';
-        target.position = { x: 200, y: 200 };
-        target.size = { width: 0, height: 0 };
-        graph.add(target);
-
-        const edge = new GEdge();
-        edge.id = 'edge0';
-        edge.sourceId = 'node0';
-        edge.targetId = 'node1';
-        edge.routerKind = 'degenerate-router';
-        graph.add(edge);
-
-        const router = new DegenerateRouter();
-        const container = new Container();
-        container.load(routingModule);
-
-        const routerRegistry = container.get<EdgeRouterRegistry>(EdgeRouterRegistry);
-        routerRegistry.register('degenerate-router', router);
-
-        it('should fall back to source and target if the edge cannot be routed', () => {
-            router.nextRoute = [];
-
-            expect(calcElementAndRoute(edge, routerRegistry).newRoutingPoints).toEqual([
-                { x: 10, y: 10 },
-                { x: 200, y: 200 }
-            ]);
-        });
-
-        it('should fall back to source and target if the route has a single point', () => {
-            router.nextRoute = [{ kind: 'source', x: 10, y: 10 }];
-
-            expect(calcElementAndRoute(edge, routerRegistry).newRoutingPoints).toEqual([
-                { x: 10, y: 10 },
-                { x: 200, y: 200 }
-            ]);
-        });
-
-        it('should keep a route that describes an edge', () => {
-            router.nextRoute = [
-                { kind: 'source', x: 10, y: 10 },
-                { kind: 'target', x: 200, y: 200 }
-            ];
-
-            expect(calcElementAndRoute(edge, routerRegistry).newRoutingPoints).toEqual([
-                { x: 10, y: 10, kind: 'source' },
-                { x: 200, y: 200, kind: 'target' }
             ]);
         });
     });

--- a/packages/client/src/utils/gmodel-util.ts
+++ b/packages/client/src/utils/gmodel-util.ts
@@ -31,6 +31,7 @@ import {
     RoutedPoint,
     Selectable,
     TypeGuard,
+    createFeatureSet,
     distinctAdd,
     getAbsoluteBounds,
     getZoom,
@@ -266,9 +267,9 @@ export function enableFeatures(element: GModelElement, ...features: symbol[]): v
 export function enableFeatures(element: GModelElement, ...features: symbol[] | [symbol[]]): void {
     const toEnable = Array.isArray(features[0]) ? features[0] : (features as symbol[]);
     if (element.features === undefined) {
-        element.features = new Set<symbol>(toEnable);
+        element.features = createFeatureSet(toEnable);
     } else if (element.features instanceof Set) {
-        element.features = new Set<symbol>([...element.features, ...toEnable]);
+        element.features = createFeatureSet([...element.features], { enable: toEnable });
     }
 }
 

--- a/packages/client/src/utils/gmodel-util.ts
+++ b/packages/client/src/utils/gmodel-util.ts
@@ -410,13 +410,17 @@ export function calcElementAndRoutingPoints(element: GRoutableElement, routerReg
  * Helper function to calculate the route for a given {@link GRoutableElement}.
  * If client layout is activated, i.e., the edge routing registry is given and has a router for the element, then the points
  * from the calculated route are used, otherwise we use the already specified routing points of the {@link GRoutableElement}.
+ * A route of less than two points cannot describe an edge and is treated like a missing route.
  * @param element The element to translate.
  * @param routerRegistry the edge router registry.
- * @returns The corresponding route for the given element.
+ * @returns The corresponding route for the given element, with at least a source and a target point.
  */
 export function calcElementAndRoute(element: GRoutableElement, routerRegistry?: EdgeRouterRegistry): ElementAndRoutingPoints {
     let route: Point[] | undefined = routerRegistry ? calcRoute(element, routerRegistry, ROUTE_KINDS) : undefined;
-    if (!route) {
+    // routers report that they cannot route an edge by returning an empty route, e.g. when an endpoint
+    // is not part of the model or has no anchor yet. an empty array is truthy, so the length is what
+    // distinguishes an unroutable edge from a routed one here
+    if (!route || route.length < 2) {
         // add source and target to the routing points
         route = [...element.routingPoints];
         route.splice(0, 0, element.source?.position || Point.ORIGIN);

--- a/packages/client/src/utils/gmodel-util.ts
+++ b/packages/client/src/utils/gmodel-util.ts
@@ -254,10 +254,9 @@ export function toggleCssClass(element: GModelElement, cssClass: string, toggle:
 /**
  * Enables the given model features on a single {@link GModelElement}.
  *
- * The feature set is established once per registered element type and is therefore shared by all
- * its instances, so the element is given a copy of it rather than having the shared one extended.
- * Elements with a feature set that is not a `Set`, i.e. a hand-written `FeatureSet`, are left
- * untouched as their features cannot be enumerated.
+ * The feature set is shared by all instances of a registered element type, so the element is given
+ * a copy of it rather than having the shared one extended. A feature set that is not a `Set` cannot
+ * be enumerated and is left untouched.
  *
  * @param element The element for which the features should be enabled.
  * @param features The features to enable.
@@ -410,17 +409,13 @@ export function calcElementAndRoutingPoints(element: GRoutableElement, routerReg
  * Helper function to calculate the route for a given {@link GRoutableElement}.
  * If client layout is activated, i.e., the edge routing registry is given and has a router for the element, then the points
  * from the calculated route are used, otherwise we use the already specified routing points of the {@link GRoutableElement}.
- * A route of less than two points cannot describe an edge and is treated like a missing route.
  * @param element The element to translate.
  * @param routerRegistry the edge router registry.
- * @returns The corresponding route for the given element, with at least a source and a target point.
+ * @returns The corresponding route for the given element.
  */
 export function calcElementAndRoute(element: GRoutableElement, routerRegistry?: EdgeRouterRegistry): ElementAndRoutingPoints {
     let route: Point[] | undefined = routerRegistry ? calcRoute(element, routerRegistry, ROUTE_KINDS) : undefined;
-    // routers report that they cannot route an edge by returning an empty route, e.g. when an endpoint
-    // is not part of the model or has no anchor yet. an empty array is truthy, so the length is what
-    // distinguishes an unroutable edge from a routed one here
-    if (!route || route.length < 2) {
+    if (!route) {
         // add source and target to the routing points
         route = [...element.routingPoints];
         route.splice(0, 0, element.source?.position || Point.ORIGIN);

--- a/packages/client/src/utils/gmodel-util.ts
+++ b/packages/client/src/utils/gmodel-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2025 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -248,6 +248,28 @@ export function removeCssClassOfElements(elements: GModelElement[], ...cssClasse
  */
 export function toggleCssClass(element: GModelElement, cssClass: string, toggle: boolean): void {
     return toggle ? addCssClasses(element, cssClass) : removeCssClasses(element, cssClass);
+}
+
+/**
+ * Enables the given model features on a single {@link GModelElement}.
+ *
+ * The feature set is established once per registered element type and is therefore shared by all
+ * its instances, so the element is given a copy of it rather than having the shared one extended.
+ * Elements with a feature set that is not a `Set`, i.e. a hand-written `FeatureSet`, are left
+ * untouched as their features cannot be enumerated.
+ *
+ * @param element The element for which the features should be enabled.
+ * @param features The features to enable.
+ */
+export function enableFeatures(element: GModelElement, features: symbol[]): void;
+export function enableFeatures(element: GModelElement, ...features: symbol[]): void;
+export function enableFeatures(element: GModelElement, ...features: symbol[] | [symbol[]]): void {
+    const toEnable = Array.isArray(features[0]) ? features[0] : (features as symbol[]);
+    if (element.features === undefined) {
+        element.features = new Set<symbol>(toEnable);
+    } else if (element.features instanceof Set) {
+        element.features = new Set<symbol>([...element.features, ...toEnable]);
+    }
 }
 
 export function isNonRoutableSelectedMovableBoundsAware(element: GModelElement): element is SelectableBoundsAware {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Validation markers and the dangling edge of the edge-creation tool only exist on the client,
but they are part of the hidden rendering and therefore of the `computedBounds` action. Their
ids are unknown to the server, which rejects the whole action, so the diagram stops settling.
Reported in eclipse-glsp/glsp#1724 with the node server and the VS Code integration.

Until eclipse-glsp/glsp-client#525 the collected bounds were only cleared on the path that
actually sends them, so an export or a failing bounds pass left them behind for the next run.
Rather than relying on that cleanup alone, the client now never names a client-only element in
a request to the server.

- Mark `GIssueMarker` and the dangling feedback edge as feedback elements. `feedbackFeature`
  already existed for that concept but was only ever set and never read
- Skip feedback elements and their routes when answering a server `RequestBoundsAction`. Local
  bounds requests keep reporting them, so decoration placement and ghost sizing are unaffected
- Reset the collected bounds when a hidden rendering starts rather than only when `postUpdate`
  completes, which the viewer never reaches when a view or the vdom patch throws
- Add `enableFeatures` to the model utilities. The feature set is established once per element
  type and shared by all its instances, so it copies before extending

Fixes eclipse-glsp/glsp#1725

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The failure itself is no longer reproducible by hand on master, because #525 closed both known
leak paths. The remaining trigger needs a rendering that throws, which is covered by a spec, so
the automated tests are the primary evidence here.

```bash
pnpm install && pnpm build
pnpm test
```

To see the new specs fail without the fix:

```bash
# 2 failures: the marker filter and the interrupted hidden rendering
git stash push -- packages/client/src/features/bounds/glsp-hidden-bounds-updater.ts \
                  packages/client/src/features/validation/issue-marker.ts
pnpm exec vitest run packages/client/src/features/bounds/glsp-hidden-bounds-updater.spec.ts
git stash pop

# 1 failure: the drawn feedback edge is not marked
git stash push -- packages/client/src/features/tools/edge-creation/dangling-edge-feedback.ts
pnpm exec vitest run packages/client/src/features/tools/edge-creation/dangling-edge-feedback.spec.ts
git stash pop
```

Manual check that nothing visible changed, since this only removes ids from what we send:

```bash
pnpm -C examples/workflow-standalone start
```

1. Click the validate button in the tool palette, markers appear on the task nodes
2. Markers are placed as before and their hover popups still work
3. Resize a marked node, the marker stays in place (local bounds requests still report it)
4. Draw an edge, the dangling feedback edge still follows the mouse and routes normally
5. Export with `Ctrl+Shift+E`, then delete a node, the model update still succeeds

- [x] Verified locally against the workflow example (node server)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- The server still rejects the entire `computedBounds` action for a single unresolvable id, which
  is why one stale entry keeps a diagram from settling. Skipping unknown ids with a warning would
  degrade more gracefully. Deliberately out of scope here, worth its own ticket for the node and
  the Java server
- In the node server, `getOrThrow(index.get(...), 'Model element not found! ID: ...')` in
  `layout-util` never reports its message because `index.get` throws first. The Java server
  returns an `Optional` there and reports it as intended
- As noted in #525, sprotty's `HiddenBoundsUpdater` has the same cleanup-only-on-success shape, so
  plain-sprotty adopters are affected as well
- `ApplyTypeHintsCommand` extends the feature set in place, which is shared by all instances of an
  element type. It is harmless today because hints are per type, but `enableFeatures` now offers
  the safe alternative if that code is ever touched

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
